### PR TITLE
fix(desktop): keep markdown tables and task lists in feedback

### DIFF
--- a/apps/desktop/src/lib/RichFeedbackEditor.svelte
+++ b/apps/desktop/src/lib/RichFeedbackEditor.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import { Editor, Node } from '@tiptap/core'
-  import Image from '@tiptap/extension-image'
-  import { Markdown } from '@tiptap/markdown'
-  import StarterKit from '@tiptap/starter-kit'
+  import { Editor } from '@tiptap/core'
   import {
     Bold,
     Heading2,
@@ -23,6 +20,7 @@
     attachmentMarkdownUrl,
     isImageMediaType,
   } from './attachmentMarkdown'
+  import { feedbackEditorExtensions } from './feedbackEditorExtensions'
 
   export let markdown = ''
   export let previews: Record<string, string> = {}
@@ -38,149 +36,10 @@
   let openAttachmentHandler = (_attachmentId: string) => {}
   $: openAttachmentHandler = onOpenAttachment
 
-  const AttachmentImage = Image.extend({
-    addAttributes() {
-      return {
-        ...this.parent?.(),
-        attachmentId: {
-          default: null,
-          parseHTML: (element) => element.getAttribute('data-attachment-id'),
-          renderHTML: (attributes) =>
-            attributes.attachmentId
-              ? { 'data-attachment-id': attributes.attachmentId }
-              : {},
-        },
-      }
-    },
-
-    renderMarkdown: (node) => {
-      const attachmentId =
-        node.attrs?.attachmentId ?? attachmentIdFromUrl(node.attrs?.src)
-      const src = attachmentId
-        ? attachmentMarkdownUrl(attachmentId)
-        : (node.attrs?.src ?? '')
-      const alt = node.attrs?.alt ?? ''
-      const title = node.attrs?.title ?? ''
-      return title ? `![${alt}](${src} "${title}")` : `![${alt}](${src})`
-    },
-  })
-
-  // A clickable chip for a non-image attachment, serialized as a markdown
-  // link `[fileName](attachment://id)`. A custom marked tokenizer claims
-  // `attachment://` links before StarterKit's built-in Link mark so they
-  // parse back into this node instead of a link mark.
-  const AttachmentFile = Node.create({
-    name: 'attachmentFile',
-    group: 'inline',
-    inline: true,
-    atom: true,
-    selectable: true,
-
-    addAttributes() {
-      return {
-        attachmentId: {
-          default: null,
-          parseHTML: (element) => element.getAttribute('data-attachment-id'),
-          renderHTML: (attributes) =>
-            attributes.attachmentId
-              ? { 'data-attachment-id': attributes.attachmentId }
-              : {},
-        },
-        fileName: {
-          default: '',
-          parseHTML: (element) => element.getAttribute('data-file-name'),
-          renderHTML: (attributes) =>
-            attributes.fileName ? { 'data-file-name': attributes.fileName } : {},
-        },
-        mediaType: {
-          default: '',
-          parseHTML: (element) => element.getAttribute('data-media-type'),
-          renderHTML: (attributes) =>
-            attributes.mediaType ? { 'data-media-type': attributes.mediaType } : {},
-        },
-      }
-    },
-
-    markdownTokenName: 'attachmentFile',
-    markdownTokenizer: {
-      name: 'attachmentFile',
-      level: 'inline',
-      start: (src) => src.indexOf('['),
-      tokenize: (src) => {
-        const match = /^\[([^\]]*)\]\(attachment:\/\/([0-9a-fA-F-]+)\)/.exec(src)
-        if (!match) return undefined
-        return { type: 'attachmentFile', raw: match[0], text: match[1], attachmentId: match[2] }
-      },
-    },
-    parseMarkdown: (token, helpers) =>
-      helpers.createNode('attachmentFile', {
-        attachmentId: token.attachmentId,
-        fileName: token.text || token.attachmentId,
-        mediaType: '',
-      }),
-
-    renderHTML({ node }) {
-      const attachmentId = node.attrs.attachmentId ?? ''
-      const fileName = node.attrs.fileName || attachmentId || 'attachment'
-      const ext = (fileName.split('.').pop() || 'FILE').toUpperCase().slice(0, 4)
-      return [
-        'a',
-        {
-          href: attachmentMarkdownUrl(attachmentId),
-          'data-attachment-id': attachmentId,
-          'data-file-name': fileName,
-          'data-media-type': node.attrs.mediaType ?? '',
-          class: 'attachment-file-chip',
-          contenteditable: 'false',
-        },
-        ['span', { class: 'attachment-file-chip-ext' }, ext],
-        ['span', { class: 'attachment-file-chip-label' }, fileName],
-      ]
-    },
-
-    parseHTML() {
-      return [
-        {
-          tag: 'a[href^="attachment://"]',
-          getAttrs: (element) => {
-            const href = element.getAttribute('href') ?? ''
-            return {
-              attachmentId:
-                element.getAttribute('data-attachment-id') ??
-                attachmentIdFromUrl(href) ??
-                null,
-              fileName:
-                element.getAttribute('data-file-name') ??
-                element.textContent?.trim() ??
-                '',
-              mediaType: element.getAttribute('data-media-type') ?? '',
-            }
-          },
-        },
-      ]
-    },
-
-    renderMarkdown: (node) => {
-      const url = attachmentMarkdownUrl(node.attrs?.attachmentId ?? '')
-      const label = (node.attrs?.fileName || node.attrs?.attachmentId || '').replace(
-        /([\[\]])/g,
-        '\\$1',
-      )
-      return `[${label}](${url})`
-    },
-  })
-
   onMount(() => {
     editor = new Editor({
       element: editorHost,
-      extensions: [
-        StarterKit.configure({
-          heading: { levels: [2, 3] },
-        }),
-        AttachmentImage,
-        AttachmentFile,
-        Markdown,
-      ],
+      extensions: feedbackEditorExtensions(),
       content: markdown,
       contentType: 'markdown',
       editable: !disabled,
@@ -577,6 +436,78 @@
     border-radius: var(--radius);
     object-fit: contain;
     background: var(--muted);
+  }
+
+  /* The table node view always wraps the table, whatever `renderWrapper` says. */
+  .editor-host :global(.feedback-prose .tableWrapper) {
+    margin: 1em 0;
+    overflow-x: auto;
+  }
+
+  .editor-host :global(.feedback-prose table) {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95em;
+  }
+
+  .editor-host :global(.feedback-prose th),
+  .editor-host :global(.feedback-prose td) {
+    position: relative;
+    border: 1px solid var(--border);
+    padding: 0.5em 0.7em;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .editor-host :global(.feedback-prose th) {
+    background: var(--muted);
+    font-weight: 650;
+  }
+
+  .editor-host :global(.feedback-prose th > p),
+  .editor-host :global(.feedback-prose td > p) {
+    margin: 0;
+  }
+
+  /* prosemirror-tables marks a multi-cell selection with this class. */
+  .editor-host :global(.feedback-prose .selectedCell::after) {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    background: color-mix(in oklab, var(--primary) 18%, transparent);
+    content: '';
+    pointer-events: none;
+  }
+
+  .editor-host :global(.feedback-prose ul[data-type='taskList']) {
+    margin: 0 0 0.9em;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* Task items carry `data-checked`, not `data-type`; scope through the list. */
+  .editor-host :global(.feedback-prose ul[data-type='taskList'] > li) {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.55em;
+    margin: 0.28em 0;
+  }
+
+  .editor-host :global(.feedback-prose ul[data-type='taskList'] > li > label) {
+    margin-top: 0.34em;
+  }
+
+  .editor-host :global(.feedback-prose ul[data-type='taskList'] > li > div) {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .editor-host :global(.feedback-prose ul[data-type='taskList'] > li > div > p) {
+    margin: 0;
+  }
+
+  .editor-host :global(.feedback-prose ul[data-type='taskList'] ul[data-type='taskList']) {
+    margin: 0.3em 0 0;
   }
 
   .editor-host :global(.feedback-prose.ProseMirror-focused) {

--- a/apps/desktop/src/lib/feedbackEditorExtensions.test.ts
+++ b/apps/desktop/src/lib/feedbackEditorExtensions.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { MarkdownManager } from '@tiptap/markdown'
+import type { JSONContent } from '@tiptap/core'
+
+import { feedbackEditorExtensions } from './feedbackEditorExtensions'
+
+function markdown() {
+  return new MarkdownManager({ extensions: feedbackEditorExtensions() })
+}
+
+/** Markdown → document → markdown → document; the second document must match. */
+function stableRoundTrip(source: string): JSONContent {
+  const manager = markdown()
+  const parsed = manager.parse(source)
+  expect(manager.parse(manager.serialize(parsed))).toEqual(parsed)
+  return parsed
+}
+
+function blockTypes(doc: JSONContent): string[] {
+  return (doc.content ?? []).map((node) => node.type ?? '')
+}
+
+function cellTexts(row: JSONContent): string[] {
+  return (row.content ?? []).map(
+    (cell) => cell.content?.[0]?.content?.[0]?.text ?? '',
+  )
+}
+
+const TABLE = [
+  '| Area | Verdict |',
+  '| --- | --- |',
+  '| Ramble | smooth |',
+  '| Table | readable |',
+].join('\n')
+
+describe('feedback editor markdown tables', () => {
+  it('parses a markdown table into table nodes instead of dropping it', () => {
+    const doc = stableRoundTrip(TABLE)
+
+    expect(blockTypes(doc)).toEqual(['table'])
+    const rows = doc.content?.[0]?.content ?? []
+    expect(rows.map((row) => row.content?.[0]?.type)).toEqual([
+      'tableHeader',
+      'tableCell',
+      'tableCell',
+    ])
+    expect(rows.map(cellTexts)).toEqual([
+      ['Area', 'Verdict'],
+      ['Ramble', 'smooth'],
+      ['Table', 'readable'],
+    ])
+  })
+
+  it('keeps the blocks around a table in order', () => {
+    const doc = stableRoundTrip(
+      ['Before the table.', '', TABLE, '', 'After the table.'].join('\n'),
+    )
+
+    expect(blockTypes(doc)).toEqual(['paragraph', 'table', 'paragraph'])
+  })
+
+  it('serializes a table back to a pipe table the host can read', () => {
+    const manager = markdown()
+
+    const serialized = manager.serialize(manager.parse(TABLE))
+
+    expect(serialized).toContain('| Area')
+    expect(serialized).toContain('| Ramble')
+    expect(serialized).toContain('| readable')
+  })
+
+  it('keeps cell alignment', () => {
+    const doc = stableRoundTrip(
+      ['| Left | Right |', '| :--- | ---: |', '| a | b |'].join('\n'),
+    )
+
+    const headerCells = doc.content?.[0]?.content?.[0]?.content ?? []
+    expect(headerCells.map((cell) => cell.attrs?.align)).toEqual(['left', 'right'])
+  })
+})
+
+describe('feedback editor markdown task lists', () => {
+  it('keeps checkbox state', () => {
+    const doc = stableRoundTrip(['- [ ] open item', '- [x] done item'].join('\n'))
+
+    expect(blockTypes(doc)).toEqual(['taskList'])
+    const items = doc.content?.[0]?.content ?? []
+    expect(items.map((item) => item.attrs?.checked)).toEqual([false, true])
+  })
+})
+
+describe('feedback editor attachment markdown', () => {
+  it('round-trips an attachment image', () => {
+    const doc = stableRoundTrip('![shot.png](attachment://abc-123)')
+
+    const image = doc.content?.[0]?.content?.[0] ?? doc.content?.[0]
+    expect(image?.type).toBe('image')
+    expect(image?.attrs?.src).toBe('attachment://abc-123')
+    expect(image?.attrs?.alt).toBe('shot.png')
+  })
+
+  it('round-trips a non-image attachment chip', () => {
+    const doc = stableRoundTrip('[notes.pdf](attachment://abc-123)')
+
+    const chip = doc.content?.[0]?.content?.[0]
+    expect(chip?.type).toBe('attachmentFile')
+    expect(chip?.attrs).toMatchObject({
+      attachmentId: 'abc-123',
+      fileName: 'notes.pdf',
+    })
+  })
+})

--- a/apps/desktop/src/lib/feedbackEditorExtensions.ts
+++ b/apps/desktop/src/lib/feedbackEditorExtensions.ts
@@ -1,0 +1,165 @@
+import { Node, type AnyExtension } from '@tiptap/core'
+import Image from '@tiptap/extension-image'
+import { TableKit } from '@tiptap/extension-table'
+import TaskItem from '@tiptap/extension-task-item'
+import TaskList from '@tiptap/extension-task-list'
+import { Markdown } from '@tiptap/markdown'
+import StarterKit from '@tiptap/starter-kit'
+
+import { attachmentIdFromUrl, attachmentMarkdownUrl } from './attachmentMarkdown'
+
+const AttachmentImage = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      attachmentId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-attachment-id'),
+        renderHTML: (attributes) =>
+          attributes.attachmentId
+            ? { 'data-attachment-id': attributes.attachmentId }
+            : {},
+      },
+    }
+  },
+
+  renderMarkdown: (node) => {
+    const attachmentId =
+      node.attrs?.attachmentId ?? attachmentIdFromUrl(node.attrs?.src)
+    const src = attachmentId
+      ? attachmentMarkdownUrl(attachmentId)
+      : (node.attrs?.src ?? '')
+    const alt = node.attrs?.alt ?? ''
+    const title = node.attrs?.title ?? ''
+    return title ? `![${alt}](${src} "${title}")` : `![${alt}](${src})`
+  },
+})
+
+// A clickable chip for a non-image attachment, serialized as a markdown
+// link `[fileName](attachment://id)`. A custom marked tokenizer claims
+// `attachment://` links before StarterKit's built-in Link mark so they
+// parse back into this node instead of a link mark.
+const AttachmentFile = Node.create({
+  name: 'attachmentFile',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      attachmentId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-attachment-id'),
+        renderHTML: (attributes) =>
+          attributes.attachmentId
+            ? { 'data-attachment-id': attributes.attachmentId }
+            : {},
+      },
+      fileName: {
+        default: '',
+        parseHTML: (element) => element.getAttribute('data-file-name'),
+        renderHTML: (attributes) =>
+          attributes.fileName ? { 'data-file-name': attributes.fileName } : {},
+      },
+      mediaType: {
+        default: '',
+        parseHTML: (element) => element.getAttribute('data-media-type'),
+        renderHTML: (attributes) =>
+          attributes.mediaType ? { 'data-media-type': attributes.mediaType } : {},
+      },
+    }
+  },
+
+  markdownTokenName: 'attachmentFile',
+  markdownTokenizer: {
+    name: 'attachmentFile',
+    level: 'inline',
+    start: (src) => src.indexOf('['),
+    tokenize: (src) => {
+      const match = /^\[([^\]]*)\]\(attachment:\/\/([0-9a-fA-F-]+)\)/.exec(src)
+      if (!match) return undefined
+      return { type: 'attachmentFile', raw: match[0], text: match[1], attachmentId: match[2] }
+    },
+  },
+  parseMarkdown: (token, helpers) =>
+    helpers.createNode('attachmentFile', {
+      attachmentId: token.attachmentId,
+      fileName: token.text || token.attachmentId,
+      mediaType: '',
+    }),
+
+  renderHTML({ node }) {
+    const attachmentId = node.attrs.attachmentId ?? ''
+    const fileName = node.attrs.fileName || attachmentId || 'attachment'
+    const ext = (fileName.split('.').pop() || 'FILE').toUpperCase().slice(0, 4)
+    return [
+      'a',
+      {
+        href: attachmentMarkdownUrl(attachmentId),
+        'data-attachment-id': attachmentId,
+        'data-file-name': fileName,
+        'data-media-type': node.attrs.mediaType ?? '',
+        class: 'attachment-file-chip',
+        contenteditable: 'false',
+      },
+      ['span', { class: 'attachment-file-chip-ext' }, ext],
+      ['span', { class: 'attachment-file-chip-label' }, fileName],
+    ]
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'a[href^="attachment://"]',
+        getAttrs: (element) => {
+          const href = element.getAttribute('href') ?? ''
+          return {
+            attachmentId:
+              element.getAttribute('data-attachment-id') ??
+              attachmentIdFromUrl(href) ??
+              null,
+            fileName:
+              element.getAttribute('data-file-name') ??
+              element.textContent?.trim() ??
+              '',
+            mediaType: element.getAttribute('data-media-type') ?? '',
+          }
+        },
+      },
+    ]
+  },
+
+  renderMarkdown: (node) => {
+    const url = attachmentMarkdownUrl(node.attrs?.attachmentId ?? '')
+    const label = (node.attrs?.fileName || node.attrs?.attachmentId || '').replace(
+      /([\[\]])/g,
+      '\\$1',
+    )
+    return `[${label}](${url})`
+  },
+})
+
+/**
+ * Extensions behind the rich feedback editor.
+ *
+ * A human can ramble in tables and checklists, and a host can hand a cooked
+ * draft back with either. Tables and task items only survive the markdown
+ * round trip when the schema knows those nodes: without them the parser drops
+ * a whole table on the floor and flattens `- [ ]` into a plain bullet. Keep
+ * this in step with `workbench/MarkdownPreview.svelte`, which renders the same
+ * markdown read-only.
+ */
+export function feedbackEditorExtensions(): AnyExtension[] {
+  return [
+    StarterKit.configure({
+      heading: { levels: [2, 3] },
+    }),
+    TableKit,
+    TaskList,
+    TaskItem.configure({ nested: true }),
+    AttachmentImage,
+    AttachmentFile,
+    Markdown,
+  ]
+}

--- a/apps/desktop/src/lib/workbench/MarkdownPreview.svelte
+++ b/apps/desktop/src/lib/workbench/MarkdownPreview.svelte
@@ -149,17 +149,18 @@
     list-style: none;
   }
 
-  :global(.attachment-markdown-prose li[data-type='taskItem']) {
+  /* Task items carry `data-checked`, not `data-type`; scope through the list. */
+  :global(.attachment-markdown-prose ul[data-type='taskList'] > li) {
     display: flex;
     align-items: flex-start;
     gap: 0.55em;
   }
 
-  :global(.attachment-markdown-prose li[data-type='taskItem'] > label) {
+  :global(.attachment-markdown-prose ul[data-type='taskList'] > li > label) {
     margin-top: 0.26em;
   }
 
-  :global(.attachment-markdown-prose li[data-type='taskItem'] > div) {
+  :global(.attachment-markdown-prose ul[data-type='taskList'] > li > div) {
     min-width: 0;
     flex: 1;
   }


### PR DESCRIPTION
## The bug

A markdown table in the feedback body is **silently dropped**. Not rendered as source, not escaped — gone.

`RichFeedbackEditor.svelte` builds its Tiptap editor from `StarterKit` alone, so the schema has no `table` node. `@tiptap/markdown` tokenizes the table fine, finds no handler for the token, and drops it. The paragraphs around it survive, which makes the loss easy to miss.

Reproduction with the editor's own extension set:

```
| Area | Verdict |
| --- | --- |
| Ramble | smooth |
```
→ `{ "type": "doc", "content": [] }`

Same class of loss, one step milder: `- [ ] todo` parses as a plain bullet, so the checkbox state is lost on every round trip.

This is not only an editing concern. `FeedbackEditorPanel` renders completed and published feedback through the same component in read-only mode, so a submitted package that contains a table reads back into the workbench without it. The package on disk is intact; the workbench view is not. That sits against the first tiebreaker in `docs/CONSTITUTION.md` — 不丢请求、草稿和已提交反馈.

`workbench/MarkdownPreview.svelte`, which renders attachment markdown read-only, already registers `TableKit` + `TaskList`/`TaskItem` and handles both correctly. This brings the editor to the same baseline.

## The change

- Move the editor's extension set into `lib/feedbackEditorExtensions.ts` so it can be unit-tested without a DOM (`AttachmentImage` and `AttachmentFile` move unchanged), matching how `workbench/*Controller.ts` is already split out of its components.
- Register `TableKit`, `TaskList` and `TaskItem` there.
- Style tables and task items in `.feedback-prose`, tracking `MarkdownPreview`'s look: header shading, cell borders, per-column alignment, `overflow-x` on the wrapper the table node view always emits, and a `.selectedCell` tint for multi-cell selections.
- Fix a dead selector in `MarkdownPreview.svelte`. Its task-item rules are written as `li[data-type='taskItem']`, but Tiptap renders task items as `li[data-checked]` — the flex rules never applied. Scoped through `ul[data-type='taskList'] > li` instead.

No new dependencies: `@tiptap/extension-table`, `@tiptap/extension-task-list` and `@tiptap/extension-task-item` are already in `apps/desktop/package.json`.

No toolbar button. Tiptap's built-in keys carry the editing: `Tab`/`Shift-Tab` move between cells, `Tab` in the last cell appends a row, selecting all cells and pressing `Backspace` deletes the table.

## Tests

`feedbackEditorExtensions.test.ts` drives `MarkdownManager` with the real extension set. Every case asserts a stable round trip (markdown → doc → markdown → doc) on top of its own claim:

- a table parses into `table`/`tableRow`/`tableHeader`/`tableCell` instead of vanishing
- blocks around a table keep their order
- a table serializes back to a pipe table the host can read
- `:---`/`---:` alignment survives
- `- [ ]` / `- [x]` keep their checked state
- attachment images and attachment file chips still round-trip (regression guard on the move)

Reverting the three extension registrations turns the first five red.

## Verification

`pnpm check`, `pnpm test` (89 tests), `pnpm check:terminology`, `pnpm build:web`, `pnpm contracts:check` all pass.

Checked by hand in the browser workbench (`pnpm dev:web` + `?preview=fixtures`) with a seeded table and task list: borders and header shading render, per-column alignment is honoured, checkboxes carry their state, typing into a cell works, `Tab` walks the cells and appends a row at the end, and the console stays clean.

---

**中文摘要**

反馈正文里的 Markdown 表格会被静默丢弃：编辑器只装了 `StarterKit`，schema 里没有 table 节点，`@tiptap/markdown` 解析出 table token 后找不到处理器就丢掉，前后段落还在，所以很难被发现。`- [ ]` 的复选框状态同样会在每次往返中丢失。

已完成的反馈在工作台回看时走的是同一个组件，所以提交过的表格也看不到（磁盘上的 package 本身完好）。同项目的只读组件 `MarkdownPreview.svelte` 已经装了 `TableKit` 和 `TaskList`/`TaskItem`，本 PR 把编辑器补齐到同一水平。

改动：把编辑器的扩展集抽到 `lib/feedbackEditorExtensions.ts`（便于无 DOM 单测），在其中注册三个扩展，补上表格与任务项样式，并修掉 `MarkdownPreview.svelte` 里一处从未生效的选择器（Tiptap 渲染的是 `li[data-checked]`，不是 `li[data-type='taskItem']`）。没有新增依赖，也没有新增工具栏按钮。

---

## Test plan

- [x] `pnpm test` — 89 tests, incl. 7 new in `feedbackEditorExtensions.test.ts`
- [x] `pnpm check` — svelte-check, 0 errors
- [x] `pnpm check:terminology`
- [x] `pnpm build:web`
- [x] `pnpm contracts:check`
- [x] Browser workbench (`pnpm dev:web` + `?preview=fixtures`) with a seeded table + task list: render, alignment, checkbox state, cell editing, `Tab` navigation, `Tab`-appends-row, clean console

## Reproducing

`pnpm dev:web` → `http://127.0.0.1:1420/?preview=fixtures`, then paste this into the feedback editor:

```
| Area | Verdict |
| :--- | ---: |
| Ramble | smooth |

- [x] done
- [ ] todo
```

Before: the table disappears entirely and the checkboxes flatten to plain bullets. After: the table renders with borders and per-column alignment, the checkboxes keep their state, cells are editable, and `Tab` walks them.
