### PR TITLE
Add multi-session workspace tabs

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -55,6 +55,7 @@
   import { checkForUpdates } from './lib/updater'
   import {
     sessionViewDescriptor,
+    workspaceViewKey,
     type SessionViewDescriptor,
   } from './lib/workspace/viewDescriptors'
   import {
@@ -137,9 +138,9 @@
   const formatTimeLocal = (value: string | null | undefined) =>
     formatTime(value, $locale, tr('Not saved yet'))
   let workspace: FeedbackWorkspaceView | null = null
-  let sessionView: SessionViewDescriptor | null = null
   let workspaceShellState: WorkspaceShellState = EMPTY_WORKSPACE_SHELL_STATE
   let renderedSessionView: SessionViewDescriptor | null = null
+  let sessionRequestIds = new Map<string, string>()
   let completedResult: FeedbackRequestView | null = null
   let publishedFeedback: PublishedFeedbackView | null = null
   let draftBody = ''
@@ -366,17 +367,6 @@
           session.host_session_id === $navigation.selectedHostSessionId,
       )
     : undefined
-  $: sessionView = workspace
-    ? sessionViewDescriptor(workspace.request.host_id, workspace.request.host_session_id)
-    : $navigation.selectedHostId && $navigation.selectedHostSessionId
-      ? sessionViewDescriptor($navigation.selectedHostId, $navigation.selectedHostSessionId)
-      : null
-  $: workspaceShellState = sessionView
-    ? workspaceShellReducer(EMPTY_WORKSPACE_SHELL_STATE, {
-        type: 'open',
-        view: sessionView,
-      })
-    : EMPTY_WORKSPACE_SHELL_STATE
   $: renderedSessionView = activeWorkspaceView(workspaceShellState)
   const sessionTabLabel = (view: SessionViewDescriptor) => {
     const session = $navigation.hostSessions.find(
@@ -626,6 +616,65 @@
     attachmentController.releasePreviews()
   }
 
+  function openSessionView(view: SessionViewDescriptor, requestId?: string) {
+    if (requestId) {
+      const nextRequestIds = new Map(sessionRequestIds)
+      nextRequestIds.set(workspaceViewKey(view), requestId)
+      sessionRequestIds = nextRequestIds
+    }
+    workspaceShellState = workspaceShellReducer(workspaceShellState, { type: 'open', view })
+  }
+
+  function openLoadedWorkspaceView(next: FeedbackWorkspaceView) {
+    openSessionView(
+      sessionViewDescriptor(next.request.host_id, next.request.host_session_id),
+      next.request.request_id,
+    )
+  }
+
+  async function selectRailScope(hostId: string | null, hostSessionId: string | null) {
+    const selection = await navigation.selectScope(hostId, hostSessionId)
+    if (!selection.selected || !hostId || !hostSessionId) return
+
+    const view = sessionViewDescriptor(hostId, hostSessionId)
+    const viewKey = workspaceViewKey(view)
+    const rememberedRequestId = sessionRequestIds.get(viewKey)
+    const request =
+      selection.requests.find((candidate) => candidate.request_id === rememberedRequestId) ??
+      selection.requests[0]
+    if (request) {
+      await openRequest(request.request_id)
+      return
+    }
+
+    if (dirty && !(await saveDraftNow())) return
+    clearWorkspace()
+    openSessionView(view)
+  }
+
+  async function activateSessionTab(viewKey: string) {
+    if (workspaceShellState.activeViewKey === viewKey) return
+    const view = workspaceShellState.views.find(
+      (candidate) => workspaceViewKey(candidate) === viewKey,
+    )
+    if (!view) return
+
+    const selection = await navigation.selectScope(view.hostId, view.hostSessionId)
+    if (!selection.selected) return
+    const rememberedRequestId = sessionRequestIds.get(viewKey)
+    const request =
+      selection.requests.find((candidate) => candidate.request_id === rememberedRequestId) ??
+      selection.requests[0]
+    if (request) {
+      await openRequest(request.request_id)
+      return
+    }
+
+    if (dirty && !(await saveDraftNow())) return
+    clearWorkspace()
+    workspaceShellState = workspaceShellReducer(workspaceShellState, { type: 'focus', viewKey })
+  }
+
   async function refreshNotificationPermission() {
     try {
       const granted = await isPermissionGranted()
@@ -636,13 +685,18 @@
     }
   }
 
-  async function openRequest(requestId: string, saveCurrent = true) {
-    if (interactionLocked || workspace?.request.request_id === requestId) return
-    if (saveCurrent && !(await saveDraftNow())) return
+  async function openRequest(requestId: string, saveCurrent = true): Promise<boolean> {
+    if (interactionLocked) return false
+    if (workspace?.request.request_id === requestId) {
+      openLoadedWorkspaceView(workspace)
+      return true
+    }
+    if (saveCurrent && !(await saveDraftNow())) return false
     loadingWorkspace = true
     pageError = ''
     completedResult = null
     publishedFeedback = null
+    let openedWorkspace: FeedbackWorkspaceView | null = null
     try {
       await enqueueDocumentTask(async () => {
         const next = previewMode
@@ -651,6 +705,7 @@
               requestId,
             })
         if (!next) throw new Error(tr('This feedback request could not be found.'))
+        openedWorkspace = next
         workspace = next
         cookedPreview = null
         adoptDraft(next.draft)
@@ -671,8 +726,11 @@
               )
         }
       })
+      if (openedWorkspace) openLoadedWorkspaceView(openedWorkspace)
+      return openedWorkspace !== null
     } catch (cause) {
       pageError = messageFrom(cause)
+      return false
     } finally {
       loadingWorkspace = false
     }
@@ -1039,7 +1097,7 @@
       refreshing={$navigation.refreshingPage}
       {resolveHostProfile}
       onSelect={(hostId, hostSessionId) =>
-        void navigation.selectScope(hostId, hostSessionId)}
+        void selectRailScope(hostId, hostSessionId)}
       onRequestSearch={(search) => void navigation.setRequestSearch(search)}
       onRenameSession={(session, title) => navigation.renameHostSession(session, title)}
       onSetSessionPinned={(session, pinned) => navigation.setHostSessionPinned(session, pinned)}
@@ -1093,6 +1151,7 @@
             views={workspaceShellState.views}
             activeViewKey={workspaceShellState.activeViewKey}
             labelForView={sessionTabLabel}
+            onActivate={(viewKey) => void activateSessionTab(viewKey)}
           />
           <SessionWorkbench
             bind:this={sessionWorkbench}

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -63,6 +63,7 @@
     workspaceShellReducer,
     type WorkspaceShellState,
   } from './lib/workspace/workspaceShell'
+  import WorkspaceTabStrip from './lib/workspace/WorkspaceTabStrip.svelte'
   import { previewFixtures, previewWorkspaceFor } from './lib/previewFixtures'
   import {
     restorePublishedAttachmentUrls,
@@ -377,6 +378,15 @@
       })
     : EMPTY_WORKSPACE_SHELL_STATE
   $: renderedSessionView = activeWorkspaceView(workspaceShellState)
+  const sessionTabLabel = (view: SessionViewDescriptor) => {
+    const session = $navigation.hostSessions.find(
+      (candidate) =>
+        candidate.host_id === view.hostId &&
+        candidate.host_session_id === view.hostSessionId,
+    )
+    const hostLabel = resolveHostProfile(view.hostId).label
+    return `${session?.title ?? view.hostSessionId} · ${hostLabel}`
+  }
   $: requestScopeLabel = $navigation.selectedHostId
     ? $navigation.selectedHostSessionId
       ? selectedHostSession?.source_hint ??
@@ -1078,85 +1088,92 @@
       />
 
       <Pane id="workspace-pane" minSize={workspaceMinimumSize}>
-        <SessionWorkbench
-          bind:this={sessionWorkbench}
-          view={renderedSessionView}
-          bind:taskBriefOpen
-          {loadingWorkspace}
-          {workspace}
-          {feedbackResult}
-          {draftBody}
-          {editorDocument}
-          {editorEpoch}
-          tidyConfig={{
-            provider: $tidyProvider,
-            apiKey: $tidyApiKey,
-            baseUrl: $tidyBaseUrl,
-            model: $tidyModel,
-            reasoningEffort: $tidyReasoningEffort,
-            locale: $locale,
-            systemPrompt: $tidySystemPrompt,
-          }}
-          tidyAutoThreshold={$tidyAutoThreshold}
-          activeActionId={workspace
-            ? activeActionByRequest.get(workspace.request.request_id)?.actionId ?? null
-            : null}
-          {savedRevision}
-          {savePhase}
-          {attachmentPreviews}
-          {dragActive}
-          rambelleStatusPortrait={rambleBelongsToWorkspace
-            ? rambelleStatusPortrait
-            : feedbackResult
-              ? rambelleArchived
-              : rambelleIdle}
-          rambleEngaged={rambleBelongsToWorkspace ? rambleEngaged : false}
-          rambleActive={rambleBelongsToWorkspace ? rambleActive : false}
-          ramblePhase={rambleBelongsToWorkspace ? visibleRamblePhase : 'idle'}
-          rambleBusy={rambleBelongsToWorkspace ? rambleBusy : true}
-          rambleStartedOnce={rambleBelongsToWorkspace ? rambleStartedOnce : false}
-          voiceDevice={rambleBelongsToWorkspace ? voiceDevice : ''}
-          voiceChunkIndex={rambleBelongsToWorkspace ? voiceChunkIndex : 0}
-          voicePartial={rambleBelongsToWorkspace ? voicePartial : ''}
-          voiceLevel={rambleBelongsToWorkspace ? voiceLevel : 0}
-          voiceModelMissing={rambleBelongsToWorkspace ? voiceModelMissing : false}
-          rambleMessage={rambleBelongsToWorkspace ? rambleMessage : ''}
-          attachmentBusy={rambleBelongsToWorkspace ? attachmentBusy : false}
-          {canSubmit}
-          cooking={currentRequestCooking}
-          cookingEnabled={$cookingEnabled}
-          {cookedDraftReady}
-          cookedPreviewModel={cookedPreview?.model ?? ''}
-          cookedPreviewMarkdown={cookedPreview?.markdown ?? ''}
-          onCookPreview={() => void cookPreviewOnly()}
-          onRestoreOriginal={restoreOriginalAfterCook}
-          {submitting}
-          {submitStage}
-          {publishedFeedback}
-          {canCancel}
-          {cancelling}
-          {approving}
-          {canOpenResumePrompt}
-          {resolveHostProfile}
-          formatTime={formatTimeLocal}
-          onReload={() => void reloadWorkspace()}
-          onDraftChange={updateDraft}
-          onTidyError={(message) => (pageError = message)}
-          onOpenTidySettings={() => void openSettings('post-processing')}
-          onSelectAction={selectAction}
-          onToggleRamble={() => void toggleRamble()}
-          onExitRamble={() => void exitRamble()}
-          onOpenVoiceSettings={() => void openSettings('voice')}
-          onStartScreenCapture={() => void attachmentController.startScreenCapture()}
-          onImportClipboard={() => void importClipboardNow()}
-          onFileSelection={attachmentController.handleFileSelection}
-          onRemoveAttachment={(attachment) => void attachmentController.removeAttachment(attachment)}
-          onOpenPackage={() => void openFeedbackPackage()}
-          onOpenResumePrompt={openResumePrompt}
-          onSubmit={() => void submitFeedback()}
-          onCancel={() => void cancelFeedback()}
-          onApprove={() => void approveFeedback()}
-        />
+        <div class="flex h-full min-h-0 min-w-0 flex-col">
+          <WorkspaceTabStrip
+            views={workspaceShellState.views}
+            activeViewKey={workspaceShellState.activeViewKey}
+            labelForView={sessionTabLabel}
+          />
+          <SessionWorkbench
+            bind:this={sessionWorkbench}
+            view={renderedSessionView}
+            bind:taskBriefOpen
+            {loadingWorkspace}
+            {workspace}
+            {feedbackResult}
+            {draftBody}
+            {editorDocument}
+            {editorEpoch}
+            tidyConfig={{
+              provider: $tidyProvider,
+              apiKey: $tidyApiKey,
+              baseUrl: $tidyBaseUrl,
+              model: $tidyModel,
+              reasoningEffort: $tidyReasoningEffort,
+              locale: $locale,
+              systemPrompt: $tidySystemPrompt,
+            }}
+            tidyAutoThreshold={$tidyAutoThreshold}
+            activeActionId={workspace
+              ? activeActionByRequest.get(workspace.request.request_id)?.actionId ?? null
+              : null}
+            {savedRevision}
+            {savePhase}
+            {attachmentPreviews}
+            {dragActive}
+            rambelleStatusPortrait={rambleBelongsToWorkspace
+              ? rambelleStatusPortrait
+              : feedbackResult
+                ? rambelleArchived
+                : rambelleIdle}
+            rambleEngaged={rambleBelongsToWorkspace ? rambleEngaged : false}
+            rambleActive={rambleBelongsToWorkspace ? rambleActive : false}
+            ramblePhase={rambleBelongsToWorkspace ? visibleRamblePhase : 'idle'}
+            rambleBusy={rambleBelongsToWorkspace ? rambleBusy : true}
+            rambleStartedOnce={rambleBelongsToWorkspace ? rambleStartedOnce : false}
+            voiceDevice={rambleBelongsToWorkspace ? voiceDevice : ''}
+            voiceChunkIndex={rambleBelongsToWorkspace ? voiceChunkIndex : 0}
+            voicePartial={rambleBelongsToWorkspace ? voicePartial : ''}
+            voiceLevel={rambleBelongsToWorkspace ? voiceLevel : 0}
+            voiceModelMissing={rambleBelongsToWorkspace ? voiceModelMissing : false}
+            rambleMessage={rambleBelongsToWorkspace ? rambleMessage : ''}
+            attachmentBusy={rambleBelongsToWorkspace ? attachmentBusy : false}
+            {canSubmit}
+            cooking={currentRequestCooking}
+            cookingEnabled={$cookingEnabled}
+            {cookedDraftReady}
+            cookedPreviewModel={cookedPreview?.model ?? ''}
+            cookedPreviewMarkdown={cookedPreview?.markdown ?? ''}
+            onCookPreview={() => void cookPreviewOnly()}
+            onRestoreOriginal={restoreOriginalAfterCook}
+            {submitting}
+            {submitStage}
+            {publishedFeedback}
+            {canCancel}
+            {cancelling}
+            {approving}
+            {canOpenResumePrompt}
+            {resolveHostProfile}
+            formatTime={formatTimeLocal}
+            onReload={() => void reloadWorkspace()}
+            onDraftChange={updateDraft}
+            onTidyError={(message) => (pageError = message)}
+            onOpenTidySettings={() => void openSettings('post-processing')}
+            onSelectAction={selectAction}
+            onToggleRamble={() => void toggleRamble()}
+            onExitRamble={() => void exitRamble()}
+            onOpenVoiceSettings={() => void openSettings('voice')}
+            onStartScreenCapture={() => void attachmentController.startScreenCapture()}
+            onImportClipboard={() => void importClipboardNow()}
+            onFileSelection={attachmentController.handleFileSelection}
+            onRemoveAttachment={(attachment) => void attachmentController.removeAttachment(attachment)}
+            onOpenPackage={() => void openFeedbackPackage()}
+            onOpenResumePrompt={openResumePrompt}
+            onSubmit={() => void submitFeedback()}
+            onCancel={() => void cancelFeedback()}
+            onApprove={() => void approveFeedback()}
+          />
+        </div>
       </Pane>
     </PaneGroup>
 

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -65,6 +65,15 @@
     type WorkspaceShellState,
   } from './lib/workspace/workspaceShell'
   import WorkspaceTabStrip from './lib/workspace/WorkspaceTabStrip.svelte'
+  import {
+    workspaceTabId,
+    workspaceTabPanelId,
+  } from './lib/workspace/workspaceTabNavigation'
+  import {
+    createSessionWorkspaceTransition,
+    type SessionWorkspaceTransitionOutcome,
+    type SessionWorkspaceTransitionTarget,
+  } from './lib/workspace/sessionWorkspaceTransition'
   import { previewFixtures, previewWorkspaceFor } from './lib/previewFixtures'
   import {
     restorePublishedAttachmentUrls,
@@ -141,6 +150,8 @@
   let workspaceShellState: WorkspaceShellState = EMPTY_WORKSPACE_SHELL_STATE
   let renderedSessionView: SessionViewDescriptor | null = null
   let sessionRequestIds = new Map<string, string>()
+  let pendingWorkspaceViewKey: string | null = null
+  let workbenchMounted = true
   let completedResult: FeedbackRequestView | null = null
   let publishedFeedback: PublishedFeedbackView | null = null
   let draftBody = ''
@@ -170,7 +181,7 @@
   let deliveredSaveError = ''
   let attachmentPreviews: Record<string, string> = {}
   let dragActive = false
-  let sessionWorkbench: FeedbackEditorHandle
+  let sessionWorkbench: FeedbackEditorHandle | undefined
   let rambleController: RambleSessionControllerHandle
   let resumePrompt: ResumePrompt | null = null
   let resumeCopyState: 'idle' | 'copied' | 'failed' = 'idle'
@@ -281,6 +292,32 @@
     routeDraftOperation,
     activeActionFor,
     applyWorkspaceMutation,
+  })
+
+  type LoadedSessionWorkspace = Readonly<{
+    workspace: FeedbackWorkspaceView
+    publishedFeedback: PublishedFeedbackView | null
+  }>
+
+  const sessionWorkspaceTransition = createSessionWorkspaceTransition<LoadedSessionWorkspace>({
+    saveCurrent: saveDraftNow,
+    unmountCurrent: () => {
+      workbenchMounted = false
+      sessionWorkbench = undefined
+      loadingWorkspace = true
+    },
+    loadTarget: loadSessionWorkspaceTarget,
+    commitTarget: commitSessionWorkspaceTarget,
+    restoreCurrent: () => {
+      workbenchMounted = true
+      loadingWorkspace = false
+    },
+    setPendingTarget: (target) => {
+      pendingWorkspaceViewKey = target?.pendingViewKey ?? null
+    },
+    reportFailure: (cause) => {
+      pageError = messageFrom(cause)
+    },
   })
 
   const navigation = createNavigationController({
@@ -411,6 +448,12 @@
     !submitting &&
     !cancelling
   $: interactionLocked = submitting || cancelling || approving
+  $: workspaceTransitionLocked =
+    interactionLocked ||
+    attachmentBusy ||
+    screenCaptureBusy ||
+    currentRequestCooking ||
+    cookedDraftReady
   $: voiceActive =
     voicePhase === 'starting' ||
     voicePhase === 'listening' ||
@@ -495,6 +538,7 @@
       if (previewMode) {
         workspace = previewFixtures.workspace
         adoptDraft(previewFixtures.workspace.draft)
+        openLoadedWorkspaceView(previewFixtures.workspace)
         savePhase = 'saved'
         if (new URLSearchParams(window.location.search).get('dialog') === 'resume') {
           resumePrompt = previewFixtures.resumePrompt
@@ -632,9 +676,36 @@
     )
   }
 
+  type NavigationScope = Readonly<{
+    hostId: string | null
+    hostSessionId: string | null
+  }>
+
+  function currentNavigationScope(): NavigationScope {
+    return {
+      hostId: $navigation.selectedHostId,
+      hostSessionId: $navigation.selectedHostSessionId,
+    }
+  }
+
+  async function restoreNavigationScope(
+    scope: NavigationScope,
+    outcome: SessionWorkspaceTransitionOutcome,
+  ) {
+    if (outcome !== 'blocked' && outcome !== 'failed') return
+    await navigation.selectScope(scope.hostId, scope.hostSessionId)
+  }
+
   async function selectRailScope(hostId: string | null, hostSessionId: string | null) {
+    if (workspaceTransitionLocked) return
+    const priorScope = currentNavigationScope()
+    sessionWorkspaceTransition.invalidate()
     const selection = await navigation.selectScope(hostId, hostSessionId)
     if (!selection.selected || !hostId || !hostSessionId) return
+    if (workspaceTransitionLocked) {
+      await navigation.selectScope(priorScope.hostId, priorScope.hostSessionId)
+      return
+    }
 
     const view = sessionViewDescriptor(hostId, hostSessionId)
     const viewKey = workspaceViewKey(view)
@@ -643,17 +714,23 @@
       selection.requests.find((candidate) => candidate.request_id === rememberedRequestId) ??
       selection.requests[0]
     if (request) {
-      await openRequest(request.request_id)
+      const outcome = await activateRequest(request.request_id)
+      await restoreNavigationScope(priorScope, outcome)
       return
     }
-
-    if (dirty && !(await saveDraftNow())) return
-    clearWorkspace()
-    openSessionView(view)
+    const outcome = await sessionWorkspaceTransition.activate({
+      view,
+      requestId: null,
+      shellAction: { type: 'open' },
+      pendingViewKey: viewKey,
+    })
+    await restoreNavigationScope(priorScope, outcome)
   }
 
   async function activateSessionTab(viewKey: string) {
-    if (workspaceShellState.activeViewKey === viewKey) return
+    if (workspaceTransitionLocked || workspaceShellState.activeViewKey === viewKey) return
+    const priorScope = currentNavigationScope()
+    sessionWorkspaceTransition.invalidate()
     const view = workspaceShellState.views.find(
       (candidate) => workspaceViewKey(candidate) === viewKey,
     )
@@ -661,18 +738,75 @@
 
     const selection = await navigation.selectScope(view.hostId, view.hostSessionId)
     if (!selection.selected) return
+    if (workspaceTransitionLocked) {
+      await navigation.selectScope(priorScope.hostId, priorScope.hostSessionId)
+      return
+    }
     const rememberedRequestId = sessionRequestIds.get(viewKey)
     const request =
       selection.requests.find((candidate) => candidate.request_id === rememberedRequestId) ??
       selection.requests[0]
     if (request) {
-      await openRequest(request.request_id)
+      const outcome = await activateRequest(request.request_id)
+      await restoreNavigationScope(priorScope, outcome)
       return
     }
+    const outcome = await sessionWorkspaceTransition.activate({
+      view,
+      requestId: null,
+      shellAction: { type: 'open' },
+      pendingViewKey: viewKey,
+    })
+    await restoreNavigationScope(priorScope, outcome)
+  }
 
-    if (dirty && !(await saveDraftNow())) return
-    clearWorkspace()
-    workspaceShellState = workspaceShellReducer(workspaceShellState, { type: 'focus', viewKey })
+  async function closeSessionTab(viewKey: string) {
+    if (workspaceTransitionLocked || pendingWorkspaceViewKey) return
+    const closingActive = workspaceShellState.activeViewKey === viewKey
+    if (!closingActive) {
+      workspaceShellState = workspaceShellReducer(workspaceShellState, {
+        type: 'close',
+        viewKey,
+      })
+      const nextRequestIds = new Map(sessionRequestIds)
+      nextRequestIds.delete(viewKey)
+      sessionRequestIds = nextRequestIds
+      return
+    }
+    sessionWorkspaceTransition.invalidate()
+    const priorScope = currentNavigationScope()
+
+    const nextShellState = workspaceShellReducer(workspaceShellState, {
+      type: 'close',
+      viewKey,
+    })
+    const fallbackView = activeWorkspaceView(nextShellState)
+    let fallbackRequestId: string | null = null
+    if (fallbackView) {
+      const selection = await navigation.selectScope(
+        fallbackView.hostId,
+        fallbackView.hostSessionId,
+      )
+      if (!selection.selected) return
+      if (workspaceTransitionLocked) {
+        await navigation.selectScope(priorScope.hostId, priorScope.hostSessionId)
+        return
+      }
+      const rememberedRequestId = sessionRequestIds.get(workspaceViewKey(fallbackView))
+      fallbackRequestId =
+        selection.requests.find((candidate) => candidate.request_id === rememberedRequestId)
+          ?.request_id ??
+        selection.requests[0]?.request_id ??
+        null
+    }
+
+    const outcome = await sessionWorkspaceTransition.activate({
+      view: fallbackView,
+      requestId: fallbackRequestId,
+      shellAction: { type: 'close', viewKey },
+      pendingViewKey: viewKey,
+    })
+    await restoreNavigationScope(priorScope, outcome)
   }
 
   async function refreshNotificationPermission() {
@@ -685,36 +819,37 @@
     }
   }
 
-  async function openRequest(requestId: string, saveCurrent = true): Promise<boolean> {
-    if (interactionLocked) return false
-    if (workspace?.request.request_id === requestId) {
-      openLoadedWorkspaceView(workspace)
-      return true
-    }
-    if (saveCurrent && !(await saveDraftNow())) return false
-    loadingWorkspace = true
-    pageError = ''
-    completedResult = null
-    publishedFeedback = null
-    let openedWorkspace: FeedbackWorkspaceView | null = null
-    try {
-      await enqueueDocumentTask(async () => {
-        const next = previewMode
-          ? previewWorkspaceFor(requestId)
-          : await invoke<FeedbackWorkspaceView>('get_feedback_workspace', {
-              requestId,
-            })
-        if (!next) throw new Error(tr('This feedback request could not be found.'))
-        openedWorkspace = next
-        workspace = next
-        cookedPreview = null
-        adoptDraft(next.draft)
-        savePhase = next.draft.updated_at ? 'saved' : 'idle'
-        saveMessage = ''
-        attachmentMessage = ''
-        await attachmentController.refreshPreviews(next)
-        if (next.request.status === 'completed' && next.feedback) {
-          publishedFeedback = previewMode
+  function viewForRequest(requestId: string): SessionViewDescriptor | null {
+    const request = [...$navigation.requests, ...$navigation.pendingRequests].find(
+      (candidate) => candidate.request_id === requestId,
+    )
+    return request
+      ? sessionViewDescriptor(request.host_id, request.host_session_id)
+      : workspace?.request.request_id === requestId
+        ? sessionViewDescriptor(workspace.request.host_id, workspace.request.host_session_id)
+        : null
+  }
+
+  async function loadSessionWorkspaceTarget(
+    target: SessionWorkspaceTransitionTarget,
+  ): Promise<LoadedSessionWorkspace | null> {
+    if (!target.requestId) return null
+    return enqueueDocumentTask(async () => {
+      const next = previewMode
+        ? previewWorkspaceFor(target.requestId as string)
+        : await invoke<FeedbackWorkspaceView>('get_feedback_workspace', {
+            requestId: target.requestId,
+          })
+      if (!next) throw new Error(tr('This feedback request could not be found.'))
+
+      const loadedView = sessionViewDescriptor(next.request.host_id, next.request.host_session_id)
+      if (target.view && workspaceViewKey(target.view) !== workspaceViewKey(loadedView)) {
+        throw new Error(tr('The feedback request no longer belongs to the selected session.'))
+      }
+
+      const nextPublishedFeedback =
+        next.request.status === 'completed' && next.feedback
+          ? previewMode
             ? {
                 markdown: next.draft.body_markdown,
                 uncooked_markdown: next.draft.body_markdown,
@@ -724,16 +859,80 @@
                   requestId: next.request.request_id,
                 }),
               )
-        }
-      })
-      if (openedWorkspace) openLoadedWorkspaceView(openedWorkspace)
-      return openedWorkspace !== null
-    } catch (cause) {
-      pageError = messageFrom(cause)
-      return false
-    } finally {
-      loadingWorkspace = false
+          : null
+      return { workspace: next, publishedFeedback: nextPublishedFeedback }
+    })
+  }
+
+  function commitSessionWorkspaceTarget(
+    target: SessionWorkspaceTransitionTarget,
+    loaded: LoadedSessionWorkspace | null,
+  ) {
+    const loadedView = loaded
+      ? sessionViewDescriptor(
+          loaded.workspace.request.host_id,
+          loaded.workspace.request.host_session_id,
+        )
+      : target.view
+    if (target.shellAction.type === 'open' && !loadedView) {
+      throw new Error(tr('This feedback request could not be found.'))
     }
+
+    const nextShellState =
+      target.shellAction.type === 'close'
+        ? workspaceShellReducer(workspaceShellState, target.shellAction)
+        : workspaceShellReducer(workspaceShellState, { type: 'open', view: loadedView! })
+
+    if (loaded) {
+      attachmentController.releasePreviews()
+      workspace = loaded.workspace
+      completedResult = null
+      publishedFeedback = loaded.publishedFeedback
+      cookedPreview = null
+      adoptDraft(loaded.workspace.draft)
+      savePhase = loaded.workspace.draft.updated_at ? 'saved' : 'idle'
+      saveMessage = ''
+      attachmentMessage = ''
+      const nextRequestIds = new Map(sessionRequestIds)
+      nextRequestIds.set(workspaceViewKey(loadedView!), loaded.workspace.request.request_id)
+      if (target.shellAction.type === 'close') nextRequestIds.delete(target.shellAction.viewKey)
+      sessionRequestIds = nextRequestIds
+    } else {
+      clearWorkspace()
+      if (target.shellAction.type === 'close') {
+        const nextRequestIds = new Map(sessionRequestIds)
+        nextRequestIds.delete(target.shellAction.viewKey)
+        sessionRequestIds = nextRequestIds
+      }
+    }
+
+    workspaceShellState = nextShellState
+    workbenchMounted = true
+    loadingWorkspace = false
+    if (loaded) void attachmentController.refreshPreviews(loaded.workspace)
+  }
+
+  async function activateRequest(
+    requestId: string,
+  ): Promise<SessionWorkspaceTransitionOutcome> {
+    if (workspaceTransitionLocked) return 'blocked'
+    sessionWorkspaceTransition.invalidate()
+    if (workspace?.request.request_id === requestId) {
+      openLoadedWorkspaceView(workspace)
+      return 'activated'
+    }
+    pageError = ''
+    const view = viewForRequest(requestId)
+    return sessionWorkspaceTransition.activate({
+      view,
+      requestId,
+      shellAction: { type: 'open' },
+      pendingViewKey: view ? workspaceViewKey(view) : `request:${JSON.stringify(requestId)}`,
+    })
+  }
+
+  async function openRequest(requestId: string, _saveCurrent = true): Promise<boolean> {
+    return (await activateRequest(requestId)) === 'activated'
   }
 
   function activeActionFor(requestId: string): ActiveAction {
@@ -752,7 +951,7 @@
   async function routeDraftOperation(requestId: string, operation: DraftOperation): Promise<void> {
     if (!requestId) return
     const run = enqueueDocumentTask(async () => {
-      if (workspace?.request.request_id === requestId) {
+      if (workbenchMounted && workspace?.request.request_id === requestId) {
         if (
           workspace.request.status === 'completed' ||
           workspace.request.status === 'cancelled'
@@ -816,13 +1015,20 @@
   }
 
   async function reloadWorkspace() {
-    if (interactionLocked) return
+    if (workspaceTransitionLocked) return
     const requestId = workspace?.request.request_id
     if (!requestId) return
     if (rambleCanExit) await exitRamble()
-    if (dirty && !(await saveDraftNow())) return
-    workspace = null
-    await openRequest(requestId, false)
+    const view = sessionViewDescriptor(
+      workspace!.request.host_id,
+      workspace!.request.host_session_id,
+    )
+    await sessionWorkspaceTransition.activate({
+      view,
+      requestId,
+      shellAction: { type: 'open' },
+      pendingViewKey: workspaceViewKey(view),
+    })
   }
 
   async function openSettings(section: SettingsSection) {
@@ -1150,10 +1356,25 @@
           <WorkspaceTabStrip
             views={workspaceShellState.views}
             activeViewKey={workspaceShellState.activeViewKey}
+            pendingViewKey={pendingWorkspaceViewKey}
+            disabled={workspaceTransitionLocked}
             labelForView={sessionTabLabel}
             onActivate={(viewKey) => void activateSessionTab(viewKey)}
+            onClose={closeSessionTab}
           />
-          <SessionWorkbench
+          <div
+            class="min-h-0 flex-1"
+            role={renderedSessionView ? 'tabpanel' : undefined}
+            id={renderedSessionView
+              ? workspaceTabPanelId(workspaceViewKey(renderedSessionView))
+              : undefined}
+            aria-labelledby={renderedSessionView
+              ? workspaceTabId(workspaceViewKey(renderedSessionView))
+              : undefined}
+          >
+            {#if workbenchMounted}
+              {#key renderedSessionView ? workspaceViewKey(renderedSessionView) : 'workspace:empty'}
+              <SessionWorkbench
             bind:this={sessionWorkbench}
             view={renderedSessionView}
             bind:taskBriefOpen
@@ -1231,7 +1452,18 @@
             onSubmit={() => void submitFeedback()}
             onCancel={() => void cancelFeedback()}
             onApprove={() => void approveFeedback()}
-          />
+              />
+              {/key}
+            {:else}
+              <div
+                class="grid h-full min-h-0 place-items-center text-sm text-muted-foreground"
+                aria-busy="true"
+                aria-live="polite"
+              >
+                {tr('Loading workspace…')}
+              </div>
+            {/if}
+          </div>
         </div>
       </Pane>
     </PaneGroup>

--- a/apps/desktop/src/lib/i18n.ts
+++ b/apps/desktop/src/lib/i18n.ts
@@ -320,6 +320,8 @@ const chinese: Record<string, string> = {
   'The capture tool encountered a problem': '截图工具遇到问题',
   'Close': '关闭',
   'Workspace tabs': '工作区标签页',
+  'Close session tab': '关闭 Session 标签页',
+  'Loading workspace…': '正在加载工作区…',
   'Connecting…': '正在连接…',
   'Cannot listen for speech events: {error}': '无法监听语音识别事件：{error}',
   'Cannot listen for the capture shortcut: {error}': '无法监听截图快捷键：{error}',

--- a/apps/desktop/src/lib/i18n.ts
+++ b/apps/desktop/src/lib/i18n.ts
@@ -319,6 +319,7 @@ const chinese: Record<string, string> = {
   'Esc or right-click to cancel · The capture is inserted into the RambleDesk document flow': 'Esc 或右键取消 · 完成后自动插入 RambleDesk 文档流',
   'The capture tool encountered a problem': '截图工具遇到问题',
   'Close': '关闭',
+  'Workspace tabs': '工作区标签页',
   'Connecting…': '正在连接…',
   'Cannot listen for speech events: {error}': '无法监听语音识别事件：{error}',
   'Cannot listen for the capture shortcut: {error}': '无法监听截图快捷键：{error}',

--- a/apps/desktop/src/lib/workbench/attachmentController.test.ts
+++ b/apps/desktop/src/lib/workbench/attachmentController.test.ts
@@ -256,4 +256,59 @@ describe('attachmentController screen capture state', () => {
     )
     expect(context.applyWorkspaceMutation).not.toHaveBeenCalled()
   })
+
+  it.each(['remove', 'reorder'] as const)(
+    'does not apply a late %s result to a newly active workspace',
+    async (operation) => {
+      const attachment = {
+        attachment_id: 'att-1',
+        file_name: 'notes.txt',
+        media_type: 'text/plain',
+      }
+      const original = {
+        request: { request_id: 'request-1' },
+        attachments: [
+          attachment,
+          { attachment_id: 'att-2', file_name: 'other.txt', media_type: 'text/plain' },
+        ],
+        draft: { saved_revision: 1 },
+      }
+      const switched = {
+        request: { request_id: 'request-2' },
+        attachments: [],
+        draft: { saved_revision: 8 },
+      }
+      const result = {
+        ...original,
+        attachments: operation === 'remove' ? original.attachments.slice(1) : [...original.attachments].reverse(),
+        draft: { saved_revision: 2 },
+      }
+      let visible = original
+      let resolveOperation: ((workspace: typeof result) => void) | undefined
+      const operationResult = new Promise<typeof result>((resolve) => (resolveOperation = resolve))
+      const { context } = controllerContext()
+      context.getWorkspace = () => visible as never
+      context.getEditor = () => ({ removeAttachmentReference: vi.fn() }) as never
+      mocks.invoke.mockImplementation(async (command: string) => {
+        if (command === 'remove_feedback_attachment' || command === 'reorder_feedback_attachments') {
+          return operationResult
+        }
+        return undefined
+      })
+      const controller = createAttachmentController(context)
+
+      const pending =
+        operation === 'remove'
+          ? controller.removeAttachment(attachment as never)
+          : controller.moveAttachment(0, 1)
+      await Promise.resolve()
+      await Promise.resolve()
+      visible = switched
+      resolveOperation?.(result)
+      await pending
+
+      expect(context.applyWorkspaceMutation).not.toHaveBeenCalled()
+      expect(context.setPreviews).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/apps/desktop/src/lib/workbench/attachmentController.ts
+++ b/apps/desktop/src/lib/workbench/attachmentController.ts
@@ -353,17 +353,19 @@ export function createAttachmentController(context: AttachmentControllerContext)
   async function removeAttachment(attachment: AttachmentView) {
     const workspace = context.getWorkspace()
     if (context.getInteractionLocked() || !workspace || context.getBusy()) return
-    context.getEditor()?.removeAttachmentReference(attachment.attachment_id)
-    if (!(await context.saveDraftNow())) return
+    const requestId = workspace.request.request_id
     context.setBusy(true)
     context.setMessage('')
     try {
+      context.getEditor()?.removeAttachmentReference(attachment.attachment_id)
+      if (!(await context.saveDraftNow())) return
       const input: RemoveAttachmentInput = {
-        request_id: workspace.request.request_id,
+        request_id: requestId,
         attachment_id: attachment.attachment_id,
         expected_revision: context.getSavedRevision(),
       }
       const next = await invoke<FeedbackWorkspaceView>('remove_feedback_attachment', { input })
+      if (context.getWorkspace()?.request.request_id !== requestId) return
       context.applyWorkspaceMutation(next)
       await refreshPreviews(next)
     } catch (cause) {
@@ -390,20 +392,22 @@ export function createAttachmentController(context: AttachmentControllerContext)
   async function moveAttachment(index: number, offset: number) {
     const workspace = context.getWorkspace()
     if (context.getInteractionLocked() || !workspace || context.getBusy()) return
+    const requestId = workspace.request.request_id
     const target = index + offset
     if (target < 0 || target >= workspace.attachments.length) return
-    if (!(await context.saveDraftNow())) return
     context.setBusy(true)
     context.setMessage('')
     try {
+      if (!(await context.saveDraftNow())) return
       const attachmentIds = workspace.attachments.map((item) => item.attachment_id)
       ;[attachmentIds[index], attachmentIds[target]] = [attachmentIds[target], attachmentIds[index]]
       const input: ReorderAttachmentsInput = {
-        request_id: workspace.request.request_id,
+        request_id: requestId,
         attachment_ids: attachmentIds,
         expected_revision: context.getSavedRevision(),
       }
       const next = await invoke<FeedbackWorkspaceView>('reorder_feedback_attachments', { input })
+      if (context.getWorkspace()?.request.request_id !== requestId) return
       context.applyWorkspaceMutation(next)
       await refreshPreviews(next)
     } catch (cause) {
@@ -438,6 +442,10 @@ export function createAttachmentController(context: AttachmentControllerContext)
       } catch {
         // A missing preview must not block editing or submission.
       }
+    }
+    if (context.getWorkspace()?.request.request_id !== next.request.request_id) {
+      for (const url of Object.values(previews)) URL.revokeObjectURL(url)
+      return
     }
     context.setPreviews(previews)
   }

--- a/apps/desktop/src/lib/workbench/navigationController.test.ts
+++ b/apps/desktop/src/lib/workbench/navigationController.test.ts
@@ -61,7 +61,9 @@ function hostSession(): HostSessionSummary {
   }
 }
 
-function createController() {
+function createController(
+  overrides: Partial<Parameters<typeof createNavigationController>[0]> = {},
+) {
   return createNavigationController({
     isTauri: true,
     previewMode: false,
@@ -71,10 +73,11 @@ function createController() {
     getWorkspaceRequestId: () => undefined,
     isDirty: () => false,
     saveDraftNow: vi.fn(async () => true),
-    openRequest: vi.fn(async () => undefined),
+    openRequest: vi.fn(async () => true),
     clearWorkspace: vi.fn(),
     onPageError: vi.fn(),
     canSendOsBanners: () => false,
+    ...overrides,
   })
 }
 
@@ -199,6 +202,78 @@ describe('navigationController', () => {
           cursor: null,
         },
       })
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('returns the request snapshot for the selected session scope', async () => {
+    const selectedRequest = feedbackRequest('selected-request')
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === 'list_feedback_requests') {
+        return { requests: [selectedRequest], next_cursor: null } satisfies ListFeedbackRequestsOutput
+      }
+      return []
+    })
+
+    const controller = createController()
+    const result = await controller.selectScope('codex', 'session-1')
+
+    expect(result).toEqual({ selected: true, requests: [selectedRequest] })
+    expect(mocks.invoke).toHaveBeenCalledWith('list_feedback_requests', {
+      input: expect.objectContaining({ host_id: 'codex', host_session_id: 'session-1' }),
+    })
+  })
+
+  it('does not select a new scope when saving the current draft fails', async () => {
+    const controller = createController({
+      isDirty: () => true,
+      saveDraftNow: vi.fn(async () => false),
+    })
+    let state: NavigationState | undefined
+    const unsubscribe = controller.subscribe((next) => (state = next))
+
+    try {
+      const result = await controller.selectScope('codex', 'session-1')
+
+      expect(result.selected).toBe(false)
+      expect(state?.selectedHostId).toBeNull()
+      expect(mocks.invoke).not.toHaveBeenCalledWith('list_feedback_requests', expect.anything())
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('ignores a stale request-list response after a newer scope wins', async () => {
+    let resolveFirst: ((value: ListFeedbackRequestsOutput) => void) | undefined
+    const firstResult = new Promise<ListFeedbackRequestsOutput>((resolve) => {
+      resolveFirst = resolve
+    })
+    const secondRequest = { ...feedbackRequest('second-request'), host_session_id: 'session-2' }
+    mocks.invoke.mockImplementation(
+      async (command: string, input?: { input?: { host_session_id?: string } }) => {
+        if (command !== 'list_feedback_requests') return []
+        if (input?.input?.host_session_id === 'session-1') return firstResult
+        return { requests: [secondRequest], next_cursor: null } satisfies ListFeedbackRequestsOutput
+      },
+    )
+
+    const controller = createController()
+    let state: NavigationState | undefined
+    const unsubscribe = controller.subscribe((next) => (state = next))
+
+    try {
+      const first = controller.selectScope('codex', 'session-1')
+      await Promise.resolve()
+      const second = await controller.selectScope('codex', 'session-2')
+      resolveFirst?.({ requests: [feedbackRequest('stale-request')], next_cursor: null })
+      const stale = await first
+
+      expect(second.selected).toBe(true)
+      expect(stale.selected).toBe(false)
+      expect(state?.selectedHostSessionId).toBe('session-2')
+      expect(state?.requests).toEqual([secondRequest])
+      expect(state?.loadingRequests).toBe(false)
     } finally {
       unsubscribe()
     }

--- a/apps/desktop/src/lib/workbench/navigationController.test.ts
+++ b/apps/desktop/src/lib/workbench/navigationController.test.ts
@@ -278,4 +278,80 @@ describe('navigationController', () => {
       unsubscribe()
     }
   })
+
+  it('rolls back the prior scope and request snapshot when the target refresh fails', async () => {
+    const priorRequest = feedbackRequest('prior-request')
+    let rejectTarget = false
+    mocks.invoke.mockImplementation(
+      async (command: string, input?: { input?: { host_session_id?: string } }) => {
+        if (command !== 'list_feedback_requests') return []
+        if (rejectTarget && input?.input?.host_session_id === 'session-2') {
+          throw new Error('target refresh failed')
+        }
+        return {
+          requests: [priorRequest],
+          next_cursor: 'prior-cursor',
+        } satisfies ListFeedbackRequestsOutput
+      },
+    )
+
+    const controller = createController()
+    let state: NavigationState | undefined
+    const unsubscribe = controller.subscribe((next) => (state = next))
+
+    try {
+      await controller.selectScope('codex', 'session-1')
+      rejectTarget = true
+
+      const result = await controller.selectScope('codex', 'session-2')
+
+      expect(result.selected).toBe(false)
+      expect(state?.selectedHostId).toBe('codex')
+      expect(state?.selectedHostSessionId).toBe('session-1')
+      expect(state?.requests).toEqual([priorRequest])
+      expect(state?.nextRequestCursor).toBe('prior-cursor')
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('does not roll back a newer scope when an older target refresh fails late', async () => {
+    let rejectOlder: ((cause: Error) => void) | undefined
+    const olderRefresh = new Promise<ListFeedbackRequestsOutput>((_, reject) => {
+      rejectOlder = reject
+    })
+    const newestRequest = { ...feedbackRequest('newest-request'), host_session_id: 'session-3' }
+    mocks.invoke.mockImplementation(
+      async (command: string, input?: { input?: { host_session_id?: string } }) => {
+        if (command !== 'list_feedback_requests') return []
+        if (input?.input?.host_session_id === 'session-2') return olderRefresh
+        return {
+          requests: [newestRequest],
+          next_cursor: 'newest-cursor',
+        } satisfies ListFeedbackRequestsOutput
+      },
+    )
+
+    const onPageError = vi.fn()
+    const controller = createController({ onPageError })
+    let state: NavigationState | undefined
+    const unsubscribe = controller.subscribe((next) => (state = next))
+
+    try {
+      const older = controller.selectScope('codex', 'session-2')
+      await Promise.resolve()
+      const newest = await controller.selectScope('codex', 'session-3')
+      rejectOlder?.(new Error('older refresh failed'))
+      const stale = await older
+
+      expect(newest.selected).toBe(true)
+      expect(stale.selected).toBe(false)
+      expect(state?.selectedHostSessionId).toBe('session-3')
+      expect(state?.requests).toEqual([newestRequest])
+      expect(state?.nextRequestCursor).toBe('newest-cursor')
+      expect(onPageError).not.toHaveBeenCalled()
+    } finally {
+      unsubscribe()
+    }
+  })
 })

--- a/apps/desktop/src/lib/workbench/navigationController.ts
+++ b/apps/desktop/src/lib/workbench/navigationController.ts
@@ -287,12 +287,14 @@ export function createNavigationController(context: NavigationControllerContext)
     await new Promise((resolve) => setTimeout(resolve, remainingMs))
   }
 
-  async function refreshRequests(openFirst = false): Promise<ListFeedbackRequestsOutput | null> {
+  async function refreshRequests(
+    openFirst = false,
+  ): Promise<ListFeedbackRequestsOutput | null | undefined> {
     const generation = ++requestRefreshGeneration
     patch({ loadingRequests: true })
     try {
       const result = await loadRequestList()
-      if (generation !== requestRefreshGeneration) return null
+      if (generation !== requestRefreshGeneration) return undefined
       patch({ requests: result.requests, nextRequestCursor: result.next_cursor })
       const currentRequestId = context.getWorkspaceRequestId()
       if (openFirst && result.requests[0]) {
@@ -302,6 +304,7 @@ export function createNavigationController(context: NavigationControllerContext)
       }
       return result
     } catch (cause) {
+      if (generation !== requestRefreshGeneration) return undefined
       context.onPageError(context.messageFrom(cause))
       return null
     } finally {
@@ -338,7 +341,7 @@ export function createNavigationController(context: NavigationControllerContext)
     const generation = ++scopeSelectionGeneration
     const state = get(store)
     if (state.selectedHostId === hostId && state.selectedHostSessionId === hostSessionId) {
-      return { selected: true, requests: state.requests }
+      return { selected: !state.loadingRequests, requests: state.requests }
     }
     if (context.isDirty() && !(await context.saveDraftNow())) {
       return { selected: false, requests: state.requests }
@@ -348,13 +351,28 @@ export function createNavigationController(context: NavigationControllerContext)
     }
     patch({ selectedHostId: hostId, selectedHostSessionId: hostSessionId })
     const result = await refreshRequests(false)
-    const current = get(store)
-    const selected =
-      result !== null &&
+    let current = get(store)
+    if (
+      result === null &&
       generation === scopeSelectionGeneration &&
       current.selectedHostId === hostId &&
       current.selectedHostSessionId === hostSessionId
-    return { selected, requests: selected ? result.requests : current.requests }
+    ) {
+      patch({
+        selectedHostId: state.selectedHostId,
+        selectedHostSessionId: state.selectedHostSessionId,
+        requests: state.requests,
+        nextRequestCursor: state.nextRequestCursor,
+      })
+      current = get(store)
+    }
+    const selected =
+      result !== null &&
+      result !== undefined &&
+      generation === scopeSelectionGeneration &&
+      current.selectedHostId === hostId &&
+      current.selectedHostSessionId === hostSessionId
+    return { selected, requests: selected ? result!.requests : current.requests }
   }
 
   async function setRequestSearch(search: string) {

--- a/apps/desktop/src/lib/workbench/navigationController.ts
+++ b/apps/desktop/src/lib/workbench/navigationController.ts
@@ -46,11 +46,16 @@ type NavigationControllerContext = {
   getWorkspaceRequestId: () => string | undefined
   isDirty: () => boolean
   saveDraftNow: () => Promise<boolean>
-  openRequest: (requestId: string, saveCurrent?: boolean) => Promise<void>
+  openRequest: (requestId: string, saveCurrent?: boolean) => Promise<boolean>
   clearWorkspace: () => void
   onPageError: (message: string) => void
   canSendOsBanners: () => boolean
 }
+
+export type ScopeSelectionResult = Readonly<{
+  selected: boolean
+  requests: readonly FeedbackRequestSummary[]
+}>
 
 const initialState: NavigationState = {
   pendingRequests: [],
@@ -70,6 +75,8 @@ const initialState: NavigationState = {
 export function createNavigationController(context: NavigationControllerContext) {
   const store = writable<NavigationState>(initialState)
   const notificationTracker = new InboxNotificationTracker()
+  let requestRefreshGeneration = 0
+  let scopeSelectionGeneration = 0
 
   function patch(next: Partial<NavigationState>) {
     store.update((current) => ({ ...current, ...next }))
@@ -280,10 +287,12 @@ export function createNavigationController(context: NavigationControllerContext)
     await new Promise((resolve) => setTimeout(resolve, remainingMs))
   }
 
-  async function refreshRequests(openFirst = false) {
+  async function refreshRequests(openFirst = false): Promise<ListFeedbackRequestsOutput | null> {
+    const generation = ++requestRefreshGeneration
     patch({ loadingRequests: true })
     try {
       const result = await loadRequestList()
+      if (generation !== requestRefreshGeneration) return null
       patch({ requests: result.requests, nextRequestCursor: result.next_cursor })
       const currentRequestId = context.getWorkspaceRequestId()
       if (openFirst && result.requests[0]) {
@@ -291,10 +300,12 @@ export function createNavigationController(context: NavigationControllerContext)
       } else if (openFirst && result.requests.length === 0) {
         if (!context.isDirty() || (await context.saveDraftNow())) context.clearWorkspace()
       }
+      return result
     } catch (cause) {
       context.onPageError(context.messageFrom(cause))
+      return null
     } finally {
-      patch({ loadingRequests: false })
+      if (generation === requestRefreshGeneration) patch({ loadingRequests: false })
     }
   }
 
@@ -320,12 +331,30 @@ export function createNavigationController(context: NavigationControllerContext)
     }
   }
 
-  async function selectScope(hostId: string | null, hostSessionId: string | null) {
+  async function selectScope(
+    hostId: string | null,
+    hostSessionId: string | null,
+  ): Promise<ScopeSelectionResult> {
+    const generation = ++scopeSelectionGeneration
     const state = get(store)
-    if (state.selectedHostId === hostId && state.selectedHostSessionId === hostSessionId) return
-    if (context.isDirty() && !(await context.saveDraftNow())) return
+    if (state.selectedHostId === hostId && state.selectedHostSessionId === hostSessionId) {
+      return { selected: true, requests: state.requests }
+    }
+    if (context.isDirty() && !(await context.saveDraftNow())) {
+      return { selected: false, requests: state.requests }
+    }
+    if (generation !== scopeSelectionGeneration) {
+      return { selected: false, requests: get(store).requests }
+    }
     patch({ selectedHostId: hostId, selectedHostSessionId: hostSessionId })
-    await refreshRequests(false)
+    const result = await refreshRequests(false)
+    const current = get(store)
+    const selected =
+      result !== null &&
+      generation === scopeSelectionGeneration &&
+      current.selectedHostId === hostId &&
+      current.selectedHostSessionId === hostSessionId
+    return { selected, requests: selected ? result.requests : current.requests }
   }
 
   async function setRequestSearch(search: string) {

--- a/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
+++ b/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { tick } from 'svelte'
+  import { X } from '@lucide/svelte'
 
   import { t } from '$lib/i18n'
   import { locale } from '$lib/preferences'
@@ -8,14 +9,21 @@
     type WorkspaceViewDescriptor,
   } from './viewDescriptors'
   import {
+    requestWorkspaceTabActivation,
+    workspaceTabId,
+    workspaceTabKeyboardAction,
     workspaceTabNavigationTarget,
+    workspaceTabPanelId,
     type WorkspaceTabNavigationIntent,
   } from './workspaceTabNavigation'
 
   export let views: readonly WorkspaceViewDescriptor[] = []
   export let activeViewKey: string | null = null
+  export let pendingViewKey: string | null = null
+  export let disabled = false
   export let labelForView: (view: WorkspaceViewDescriptor) => string
   export let onActivate: (viewKey: string) => void = () => {}
+  export let onClose: (viewKey: string) => Promise<void> | void = () => {}
 
   let viewKeys: string[] = []
   let focusedViewKey: string | null = null
@@ -28,7 +36,10 @@
   }
   $: if (activeViewKey !== lastScrolledActiveViewKey) {
     lastScrolledActiveViewKey = activeViewKey
-    if (activeViewKey) void revealTab(activeViewKey, false)
+    if (activeViewKey) {
+      focusedViewKey = activeViewKey
+      void revealTab(activeViewKey, false)
+    }
   }
 
   function tr(source: string) {
@@ -60,22 +71,27 @@
   }
 
   function handleKeydown(event: KeyboardEvent, viewKey: string) {
-    if (event.key === 'ArrowLeft') {
-      event.preventDefault()
-      moveFocus('previous')
-    } else if (event.key === 'ArrowRight') {
-      event.preventDefault()
-      moveFocus('next')
-    } else if (event.key === 'Home') {
-      event.preventDefault()
-      moveFocus('first')
-    } else if (event.key === 'End') {
-      event.preventDefault()
-      moveFocus('last')
-    } else if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      onActivate(viewKey)
-    }
+    const action = workspaceTabKeyboardAction(event.key)
+    if (!action) return
+    event.preventDefault()
+    if (action.type === 'move') moveFocus(action.intent)
+    else if (action.type === 'activate') activateTab(viewKey)
+    else void closeAndFocus(viewKey)
+  }
+
+  function activateTab(viewKey: string) {
+    focusedViewKey = viewKey
+    requestWorkspaceTabActivation(viewKey, disabled || pendingViewKey !== null, onActivate)
+  }
+
+  async function closeAndFocus(viewKey: string) {
+    await onClose(viewKey)
+    await tick()
+    const nextViewKey =
+      activeViewKey && viewKeys.includes(activeViewKey) ? activeViewKey : viewKeys[0] ?? null
+    if (!nextViewKey) return
+    focusedViewKey = nextViewKey
+    await revealTab(nextViewKey, true)
   }
 </script>
 
@@ -86,29 +102,54 @@
       role="tablist"
       aria-label={tr('Workspace tabs')}
       aria-orientation="horizontal"
+      aria-busy={pendingViewKey !== null}
     >
       <div class="flex min-w-max items-end gap-1">
         {#each views as view (workspaceViewKey(view))}
           {@const viewKey = workspaceViewKey(view)}
-          <button
-            use:registerTab={viewKey}
-            type="button"
-            role="tab"
-            aria-selected={activeViewKey === viewKey}
-            tabindex={focusedViewKey === viewKey ? 0 : -1}
+          {@const label = labelForView(view)}
+          <div
+            role="presentation"
             class={[
-              'max-w-52 shrink-0 truncate rounded-t-md border border-b-0 px-3 py-1.5 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50',
+              'flex max-w-56 shrink-0 items-center rounded-t-md border border-b-0 transition-colors',
               activeViewKey === viewKey
-                ? 'bg-background font-medium text-foreground'
+                ? 'bg-background text-foreground'
                 : 'border-transparent text-muted-foreground hover:bg-background/60 hover:text-foreground',
             ]}
-            title={labelForView(view)}
-            onclick={() => onActivate(viewKey)}
-            onfocus={() => (focusedViewKey = viewKey)}
-            onkeydown={(event) => handleKeydown(event, viewKey)}
           >
-            {labelForView(view)}
-          </button>
+            <button
+              use:registerTab={viewKey}
+              type="button"
+              role="tab"
+              id={workspaceTabId(viewKey)}
+              data-workspace-view-key={viewKey}
+              data-active={activeViewKey === viewKey ? 'true' : 'false'}
+              aria-controls={workspaceTabPanelId(viewKey)}
+              aria-selected={activeViewKey === viewKey}
+              tabindex={focusedViewKey === viewKey ? 0 : -1}
+              class={[
+                'min-w-0 flex-1 truncate rounded-tl-md px-3 py-1.5 text-left text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+                activeViewKey === viewKey ? 'font-medium' : undefined,
+              ]}
+              title={label}
+              disabled={disabled || pendingViewKey !== null}
+              onclick={() => activateTab(viewKey)}
+              onkeydown={(event) => handleKeydown(event, viewKey)}
+            >
+              {label}
+            </button>
+            <button
+              type="button"
+              class="mr-1 grid size-5 shrink-0 place-items-center rounded-sm text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-40"
+              aria-label={`${tr('Close session tab')}: ${label}`}
+              title={tr('Close session tab')}
+              tabindex={activeViewKey === viewKey ? 0 : -1}
+              disabled={disabled || pendingViewKey !== null}
+              onclick={() => void closeAndFocus(viewKey)}
+            >
+              <X class="size-3" aria-hidden="true" />
+            </button>
+          </div>
         {/each}
       </div>
     </div>

--- a/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
+++ b/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { tick } from 'svelte'
+
+  import { t } from '$lib/i18n'
+  import { locale } from '$lib/preferences'
+  import {
+    workspaceViewKey,
+    type WorkspaceViewDescriptor,
+  } from './viewDescriptors'
+  import {
+    workspaceTabNavigationTarget,
+    type WorkspaceTabNavigationIntent,
+  } from './workspaceTabNavigation'
+
+  export let views: readonly WorkspaceViewDescriptor[] = []
+  export let activeViewKey: string | null = null
+  export let labelForView: (view: WorkspaceViewDescriptor) => string
+  export let onActivate: (viewKey: string) => void = () => {}
+
+  let viewKeys: string[] = []
+  let focusedViewKey: string | null = null
+  let tabButtons = new Map<string, HTMLButtonElement>()
+  let lastScrolledActiveViewKey: string | null = null
+
+  $: viewKeys = views.map(workspaceViewKey)
+  $: if (!focusedViewKey || !viewKeys.includes(focusedViewKey)) {
+    focusedViewKey = activeViewKey && viewKeys.includes(activeViewKey) ? activeViewKey : viewKeys[0] ?? null
+  }
+  $: if (activeViewKey !== lastScrolledActiveViewKey) {
+    lastScrolledActiveViewKey = activeViewKey
+    if (activeViewKey) void revealTab(activeViewKey, false)
+  }
+
+  function tr(source: string) {
+    return t($locale, source)
+  }
+
+  function registerTab(node: HTMLButtonElement, viewKey: string) {
+    tabButtons.set(viewKey, node)
+    return {
+      destroy() {
+        if (tabButtons.get(viewKey) === node) tabButtons.delete(viewKey)
+      },
+    }
+  }
+
+  async function revealTab(viewKey: string, focus: boolean) {
+    await tick()
+    const tab = tabButtons.get(viewKey)
+    if (!tab) return
+    tab.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    if (focus) tab.focus()
+  }
+
+  function moveFocus(intent: WorkspaceTabNavigationIntent) {
+    const nextViewKey = workspaceTabNavigationTarget(viewKeys, focusedViewKey, intent)
+    if (!nextViewKey) return
+    focusedViewKey = nextViewKey
+    void revealTab(nextViewKey, true)
+  }
+
+  function handleKeydown(event: KeyboardEvent, viewKey: string) {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      moveFocus('previous')
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      moveFocus('next')
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      moveFocus('first')
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      moveFocus('last')
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onActivate(viewKey)
+    }
+  }
+</script>
+
+{#if views.length > 0}
+  <div class="shrink-0 border-b bg-muted/25 px-2 pt-1.5">
+    <div
+      class="overflow-x-auto overscroll-x-contain [scrollbar-width:thin]"
+      role="tablist"
+      aria-label={tr('Workspace tabs')}
+      aria-orientation="horizontal"
+    >
+      <div class="flex min-w-max items-end gap-1">
+        {#each views as view (workspaceViewKey(view))}
+          {@const viewKey = workspaceViewKey(view)}
+          <button
+            use:registerTab={viewKey}
+            type="button"
+            role="tab"
+            aria-selected={activeViewKey === viewKey}
+            tabindex={focusedViewKey === viewKey ? 0 : -1}
+            class={[
+              'max-w-52 shrink-0 truncate rounded-t-md border border-b-0 px-3 py-1.5 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50',
+              activeViewKey === viewKey
+                ? 'bg-background font-medium text-foreground'
+                : 'border-transparent text-muted-foreground hover:bg-background/60 hover:text-foreground',
+            ]}
+            title={labelForView(view)}
+            onclick={() => onActivate(viewKey)}
+            onfocus={() => (focusedViewKey = viewKey)}
+            onkeydown={(event) => handleKeydown(event, viewKey)}
+          >
+            {labelForView(view)}
+          </button>
+        {/each}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/apps/desktop/src/lib/workspace/sessionWorkspaceTransition.test.ts
+++ b/apps/desktop/src/lib/workspace/sessionWorkspaceTransition.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { sessionViewDescriptor, workspaceViewKey } from './viewDescriptors'
+import {
+  createSessionWorkspaceTransition,
+  type SessionWorkspaceTransitionAdapter,
+  type SessionWorkspaceTransitionTarget,
+} from './sessionWorkspaceTransition'
+
+type Loaded = Readonly<{ requestId: string }>
+
+const alpha = sessionViewDescriptor('codex', 'alpha')
+const beta = sessionViewDescriptor('pi', 'beta')
+
+function target(
+  view = beta,
+  requestId: string | null = 'request-beta',
+): SessionWorkspaceTransitionTarget {
+  return {
+    view,
+    requestId,
+    shellAction: { type: 'open' },
+    pendingViewKey: workspaceViewKey(view),
+  }
+}
+
+function harness(overrides: Partial<SessionWorkspaceTransitionAdapter<Loaded>> = {}) {
+  const events: string[] = []
+  let mountedEditors = 1
+  let maximumMountedEditors = 1
+  const adapter: SessionWorkspaceTransitionAdapter<Loaded> = {
+    saveCurrent: vi.fn(async () => {
+      events.push('save')
+      return true
+    }),
+    unmountCurrent: vi.fn(() => {
+      events.push('unmount')
+      mountedEditors = 0
+    }),
+    loadTarget: vi.fn(async (next) => {
+      events.push(`load:${next.requestId}`)
+      return { requestId: next.requestId ?? '' }
+    }),
+    commitTarget: vi.fn((next) => {
+      events.push(`commit:${next.requestId}`)
+      mountedEditors += 1
+      maximumMountedEditors = Math.max(maximumMountedEditors, mountedEditors)
+    }),
+    restoreCurrent: vi.fn(() => {
+      events.push('restore')
+      mountedEditors = 1
+      maximumMountedEditors = Math.max(maximumMountedEditors, mountedEditors)
+    }),
+    setPendingTarget: vi.fn(),
+    reportFailure: vi.fn(),
+    ...overrides,
+  }
+  return {
+    adapter,
+    events,
+    maximumMountedEditors: () => maximumMountedEditors,
+    transition: createSessionWorkspaceTransition(adapter),
+  }
+}
+
+describe('sessionWorkspaceTransition', () => {
+  it('saves, unmounts, loads, and commits in order with at most one editor mounted', async () => {
+    const run = harness()
+
+    await expect(run.transition.activate(target())).resolves.toBe('activated')
+
+    expect(run.events).toEqual(['save', 'unmount', 'load:request-beta', 'commit:request-beta'])
+    expect(run.maximumMountedEditors()).toBe(1)
+  })
+
+  it('blocks before unmounting when the current draft cannot be saved', async () => {
+    const run = harness({
+      saveCurrent: vi.fn(async () => {
+        run.events.push('save')
+        return false
+      }),
+    })
+
+    await expect(run.transition.activate(target())).resolves.toBe('blocked')
+
+    expect(run.events).toEqual(['save', 'restore'])
+    expect(run.adapter.loadTarget).not.toHaveBeenCalled()
+    expect(run.adapter.commitTarget).not.toHaveBeenCalled()
+  })
+
+  it('restores the prior view when loading fails', async () => {
+    const failure = new Error('load failed')
+    const run = harness({
+      loadTarget: vi.fn(async () => {
+        run.events.push('load')
+        throw failure
+      }),
+    })
+
+    await expect(run.transition.activate(target())).resolves.toBe('failed')
+
+    expect(run.events).toEqual(['save', 'unmount', 'load', 'restore'])
+    expect(run.adapter.commitTarget).not.toHaveBeenCalled()
+    expect(run.adapter.reportFailure).toHaveBeenCalledWith(failure)
+  })
+
+  it('commits only the latest target when an older load finishes late', async () => {
+    let resolveAlpha: ((loaded: Loaded) => void) | undefined
+    const alphaLoaded = new Promise<Loaded>((resolve) => (resolveAlpha = resolve))
+    const run = harness({
+      loadTarget: vi.fn(async (next) => {
+        run.events.push(`load:${next.requestId}`)
+        return next.requestId === 'request-alpha'
+          ? alphaLoaded
+          : { requestId: next.requestId ?? '' }
+      }),
+    })
+
+    const firstTarget = target(alpha, 'request-alpha')
+    const first = run.transition.activate(firstTarget)
+    await Promise.resolve()
+    await Promise.resolve()
+    const latest = run.transition.activate(target(beta, 'request-beta'))
+    resolveAlpha?.({ requestId: 'request-alpha' })
+
+    await expect(first).resolves.toBe('stale')
+    await expect(latest).resolves.toBe('activated')
+    expect(run.adapter.commitTarget).toHaveBeenCalledTimes(1)
+    expect(run.adapter.commitTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'request-beta' }),
+      { requestId: 'request-beta' },
+    )
+    expect(run.maximumMountedEditors()).toBe(1)
+  })
+
+  it('treats an older failed save as stale when a newer intent wins', async () => {
+    let resolveOlderSave: ((saved: boolean) => void) | undefined
+    const olderSave = new Promise<boolean>((resolve) => (resolveOlderSave = resolve))
+    let saveCalls = 0
+    const run = harness({
+      saveCurrent: vi.fn(async () => {
+        run.events.push('save')
+        saveCalls += 1
+        return saveCalls === 1 ? olderSave : true
+      }),
+    })
+
+    const older = run.transition.activate(target(alpha, 'request-alpha'))
+    await Promise.resolve()
+    await Promise.resolve()
+    const newest = run.transition.activate(target(beta, 'request-beta'))
+    resolveOlderSave?.(false)
+
+    await expect(older).resolves.toBe('stale')
+    await expect(newest).resolves.toBe('activated')
+    expect(run.adapter.restoreCurrent).not.toHaveBeenCalled()
+    expect(run.adapter.commitTarget).toHaveBeenCalledTimes(1)
+    expect(run.adapter.commitTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'request-beta' }),
+      { requestId: 'request-beta' },
+    )
+  })
+
+  it('invalidates an in-flight load and restores the current editor', async () => {
+    let resolveLoad: ((loaded: Loaded) => void) | undefined
+    const loading = new Promise<Loaded>((resolve) => (resolveLoad = resolve))
+    const run = harness({ loadTarget: vi.fn(async () => loading) })
+    const activation = run.transition.activate(target())
+    await Promise.resolve()
+    await Promise.resolve()
+
+    run.transition.invalidate()
+    resolveLoad?.({ requestId: 'request-beta' })
+
+    await expect(activation).resolves.toBe('stale')
+    expect(run.adapter.commitTarget).not.toHaveBeenCalled()
+    expect(run.adapter.restoreCurrent).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the last view after saving and unmounting without loading another request', async () => {
+    const run = harness()
+    const closeLast: SessionWorkspaceTransitionTarget = {
+      view: null,
+      requestId: null,
+      shellAction: { type: 'close', viewKey: workspaceViewKey(alpha) },
+      pendingViewKey: workspaceViewKey(alpha),
+    }
+
+    await expect(run.transition.activate(closeLast)).resolves.toBe('activated')
+
+    expect(run.events).toEqual(['save', 'unmount', 'commit:null'])
+    expect(run.adapter.loadTarget).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/workspace/sessionWorkspaceTransition.ts
+++ b/apps/desktop/src/lib/workspace/sessionWorkspaceTransition.ts
@@ -1,0 +1,86 @@
+import type { SessionViewDescriptor } from './viewDescriptors'
+
+export type SessionWorkspaceShellIntent =
+  | Readonly<{ type: 'open' }>
+  | Readonly<{ type: 'close'; viewKey: string }>
+
+export type SessionWorkspaceTransitionTarget = Readonly<{
+  view: SessionViewDescriptor | null
+  requestId: string | null
+  shellAction: SessionWorkspaceShellIntent
+  pendingViewKey: string
+}>
+
+export type SessionWorkspaceTransitionOutcome =
+  | 'activated'
+  | 'blocked'
+  | 'failed'
+  | 'stale'
+
+export type SessionWorkspaceTransitionAdapter<LoadedWorkspace> = {
+  saveCurrent: () => Promise<boolean>
+  unmountCurrent: () => void
+  loadTarget: (target: SessionWorkspaceTransitionTarget) => Promise<LoadedWorkspace | null>
+  commitTarget: (
+    target: SessionWorkspaceTransitionTarget,
+    loaded: LoadedWorkspace | null,
+  ) => void
+  restoreCurrent: () => void
+  setPendingTarget: (target: SessionWorkspaceTransitionTarget | null) => void
+  reportFailure: (cause: unknown) => void
+}
+
+export function createSessionWorkspaceTransition<LoadedWorkspace>(
+  adapter: SessionWorkspaceTransitionAdapter<LoadedWorkspace>,
+) {
+  let latestIntent = 0
+  let transitionQueue: Promise<void> = Promise.resolve()
+
+  function activate(
+    target: SessionWorkspaceTransitionTarget,
+  ): Promise<SessionWorkspaceTransitionOutcome> {
+    const intent = ++latestIntent
+    adapter.setPendingTarget(target)
+
+    const result = transitionQueue.then(async (): Promise<SessionWorkspaceTransitionOutcome> => {
+      if (intent !== latestIntent) return 'stale'
+
+      try {
+        const saved = await adapter.saveCurrent()
+        if (intent !== latestIntent) return 'stale'
+        if (!saved) {
+          adapter.restoreCurrent()
+          return 'blocked'
+        }
+
+        adapter.unmountCurrent()
+        const loaded = target.requestId ? await adapter.loadTarget(target) : null
+        if (intent !== latestIntent) return 'stale'
+
+        adapter.commitTarget(target, loaded)
+        return 'activated'
+      } catch (cause) {
+        if (intent !== latestIntent) return 'stale'
+        adapter.restoreCurrent()
+        adapter.reportFailure(cause)
+        return 'failed'
+      } finally {
+        if (intent === latestIntent) adapter.setPendingTarget(null)
+      }
+    })
+
+    transitionQueue = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    return result
+  }
+
+  function invalidate() {
+    latestIntent += 1
+    adapter.restoreCurrent()
+    adapter.setPendingTarget(null)
+  }
+
+  return { activate, invalidate }
+}

--- a/apps/desktop/src/lib/workspace/workspaceTabNavigation.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceTabNavigation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { workspaceTabNavigationTarget } from './workspaceTabNavigation'
+
+describe('workspaceTabNavigationTarget', () => {
+  const keys = [
+    'session:["codex","alpha"]',
+    'session:["codex","beta"]',
+    'session:["pi","alpha"]',
+  ]
+
+  it('moves to adjacent tabs and wraps at both ends', () => {
+    expect(workspaceTabNavigationTarget(keys, keys[0], 'next')).toBe(keys[1])
+    expect(workspaceTabNavigationTarget(keys, keys[2], 'next')).toBe(keys[0])
+    expect(workspaceTabNavigationTarget(keys, keys[2], 'previous')).toBe(keys[1])
+    expect(workspaceTabNavigationTarget(keys, keys[0], 'previous')).toBe(keys[2])
+  })
+
+  it('moves directly to the first or last tab', () => {
+    expect(workspaceTabNavigationTarget(keys, keys[1], 'first')).toBe(keys[0])
+    expect(workspaceTabNavigationTarget(keys, keys[1], 'last')).toBe(keys[2])
+  })
+
+  it('uses a deterministic edge when focus is absent or stale', () => {
+    expect(workspaceTabNavigationTarget(keys, null, 'next')).toBe(keys[0])
+    expect(workspaceTabNavigationTarget(keys, 'session:missing', 'previous')).toBe(keys[2])
+  })
+
+  it('handles empty and single-tab workspaces', () => {
+    expect(workspaceTabNavigationTarget([], null, 'next')).toBeNull()
+    expect(workspaceTabNavigationTarget([keys[0]], keys[0], 'next')).toBe(keys[0])
+    expect(workspaceTabNavigationTarget([keys[0]], keys[0], 'previous')).toBe(keys[0])
+  })
+})

--- a/apps/desktop/src/lib/workspace/workspaceTabNavigation.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceTabNavigation.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { workspaceTabNavigationTarget } from './workspaceTabNavigation'
+import {
+  requestWorkspaceTabActivation,
+  workspaceTabId,
+  workspaceTabKeyboardAction,
+  workspaceTabNavigationTarget,
+  workspaceTabPanelId,
+} from './workspaceTabNavigation'
 
 describe('workspaceTabNavigationTarget', () => {
   const keys = [
@@ -30,5 +36,34 @@ describe('workspaceTabNavigationTarget', () => {
     expect(workspaceTabNavigationTarget([], null, 'next')).toBeNull()
     expect(workspaceTabNavigationTarget([keys[0]], keys[0], 'next')).toBe(keys[0])
     expect(workspaceTabNavigationTarget([keys[0]], keys[0], 'previous')).toBe(keys[0])
+  })
+
+  it('maps keyboard input to focus, activation, and close actions', () => {
+    expect(workspaceTabKeyboardAction('ArrowLeft')).toEqual({ type: 'move', intent: 'previous' })
+    expect(workspaceTabKeyboardAction('Home')).toEqual({ type: 'move', intent: 'first' })
+    expect(workspaceTabKeyboardAction('Enter')).toEqual({ type: 'activate' })
+    expect(workspaceTabKeyboardAction(' ')).toEqual({ type: 'activate' })
+    expect(workspaceTabKeyboardAction('Delete')).toEqual({ type: 'close' })
+    expect(workspaceTabKeyboardAction('Escape')).toBeNull()
+  })
+
+  it('derives stable and distinct tab and panel ids from the composite view key', () => {
+    expect(workspaceTabId(keys[0])).toBe(
+      'workspace-tab-session%3A%5B%22codex%22%2C%22alpha%22%5D',
+    )
+    expect(workspaceTabPanelId(keys[0])).toBe(
+      'workspace-tabpanel-session%3A%5B%22codex%22%2C%22alpha%22%5D',
+    )
+    expect(workspaceTabId(keys[0])).not.toBe(workspaceTabId(keys[2]))
+    expect(workspaceTabId(keys[0])).not.toBe(workspaceTabPanelId(keys[0]))
+  })
+
+  it('uses the same explicit activation contract for pointer click and keyboard activation', () => {
+    const activations: string[] = []
+    const activate = (viewKey: string) => activations.push(viewKey)
+
+    expect(requestWorkspaceTabActivation(keys[1], false, activate)).toBe(true)
+    expect(requestWorkspaceTabActivation(keys[2], true, activate)).toBe(false)
+    expect(activations).toEqual([keys[1]])
   })
 })

--- a/apps/desktop/src/lib/workspace/workspaceTabNavigation.ts
+++ b/apps/desktop/src/lib/workspace/workspaceTabNavigation.ts
@@ -1,5 +1,38 @@
 export type WorkspaceTabNavigationIntent = 'first' | 'last' | 'next' | 'previous'
 
+export type WorkspaceTabKeyboardAction =
+  | Readonly<{ type: 'activate' }>
+  | Readonly<{ type: 'close' }>
+  | Readonly<{ type: 'move'; intent: WorkspaceTabNavigationIntent }>
+
+export function workspaceTabId(viewKey: string): string {
+  return `workspace-tab-${encodeURIComponent(viewKey)}`
+}
+
+export function workspaceTabPanelId(viewKey: string): string {
+  return `workspace-tabpanel-${encodeURIComponent(viewKey)}`
+}
+
+export function workspaceTabKeyboardAction(key: string): WorkspaceTabKeyboardAction | null {
+  if (key === 'ArrowLeft') return { type: 'move', intent: 'previous' }
+  if (key === 'ArrowRight') return { type: 'move', intent: 'next' }
+  if (key === 'Home') return { type: 'move', intent: 'first' }
+  if (key === 'End') return { type: 'move', intent: 'last' }
+  if (key === 'Enter' || key === ' ') return { type: 'activate' }
+  if (key === 'Delete') return { type: 'close' }
+  return null
+}
+
+export function requestWorkspaceTabActivation(
+  viewKey: string,
+  blocked: boolean,
+  activate: (viewKey: string) => void,
+): boolean {
+  if (blocked) return false
+  activate(viewKey)
+  return true
+}
+
 export function workspaceTabNavigationTarget(
   viewKeys: readonly string[],
   currentViewKey: string | null,

--- a/apps/desktop/src/lib/workspace/workspaceTabNavigation.ts
+++ b/apps/desktop/src/lib/workspace/workspaceTabNavigation.ts
@@ -1,0 +1,19 @@
+export type WorkspaceTabNavigationIntent = 'first' | 'last' | 'next' | 'previous'
+
+export function workspaceTabNavigationTarget(
+  viewKeys: readonly string[],
+  currentViewKey: string | null,
+  intent: WorkspaceTabNavigationIntent,
+): string | null {
+  if (viewKeys.length === 0) return null
+  if (intent === 'first') return viewKeys[0]
+  if (intent === 'last') return viewKeys[viewKeys.length - 1]
+
+  const currentIndex = currentViewKey ? viewKeys.indexOf(currentViewKey) : -1
+  if (currentIndex === -1) {
+    return intent === 'previous' ? viewKeys[viewKeys.length - 1] : viewKeys[0]
+  }
+
+  const offset = intent === 'next' ? 1 : -1
+  return viewKeys[(currentIndex + offset + viewKeys.length) % viewKeys.length]
+}


### PR DESCRIPTION
## Summary
- add a single-row Session tab strip with stable identity, horizontal overflow, roving keyboard focus, activation, Delete close, and tab/tabpanel accessibility wiring
- open or focus Session views from the existing flat rail while preserving All Requests and Host-only filtering
- coordinate every active Session transition through save → unmount → load → atomic commit, with latest-wins generation checks and rollback on save/load/scope failure
- keep exactly one SessionWorkbench/editor mounted; closing a tab does not archive a Session, cancel feedback, or stop background Ramble work
- isolate late attachment results and lock transitions during request-local attachment, capture, Cooking, and cooked-preview operations

## Commit structure
1. `Add tab strip with keyboard navigation and overflow`
2. `Open and focus sessions from the sidebar`
3. `Preserve the single-editor save-unmount-load contract`

## Validation
- 42 Vitest files / 201 tests passed
- `pnpm -C apps/desktop check` (0 errors, 0 warnings)
- `pnpm -C apps/desktop build:web`
- debug macOS `.app` bundle built successfully
- `git diff --check main...HEAD`
- browser fixture: initial Session tab, rail opens a second Session, Enter switches, Delete closes, active tab id matches tabpanel label, one Workbench and at most one editor
- Standards and Spec re-reviews: no blocking findings

## Manual acceptance still requested
- native mouse click/close and narrow-window overflow
- dirty Draft switch/save failure
- active/inactive close while a background Ramble continues

The in-app browser automation surface focused role=tab controls without dispatching their click handler; keyboard and rail paths passed. Source review found a single standard `onclick` path with no overlay or duplicate handler, so native pointer acceptance remains explicit rather than overstated.