### PR TITLE
feat: add opt-in desktop notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +432,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -575,6 +708,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1041,6 +1183,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1254,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1258,6 +1437,19 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1638,6 +1830,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2260,6 +2458,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2599,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2593,6 +2819,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2688,6 +2915,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "pango"
@@ -2824,6 +3061,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,6 +3141,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3115,6 +3377,7 @@ dependencies = [
  "rambledesk-storage",
  "tauri",
  "tauri-build",
+ "tauri-plugin-notification",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3169,8 +3432,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3195,12 +3468,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4555,6 +4847,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,6 +4979,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.19",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -5141,6 +5479,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6115,6 +6464,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6199,3 +6609,43 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "winnow 1.0.4",
+]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Agent 通过本地 MCP 下发结构化请求；人类按清单真实使用、自
 M0 技术与协议尖峰已完成。M1 已落地 SQLite 持久请求内核、
 `request_feedback/get_feedback/cancel_feedback` polling 工具、Inbox、Markdown
 Draft 自动保存和 crash-safe Feedback Package 提交；MCP Inspector、Claude Code
-与官方 Rust SDK 实测通过。下一步完成 M1 的系统通知与桌面端运行验收。
+与官方 Rust SDK 实测通过。新请求系统通知采用显式授权且不显示工作内容；下一步
+只剩 macOS 通知权限和实际投递的人工验收。
 
 ## 本地验证
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,7 +13,8 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "2.11.1"
+    "@tauri-apps/api": "2.11.1",
+    "@tauri-apps/plugin-notification": "2.3.3"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "7.2.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ rambledesk-core.workspace = true
 rambledesk-mcp.workspace = true
 rambledesk-storage.workspace = true
 tauri.workspace = true
+tauri-plugin-notification = "2.3.3"
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,10 @@
   "identifier": "default",
   "description": "Default permissions for the RambleDesk main window",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "notification:allow-is-permission-granted",
+    "notification:allow-request-permission",
+    "notification:allow-notify"
+  ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use rambledesk_core::{
     FeedbackWorkspaceView, HealthSnapshot, SaveDraftInput, SubmitFeedbackInput,
 };
 use rambledesk_mcp::{AccessToken, ServerConfig, ServerHandle, default_token_path, start_server};
+use std::path::PathBuf;
 use tauri::{Manager, RunEvent};
 
 struct WorkbenchState {
@@ -65,6 +66,35 @@ fn configured_port() -> Result<u16, String> {
     }
 }
 
+fn configured_path(
+    variable: &str,
+    default: impl FnOnce() -> Result<PathBuf, String>,
+) -> Result<PathBuf, String> {
+    match std::env::var(variable) {
+        Ok(value) => {
+            let path = PathBuf::from(value);
+            if !path.is_absolute() {
+                return Err(format!("{variable} must be an absolute path"));
+            }
+            Ok(path)
+        }
+        Err(std::env::VarError::NotPresent) => default(),
+        Err(error) => Err(format!("failed to read {variable}: {error}")),
+    }
+}
+
+fn configured_database_path() -> Result<PathBuf, String> {
+    configured_path("RAMBLEDESK_DATABASE_FILE", || {
+        rambledesk_storage::default_database_path().map_err(|error| error.to_string())
+    })
+}
+
+fn configured_token_path() -> Result<PathBuf, String> {
+    configured_path("RAMBLEDESK_TOKEN_FILE", || {
+        default_token_path().map_err(|error| error.to_string())
+    })
+}
+
 pub fn run() {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -75,9 +105,10 @@ pub fn run() {
         .init();
 
     let app = tauri::Builder::default()
+        .plugin(tauri_plugin_notification::init())
         .setup(|app| {
-            let token = AccessToken::load_or_create(&default_token_path()?)?;
-            let database_path = rambledesk_storage::default_database_path()?;
+            let token = AccessToken::load_or_create(&configured_token_path()?)?;
+            let database_path = configured_database_path()?;
             let store = tauri::async_runtime::block_on(
                 rambledesk_storage::SqliteFeedbackStore::connect(&database_path),
             )?;
@@ -119,6 +150,22 @@ mod tests {
         // The environment is intentionally not mutated because tests may run concurrently.
         if std::env::var_os("RAMBLEDESK_MCP_PORT").is_none() {
             assert_eq!(configured_port().expect("default port"), 37_642);
+        }
+    }
+
+    #[test]
+    fn configured_paths_default_when_overrides_are_absent() {
+        if std::env::var_os("RAMBLEDESK_DATABASE_FILE").is_none() {
+            assert_eq!(
+                configured_database_path().expect("default database"),
+                rambledesk_storage::default_database_path().expect("storage default")
+            );
+        }
+        if std::env::var_os("RAMBLEDESK_TOKEN_FILE").is_none() {
+            assert_eq!(
+                configured_token_path().expect("default token"),
+                default_token_path().expect("token default")
+            );
         }
     }
 }

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
   import { invoke } from '@tauri-apps/api/core'
+  import {
+    isPermissionGranted,
+    requestPermission,
+    sendNotification,
+  } from '@tauri-apps/plugin-notification'
   import { onMount } from 'svelte'
 
   import type {
@@ -12,6 +17,11 @@
   } from './lib/feedback'
   import { requestStatusLabel } from './lib/feedback'
   import type { HealthSnapshot } from './lib/generated/health'
+  import {
+    InboxNotificationTracker,
+    notificationLabel,
+    type NotificationState,
+  } from './lib/notifications'
 
   type SavePhase = 'idle' | 'unsaved' | 'saving' | 'saved' | 'error'
   type CommandError = { code: string; message: string; retryable: boolean }
@@ -30,9 +40,11 @@
   let loadingInbox = true
   let loadingWorkspace = false
   let submitting = false
+  let notificationState: NotificationState = 'checking'
   let saveTimer: ReturnType<typeof setTimeout> | undefined
   let inboxTimer: ReturnType<typeof setInterval> | undefined
   let activeSave: Promise<boolean> | null = null
+  const notificationTracker = new InboxNotificationTracker()
 
   $: dirty = workspace !== null && draftBody !== savedBody
   $: canSubmit =
@@ -44,6 +56,7 @@
 
   onMount(() => {
     void initialize()
+    void refreshNotificationPermission()
     inboxTimer = setInterval(() => void refreshInbox(), 5_000)
     return () => {
       if (saveTimer) clearTimeout(saveTimer)
@@ -62,7 +75,7 @@
       ])
       health = nextHealth
       endpoint = nextEndpoint
-      inbox = nextInbox
+      applyInboxSnapshot(nextInbox)
       if (nextInbox.length > 0) {
         await openRequest(nextInbox[0].request_id, false)
       }
@@ -75,9 +88,43 @@
 
   async function refreshInbox() {
     try {
-      inbox = await invoke<FeedbackRequestSummary[]>('list_feedback_inbox')
+      const nextInbox = await invoke<FeedbackRequestSummary[]>('list_feedback_inbox')
+      applyInboxSnapshot(nextInbox)
     } catch (cause) {
       pageError = messageFrom(cause)
+    }
+  }
+
+  function applyInboxSnapshot(nextInbox: FeedbackRequestSummary[]) {
+    const arrivals = notificationTracker.observe(nextInbox)
+    inbox = nextInbox
+    if (arrivals.length > 0 && notificationState === 'enabled') {
+      sendNotification({
+        title: 'RambleDesk',
+        body:
+          arrivals.length === 1
+            ? '新的体验反馈请求已到达。打开工作台查看。'
+            : `${arrivals.length} 个新的体验反馈请求已到达。打开工作台查看。`,
+      })
+    }
+  }
+
+  async function refreshNotificationPermission() {
+    try {
+      notificationState = (await isPermissionGranted()) ? 'enabled' : 'disabled'
+    } catch {
+      notificationState = 'unavailable'
+    }
+  }
+
+  async function enableNotifications() {
+    if (notificationState !== 'disabled') return
+    notificationState = 'checking'
+    try {
+      const permission = await requestPermission()
+      notificationState = permission === 'granted' ? 'enabled' : 'disabled'
+    } catch {
+      notificationState = 'unavailable'
     }
   }
 
@@ -231,9 +278,20 @@
         <small>体验反馈工作台</small>
       </div>
     </div>
-    <div class="runtime" title={endpoint}>
-      <span class:online={health?.status === 'ready'}></span>
-      {health?.status === 'ready' ? 'MCP 在线' : '正在连接'}
+    <div class="topbar-actions">
+      <button
+        class:enabled={notificationState === 'enabled'}
+        class="notification-button"
+        disabled={notificationState !== 'disabled'}
+        onclick={enableNotifications}
+        title="新请求通知不会包含项目或反馈内容"
+      >
+        {notificationLabel(notificationState)}
+      </button>
+      <div class="runtime" title={endpoint}>
+        <span class:online={health?.status === 'ready'}></span>
+        {health?.status === 'ready' ? 'MCP 在线' : '正在连接'}
+      </div>
     </div>
   </header>
 

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -45,6 +45,7 @@ body {
 }
 
 .brand,
+.topbar-actions,
 .runtime,
 .panel-heading,
 .workspace-heading,
@@ -57,6 +58,10 @@ body {
 }
 
 .brand {
+  gap: 12px;
+}
+
+.topbar-actions {
   gap: 12px;
 }
 
@@ -104,6 +109,27 @@ body {
 .runtime span.online {
   background: #3b9952;
   box-shadow: 0 0 0 4px rgb(59 153 82 / 12%);
+}
+
+.notification-button {
+  padding: 7px 10px;
+  border: 1px solid #d1d3ca;
+  border-radius: 999px;
+  color: #5d675c;
+  background: #fff;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.notification-button.enabled {
+  border-color: #bfd2bd;
+  color: #315d39;
+  background: #e6efe3;
+}
+
+.notification-button:disabled {
+  cursor: default;
+  opacity: 0.78;
 }
 
 .workbench {

--- a/apps/desktop/src/lib/notifications.test.ts
+++ b/apps/desktop/src/lib/notifications.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import type { FeedbackRequestSummary } from './feedback'
+import {
+  collectNewRequests,
+  InboxNotificationTracker,
+  notificationLabel,
+} from './notifications'
+
+function request(requestId: string): FeedbackRequestSummary {
+  return {
+    request_id: requestId,
+    project_id: 'project',
+    project_name: 'Private project',
+    agent: 'agent',
+    session_id: 'session',
+    what_happened: 'Sensitive summary',
+    status: 'waiting',
+    revision: 0,
+    created_at: '2026-07-29T00:00:00Z',
+    updated_at: '2026-07-29T00:00:00Z',
+  }
+}
+
+describe('notification inbox tracking', () => {
+  it('marks the initial inbox known and reports only later arrivals', () => {
+    const known = new Set<string>()
+    expect(collectNewRequests(known, [request('one')]).map((item) => item.request_id)).toEqual([
+      'one',
+    ])
+    expect(
+      collectNewRequests(known, [request('one'), request('two')]).map((item) => item.request_id),
+    ).toEqual(['two'])
+    expect(collectNewRequests(known, [request('two')])).toEqual([])
+  })
+
+  it('treats whichever concurrent startup snapshot arrives first as the baseline', () => {
+    const tracker = new InboxNotificationTracker()
+    expect(tracker.observe([request('existing')])).toEqual([])
+    expect(
+      tracker
+        .observe([request('existing'), request('arrived-during-startup')])
+        .map((item) => item.request_id),
+    ).toEqual(['arrived-during-startup'])
+    expect(tracker.observe([request('arrived-during-startup')])).toEqual([])
+  })
+
+  it('keeps permission labels understandable', () => {
+    expect(notificationLabel('enabled')).toBe('通知已开启')
+    expect(notificationLabel('disabled')).toBe('启用通知')
+    expect(notificationLabel('unavailable')).toBe('通知不可用')
+  })
+})

--- a/apps/desktop/src/lib/notifications.ts
+++ b/apps/desktop/src/lib/notifications.ts
@@ -1,0 +1,39 @@
+import type { FeedbackRequestSummary } from './feedback'
+
+export type NotificationState = 'checking' | 'enabled' | 'disabled' | 'unavailable'
+
+export function collectNewRequests(
+  knownRequestIds: Set<string>,
+  requests: FeedbackRequestSummary[],
+): FeedbackRequestSummary[] {
+  const arrivals = requests.filter((request) => !knownRequestIds.has(request.request_id))
+  for (const request of requests) knownRequestIds.add(request.request_id)
+  return arrivals
+}
+
+export class InboxNotificationTracker {
+  private initialized = false
+  private readonly knownRequestIds = new Set<string>()
+
+  observe(requests: FeedbackRequestSummary[]): FeedbackRequestSummary[] {
+    const arrivals = collectNewRequests(this.knownRequestIds, requests)
+    if (!this.initialized) {
+      this.initialized = true
+      return []
+    }
+    return arrivals
+  }
+}
+
+export function notificationLabel(state: NotificationState): string {
+  switch (state) {
+    case 'checking':
+      return '检查通知…'
+    case 'enabled':
+      return '通知已开启'
+    case 'disabled':
+      return '启用通知'
+    case 'unavailable':
+      return '通知不可用'
+  }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -154,6 +154,20 @@ RambleDesk 借鉴 Kotone 已验证的 workspace 结构和 ports/adapters 依赖�
 不是 Kotone 的子项目，也不对其 crate 建立 sibling path dependency。具体迁移
 边界见 [KOTONE_REUSE.md](KOTONE_REUSE.md)。
 
+### 2.6 隔离桌面运行
+
+桌面端运行验收可用绝对路径覆盖本地状态，不触碰日常数据：
+
+```bash
+RAMBLEDESK_DATABASE_FILE=/absolute/test/rambledesk.sqlite3 \
+RAMBLEDESK_TOKEN_FILE=/absolute/test/mcp.token \
+RAMBLEDESK_MCP_PORT=0 \
+pnpm dev
+```
+
+通知权限只在用户点击工作台中的“启用通知”后请求；启动和自动测试不得主动弹出
+系统权限框。
+
 ## 3. 数据库基线
 
 首个 migration 至少包含：
@@ -310,8 +324,8 @@ Tasks 保留为双方显式声明支持后的增强路径。
 当前已完成前两条切片：完整初始 migration、canonical Project identity、
 持久 `request_feedback/get_feedback/cancel_feedback`、Inbox、单请求工作区、
 基于 aggregate revision 的 Draft 自动保存，以及带 publication intent 和启动
-对账的 crash-safe Feedback Package 提交。系统通知与桌面端人工运行验收仍属于
-后续 M1 切片。
+对账的 crash-safe Feedback Package 提交。系统通知插件、显式权限入口和隐私化
+新请求通知也已接入；macOS 权限和实际投递仍需解锁桌面后由用户人工验收。
 
 当前 crash-safe package 提交验收目标是已实测的 macOS/Unix 文件系统。非 Unix
 平台在实现并验证 durable directory barrier 前必须返回明确发布失败，不能先把
@@ -383,6 +397,7 @@ SQLite 标记为 completed；Windows/Linux 完整安装与掉电回归属于 M4 
 - [x] 锁定 SDK、toolchain、TypeScript DTO 生成和 polling 首发模式；
 - [x] M1 第一切片引入 SQLite、持久请求状态机和 polling 业务工具。
 - [x] M1 第二切片引入 Inbox、Draft CAS 和纯文本 Feedback Package 提交。
+- [x] M1 第三切片接入显式授权、内容脱敏的新请求系统通知。
 
 不要在 M0 中实现语音、截图、完整导航或视觉系统。
 
@@ -409,5 +424,5 @@ SQLite 标记为 completed；Windows/Linux 完整安装与掉电回归属于 M4 
 ## 9. 当前判断
 
 M0 已通过自动化与真实客户端验收。M1 的持久请求、Inbox、Draft 与纯文本提交
-纵向闭环已经落地；下一条切片应补系统通知和桌面端运行验收，不提前引入语音、
-截图或 Tasks 专用业务分支。
+纵向闭环和系统通知代码已经落地；解锁 macOS 后应人工确认权限请求与实际通知
+投递，再决定进入 M2，不提前引入语音、截图或 Tasks 专用业务分支。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@tauri-apps/api':
         specifier: 2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-notification':
+        specifier: 2.3.3
+        version: 2.3.3
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: 7.2.0
@@ -257,6 +260,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -809,6 +815,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tybys/wasm-util@0.10.3':
     dependencies:


### PR DESCRIPTION
## Summary

- add opt-in macOS desktop notifications for newly arrived feedback requests
- keep notification content private and request permission only after an explicit user click
- add isolated database/token runtime overrides for safe desktop acceptance testing
- use least-privilege Tauri notification capabilities and race-safe inbox baseline tracking

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm contracts:check`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- independent contract re-review: no P0-P2 blockers

## Manual acceptance remaining

The desktop app starts without prompting for notification permission. Final macOS permission and delivery acceptance requires the user to unlock the Mac, click **启用通知**, approve the system prompt, and trigger a new MCP request.
