### PR TITLE
Introduce the WorkspaceShell state seam

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -57,6 +57,12 @@
     sessionViewDescriptor,
     type SessionViewDescriptor,
   } from './lib/workspace/viewDescriptors'
+  import {
+    activeWorkspaceView,
+    EMPTY_WORKSPACE_SHELL_STATE,
+    workspaceShellReducer,
+    type WorkspaceShellState,
+  } from './lib/workspace/workspaceShell'
   import { previewFixtures, previewWorkspaceFor } from './lib/previewFixtures'
   import {
     restorePublishedAttachmentUrls,
@@ -131,6 +137,8 @@
     formatTime(value, $locale, tr('Not saved yet'))
   let workspace: FeedbackWorkspaceView | null = null
   let sessionView: SessionViewDescriptor | null = null
+  let workspaceShellState: WorkspaceShellState = EMPTY_WORKSPACE_SHELL_STATE
+  let renderedSessionView: SessionViewDescriptor | null = null
   let completedResult: FeedbackRequestView | null = null
   let publishedFeedback: PublishedFeedbackView | null = null
   let draftBody = ''
@@ -362,6 +370,13 @@
     : $navigation.selectedHostId && $navigation.selectedHostSessionId
       ? sessionViewDescriptor($navigation.selectedHostId, $navigation.selectedHostSessionId)
       : null
+  $: workspaceShellState = sessionView
+    ? workspaceShellReducer(EMPTY_WORKSPACE_SHELL_STATE, {
+        type: 'open',
+        view: sessionView,
+      })
+    : EMPTY_WORKSPACE_SHELL_STATE
+  $: renderedSessionView = activeWorkspaceView(workspaceShellState)
   $: requestScopeLabel = $navigation.selectedHostId
     ? $navigation.selectedHostSessionId
       ? selectedHostSession?.source_hint ??
@@ -1065,7 +1080,7 @@
       <Pane id="workspace-pane" minSize={workspaceMinimumSize}>
         <SessionWorkbench
           bind:this={sessionWorkbench}
-          view={sessionView}
+          view={renderedSessionView}
           bind:taskBriefOpen
           {loadingWorkspace}
           {workspace}

--- a/apps/desktop/src/lib/workspace/viewDescriptors.ts
+++ b/apps/desktop/src/lib/workspace/viewDescriptors.ts
@@ -4,6 +4,8 @@ export type SessionViewDescriptor = Readonly<{
   hostSessionId: string
 }>
 
+export type WorkspaceViewDescriptor = SessionViewDescriptor
+
 export function sessionViewDescriptor(
   hostId: string,
   hostSessionId: string,

--- a/apps/desktop/src/lib/workspace/workspaceShell.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceShell.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  sessionViewDescriptor,
+  workspaceViewKey,
+  type WorkspaceViewDescriptor,
+} from './viewDescriptors'
+import {
+  activeWorkspaceView,
+  EMPTY_WORKSPACE_SHELL_STATE,
+  workspaceShellReducer,
+  type WorkspaceShellAction,
+  type WorkspaceShellState,
+} from './workspaceShell'
+
+const alpha = sessionViewDescriptor('codex', 'alpha')
+const beta = sessionViewDescriptor('codex', 'beta')
+const gamma = sessionViewDescriptor('pi', 'gamma')
+
+function reduce(
+  state: WorkspaceShellState,
+  ...actions: WorkspaceShellAction[]
+): WorkspaceShellState {
+  return actions.reduce(workspaceShellReducer, state)
+}
+
+function open(view: WorkspaceViewDescriptor): WorkspaceShellAction {
+  return { type: 'open', view }
+}
+
+function expectValidState(state: WorkspaceShellState) {
+  const keys = state.views.map(workspaceViewKey)
+  expect(new Set(keys).size).toBe(keys.length)
+  if (state.activeViewKey === null) expect(state.views).toHaveLength(0)
+  else expect(keys).toContain(state.activeViewKey)
+}
+
+describe('workspaceShellReducer', () => {
+  it('starts empty and opens consecutive views with the latest active', () => {
+    expect(EMPTY_WORKSPACE_SHELL_STATE).toEqual({ views: [], activeViewKey: null })
+    expect(activeWorkspaceView(EMPTY_WORKSPACE_SHELL_STATE)).toBeNull()
+
+    const first = workspaceShellReducer(EMPTY_WORKSPACE_SHELL_STATE, open(alpha))
+    const second = workspaceShellReducer(first, open(beta))
+
+    expect(first.views).toEqual([alpha])
+    expect(activeWorkspaceView(first)).toBe(alpha)
+    expect(second.views).toEqual([alpha, beta])
+    expect(activeWorkspaceView(second)).toBe(beta)
+    expectValidState(first)
+    expectValidState(second)
+  })
+
+  it('deduplicates by stable key, focuses the existing view, and keeps its position', () => {
+    const duplicateAlpha = sessionViewDescriptor('codex', 'alpha')
+    const beforeDuplicate = reduce(
+      EMPTY_WORKSPACE_SHELL_STATE,
+      open(alpha),
+      open(beta),
+    )
+    const result = workspaceShellReducer(beforeDuplicate, open(duplicateAlpha))
+
+    expect(result.views).toEqual([alpha, beta])
+    expect(result.views[0]).toBe(alpha)
+    expect(result.activeViewKey).toBe(workspaceViewKey(alpha))
+    expectValidState(result)
+  })
+
+  it('keeps the same session id from different hosts as distinct views', () => {
+    const codex = sessionViewDescriptor('codex', 'shared')
+    const pi = sessionViewDescriptor('pi', 'shared')
+    const result = reduce(EMPTY_WORKSPACE_SHELL_STATE, open(codex), open(pi))
+
+    expect(result.views).toEqual([codex, pi])
+    expect(activeWorkspaceView(result)).toBe(pi)
+    expectValidState(result)
+  })
+
+  it('focuses known views and ignores active or unknown keys', () => {
+    const initial = reduce(EMPTY_WORKSPACE_SHELL_STATE, open(alpha), open(beta))
+    const focused = workspaceShellReducer(initial, {
+      type: 'focus',
+      viewKey: workspaceViewKey(alpha),
+    })
+
+    expect(activeWorkspaceView(focused)).toBe(alpha)
+    expect(
+      workspaceShellReducer(focused, {
+        type: 'focus',
+        viewKey: workspaceViewKey(alpha),
+      }),
+    ).toBe(focused)
+    expect(workspaceShellReducer(focused, { type: 'focus', viewKey: 'session:missing' })).toBe(
+      focused,
+    )
+    expectValidState(focused)
+  })
+
+  it('closes an inactive view without changing the active view', () => {
+    const initial = reduce(
+      EMPTY_WORKSPACE_SHELL_STATE,
+      open(alpha),
+      open(beta),
+      open(gamma),
+    )
+    const result = workspaceShellReducer(initial, {
+      type: 'close',
+      viewKey: workspaceViewKey(alpha),
+    })
+
+    expect(result.views).toEqual([beta, gamma])
+    expect(activeWorkspaceView(result)).toBe(gamma)
+    expectValidState(result)
+  })
+
+  it('focuses the right neighbor, otherwise the left neighbor, when closing active views', () => {
+    const middleActive = reduce(
+      EMPTY_WORKSPACE_SHELL_STATE,
+      open(alpha),
+      open(beta),
+      open(gamma),
+      { type: 'focus', viewKey: workspaceViewKey(beta) },
+    )
+    const closedMiddle = workspaceShellReducer(middleActive, {
+      type: 'close',
+      viewKey: workspaceViewKey(beta),
+    })
+    expect(closedMiddle.views).toEqual([alpha, gamma])
+    expect(activeWorkspaceView(closedMiddle)).toBe(gamma)
+
+    const closedRight = workspaceShellReducer(
+      reduce(EMPTY_WORKSPACE_SHELL_STATE, open(alpha), open(beta), open(gamma)),
+      { type: 'close', viewKey: workspaceViewKey(gamma) },
+    )
+    expect(closedRight.views).toEqual([alpha, beta])
+    expect(activeWorkspaceView(closedRight)).toBe(beta)
+
+    const closedLeft = workspaceShellReducer(
+      reduce(
+        EMPTY_WORKSPACE_SHELL_STATE,
+        open(alpha),
+        open(beta),
+        open(gamma),
+        { type: 'focus', viewKey: workspaceViewKey(alpha) },
+      ),
+      { type: 'close', viewKey: workspaceViewKey(alpha) },
+    )
+    expect(closedLeft.views).toEqual([beta, gamma])
+    expect(activeWorkspaceView(closedLeft)).toBe(beta)
+    expectValidState(closedMiddle)
+    expectValidState(closedRight)
+    expectValidState(closedLeft)
+  })
+
+  it('becomes empty after closing the last active view and ignores unknown closes', () => {
+    const initial = workspaceShellReducer(EMPTY_WORKSPACE_SHELL_STATE, open(alpha))
+    const unknownClose = workspaceShellReducer(initial, {
+      type: 'close',
+      viewKey: 'session:missing',
+    })
+    const result = workspaceShellReducer(initial, {
+      type: 'close',
+      viewKey: workspaceViewKey(alpha),
+    })
+
+    expect(unknownClose).toBe(initial)
+    expect(result).toEqual(EMPTY_WORKSPACE_SHELL_STATE)
+    expect(activeWorkspaceView(result)).toBeNull()
+    expectValidState(result)
+  })
+
+  it('does not mutate prior state or descriptor arrays', () => {
+    const views = Object.freeze([alpha, beta])
+    const initial: WorkspaceShellState = Object.freeze({
+      views,
+      activeViewKey: workspaceViewKey(beta),
+    })
+    const snapshot = [...views]
+
+    const result = workspaceShellReducer(initial, open(gamma))
+
+    expect(initial.views).toBe(views)
+    expect(initial.views).toEqual(snapshot)
+    expect(result.views).toEqual([alpha, beta, gamma])
+    expect(result.views).not.toBe(initial.views)
+    expectValidState(initial)
+    expectValidState(result)
+  })
+})

--- a/apps/desktop/src/lib/workspace/workspaceShell.ts
+++ b/apps/desktop/src/lib/workspace/workspaceShell.ts
@@ -1,0 +1,67 @@
+import {
+  workspaceViewKey,
+  type WorkspaceViewDescriptor,
+} from './viewDescriptors'
+
+export type WorkspaceShellState = Readonly<{
+  views: readonly WorkspaceViewDescriptor[]
+  activeViewKey: string | null
+}>
+
+export type WorkspaceShellAction =
+  | Readonly<{ type: 'open'; view: WorkspaceViewDescriptor }>
+  | Readonly<{ type: 'focus'; viewKey: string }>
+  | Readonly<{ type: 'close'; viewKey: string }>
+
+const EMPTY_WORKSPACE_VIEWS: readonly WorkspaceViewDescriptor[] = Object.freeze([])
+
+export const EMPTY_WORKSPACE_SHELL_STATE: WorkspaceShellState = Object.freeze({
+  views: EMPTY_WORKSPACE_VIEWS,
+  activeViewKey: null,
+})
+
+export function workspaceShellReducer(
+  state: WorkspaceShellState,
+  action: WorkspaceShellAction,
+): WorkspaceShellState {
+  switch (action.type) {
+    case 'open': {
+      const viewKey = workspaceViewKey(action.view)
+      const alreadyOpen = state.views.some((view) => workspaceViewKey(view) === viewKey)
+      if (alreadyOpen) {
+        return state.activeViewKey === viewKey ? state : { ...state, activeViewKey: viewKey }
+      }
+      return {
+        views: [...state.views, action.view],
+        activeViewKey: viewKey,
+      }
+    }
+    case 'focus': {
+      if (state.activeViewKey === action.viewKey) return state
+      const known = state.views.some((view) => workspaceViewKey(view) === action.viewKey)
+      return known ? { ...state, activeViewKey: action.viewKey } : state
+    }
+    case 'close': {
+      const closedIndex = state.views.findIndex(
+        (view) => workspaceViewKey(view) === action.viewKey,
+      )
+      if (closedIndex === -1) return state
+
+      const views = state.views.filter((_, index) => index !== closedIndex)
+      if (state.activeViewKey !== action.viewKey) return { ...state, views }
+
+      const fallback = views[Math.min(closedIndex, views.length - 1)]
+      return {
+        views,
+        activeViewKey: fallback ? workspaceViewKey(fallback) : null,
+      }
+    }
+  }
+}
+
+export function activeWorkspaceView(
+  state: WorkspaceShellState,
+): WorkspaceViewDescriptor | null {
+  if (!state.activeViewKey) return null
+  return state.views.find((view) => workspaceViewKey(view) === state.activeViewKey) ?? null
+}


### PR DESCRIPTION
## Summary
- add a pure, readonly WorkspaceShell reducer for open, focus, close, and stable-key deduplication
- cover ordering, active-view fallback, cross-host identity, unknown actions, and immutability with focused tests
- project the current single Session through WorkspaceShell into the existing SessionWorkbench
- deliberately defer tabs, history, persistence, keyed remounting, and multi-editor behavior to later PRs

## Validation
- 40 test files / 180 tests passed
- `pnpm -C apps/desktop check` (0 errors, 0 warnings)
- `pnpm -C apps/desktop build:web`
- `git diff --check main...HEAD`
- browser fixture: one `.workspace-panel`, one contenteditable editor, stable Session view key

## Review notes
- Standards review: no blocking findings
- Spec review: no blocking findings
- DOM-level switching automation is deferred to UI-4, where real tab switching and the save-unmount-load contract are introduced.