### PR TITLE
Define the Workbench transport and Web Access architecture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,45 +1,121 @@
 # RambleDesk 架构基线
 
-> 状态：v2 当前基线。
+> 状态：v3 当前与目标边界。
 > 术语源：[TERMINOLOGY.md](TERMINOLOGY.md)。本文若与术语表冲突，以术语表为准。
 
-本文描述 RambleDesk 当前应遵循的结构边界。
+本文同时记录已经存在的结构与后续 Web 工作必须遵守的目标边界：
+
+- **CURRENT** 表示仓库当前已经实现并可验证的事实；
+- **TARGET** 表示已接受但尚未完成的演进边界，不得在产品文案中冒充已有能力。
+
+Backend Runtime 是运行角色，不是新 crate 的名字。除非另有标记，package 章节描述 CURRENT；
+TARGET 不预设新 crate、Web app 目录或 headless composition root。
 
 ## 运行时拓扑
 
+### CURRENT
+
 ```text
-┌────────────────────┐     MCP transport      ┌──────────────────────────────┐
-│ Generic MCP hosts  │ ─────────────────────→ │ RambleDesk local server      │
-│ Claude/Codex/...   │     /mcp               │                              │
-└────────────────────┘                         │  auth / listener / guards    │
-                                               │  route mounting              │
-┌────────────────────┐     Local JSON API      │                              │
-│ Pi package         │ ─────────────────────→ │  /api/feedback/*             │
-│ packages/pi-*      │     /api               │                              │
-└────────────────────┘                         └──────────────┬───────────────┘
-                                                              │
-┌────────────────────┐     Tauri commands/events              │
-│ Workbench UI       │ ←──────────────────────────────────────┘
-└────────────────────┘
-                                                              │
-                                                              ▼
-                                      ┌──────────────────────────────┐
-                                      │ rambledesk-core              │
-                                      │ application contracts         │
-                                      └──────────────┬───────────────┘
-                                                     │
-                                                     ▼
-                                      ┌──────────────────────────────┐
-                                      │ rambledesk-storage           │
-                                      │ SQLite + feedback packages   │
-                                      └──────────────────────────────┘
+┌────────────────────┐   MCP / Local JSON API   ┌──────────────────────────┐
+│ Host Adapters      │ ───────────────────────→ │ Local Integration Server │
+│ Generic MCP / Pi   │                          │ one /api + /mcp listener │
+└────────────────────┘                          └────────────┬─────────────┘
+                                                           │ application calls
+                                                           ▼
+┌────────────────────┐   Tauri Application      ┌──────────────────────────┐
+│ Desktop Client     │ ─ Transport Impl. ─────→ │ Backend Runtime          │
+└────────────────────┘                          │ core + storage + config  │
+                                                └──────────────────────────┘
+
+┌────────────────────┐
+│ Desktop Shell      │ ─── Native Capability Implementation
+└────────────────────┘      (outside Application Transport)
 ```
 
-`apps/desktop` 是装配根：它装配 storage、core application、本地服务、host knowledge、desktop-only capabilities。CLI 和测试可以复用同一套 crate，但不能成为第二套业务实现。
+`apps/desktop` 是 CURRENT composition root。每个 desktop 进程创建一份
+`FeedbackApplication`，由 Tauri state 与该进程的 Local Integration Server 共同调用；这不表示
+跨进程全局单例。当前只有一个承载 `/api` 与 `/mcp` 的 loopback listener，没有 Web 静态资源
+或 WebSocket route。MCP SSE 属于 MCP transport，不是 Web Client 的事件流。
+
+### TARGET
+
+```text
+┌────────────────────┐                          ┌──────────────────────────┐
+│ Host Adapters      │ → Local Integration ──→ │                          │
+└────────────────────┘   Server                 │                          │
+                                                │ Backend Runtime          │
+┌────────────────────┐   Tauri Application      │ same application Module  │
+│ Desktop Client     │ ─ Transport Impl. ─────→ │ and business facts       │
+└────────────────────┘                          │                          │
+                                                │                          │
+┌────────────────────┐   Web Access HTTP + WS   │                          │
+│ future Web Client  │ ─ Transport Impl. ─────→ │                          │
+└────────────────────┘                          └──────────────────────────┘
+
+Desktop Shell ─── Native Capability Implementation ───┐
+                                                      ├─ outside Application Transport
+Web browser  ─── Browser Capability Implementation ───┘
+```
+
+Desktop Client 与 future Web Client 复用同一 Workbench Client 和 Application Transport
+Interface。Tauri 与 HTTP + WebSocket 是两个 Implementation，但调用同一 Backend Runtime
+application Module；Web 路径不得形成第二套业务实现。
+
+Local Integration Server 与 Web Access 必须复用 server Module 内同一套 security policy/primitives，
+但拥有独立 listener handle、route set、credential、auth domain 和启停生命周期。单一安全策略
+实现不等于共享 listener。Web Access 默认关闭；停止它不得停止 Backend Runtime 或 Local
+Integration Server。
+
+## Application Transport 与恢复合同
+
+Application Transport Interface 暴露 typed command/query、变化订阅、ready barrier 和
+capability manifest。Capability manifest 只报告能力是否可用；设备操作不通过 Transport 执行。
+
+TARGET Web Transport 遵循：
+
+1. Backend Runtime 每次启动生成一个 opaque、进程生命周期内不变且跨启动唯一的
+   `runtime_generation`；
+2. WebSocket `ready` frame 携带该 generation。Client 只接受当前 connection epoch 的 ready，并
+   原子替换 active generation、清空旧投影、取消或标记旧 in-flight HTTP request 为 stale；
+3. HTTP snapshot/query 返回 Backend Runtime 当前事实的可丢弃投影，不成为第二事实源；每份
+   snapshot 携带 generation 和相关 resource revision；
+4. WebSocket 只传递 readiness 与轻量 invalidation，不承载 canonical Request/Draft/Package；
+   invalidation 携带同一 generation 下可比较的 resource key/revision；
+5. 客户端确认 ready 并建立 active generation 后，才允许发出会产生事件或修改状态的 command，
+   避免首次订阅窗口丢事件。typed command envelope 携带 `expected_runtime_generation`，Web HTTP
+   Implementation 映射为 `X-RambleDesk-Runtime-Generation`；Web session record 也绑定签发时的
+   generation。服务端在任何领域副作用前原子比较 session、command 与当前 generation，任一不匹配
+   都返回 HTTP `409` / typed `stale_generation`；Client 重新 bootstrap、连接并 refetch。resource
+   revision/CAS 不能替代该 runtime generation 检查；
+6. Client 只应用与 active ready generation 一致、且 revision 不低于已应用投影的 response；来自
+   旧 socket、旧 connection epoch 或旧 generation 的 frame/response 一律丢弃；
+7. fetch 期间若收到更高 revision 的 invalidation，当前 fetch 完成后必须再次 refetch；
+8. WebSocket 断线后先重新建立并确认 ready，再 refetch 完整 snapshot；
+9. 首期不实现 sequence replay、ring buffer 或 multiplex protocol。
+
+CURRENT Tauri commands/events 仍是 Desktop Client 的具体 Implementation。现有 MCP SSE 不能
+复用为上述 WebSocket invalidation/readiness contract。
+
+## Capability 边界
+
+Native Capability 与 Browser Capability 都位于 Application Transport 之外。共享 Workbench
+Client 只能根据 capability manifest 呈现可用操作：
+
+- Native Capability 可以提供全局快捷键、系统截图、原生录音、tray、updater 和 native dialog；
+- Browser Capability 受 secure context、浏览器权限、用户手势和当前设备限制；
+- Browser file picker 选择客户端文件，不代表 Backend Runtime 所在机器的 working directory；
+- 缺失或降级的 Browser Capability 必须明确不可用，不能伪装成 Native Capability 等价实现。
 
 ## Feedback Draft 所有权
 
-工作台最多只有一个可编辑 `RichFeedbackEditor`。当前 request 通过 Editor transaction 写入；后台 Active Ramble 通过 TipTap JSON transformation、单一串行队列和 CAS 写入。数据库以版本化 `document_json` 为真源，保存时从同一 Document 同时生成 `body_markdown`。详见 [ADR 004](adr/004-single-editor-structured-draft.md)。
+每个 Workbench Client instance 最多只有一个可编辑 `RichFeedbackEditor`。当前 request 通过 Editor
+transaction 写入；后台 Active Ramble 通过 TipTap JSON transformation、单一串行队列和
+CAS 写入。数据库以版本化 `document_json` 为真源，保存时从同一 Document 同时生成
+`body_markdown`。多个客户端并发编辑时，Backend Runtime 的 Draft revision/CAS 负责仲裁；
+冲突必须显式反馈给人类，不得静默覆盖。详见
+[ADR 004](adr/004-single-editor-structured-draft.md)。ADR 005 将 ADR 004 的“整个应用”作用域修订为
+“每个 Workbench Client instance”；同一 Draft 可以在多个客户端打开，但只能通过 Backend Runtime
+revision/CAS 协调，不能共享 Editor handle 或 client-local 文档状态。
 
 禁止 per-request Editor、hidden Editor、session 持有 editor handle，以及自动 Tidy。
 
@@ -54,7 +130,7 @@ rambledesk/
 ├── crates/
 │   ├── rambledesk-core/          # application contract
 │   ├── rambledesk-storage/       # SQLite + feedback package publication
-│   ├── rambledesk-local-server/  # loopback HTTP server + JSON API
+│   ├── rambledesk-local-server/  # CURRENT Local Integration Server
 │   ├── rambledesk-mcp/           # Generic MCP Adapter (tool surface + installer engine)
 │   ├── rambledesk-hosts/         # Host knowledge registry + profiles + continuation strategy
 │   ├── rambledesk-speech/
@@ -77,7 +153,7 @@ rambledesk/
 不得持有：
 
 - HTTP、JSON、MCP、Pi package、Tauri command；
-- 本地服务 listener、token path、Host/Origin guard；
+- Local Integration Server listener、token path、Host/Origin guard；
 - 宿主安装逻辑、host profile、continuation strategy；
 - 源码 checkout 模型或路径依赖。
 
@@ -98,7 +174,7 @@ rambledesk/
 - 源码 checkout runtime 语义；
 - UI 或 transport 细节。
 
-### `rambledesk-local-server`
+### `rambledesk-local-server`（CURRENT）
 
 持有：
 
@@ -108,6 +184,10 @@ rambledesk/
 - `/api/feedback/request|get|wait|cancel`；
 - `/mcp` route mounting；
 - server handle、endpoint、port configuration。
+
+TARGET Web Access 必须复用该 crate/server Module 的 security policy/primitives；本架构不据此要求
+新 crate，也不允许它复用 Local Integration Server 的 listener handle、credential、auth domain、
+route set 或启停生命周期。
 
 不得持有：
 
@@ -164,23 +244,46 @@ rambledesk/
 - desktop UI 状态；
 - RambleDesk storage 逻辑。
 
-### Desktop
+### Desktop（CURRENT）
 
-Tauri 壳负责：
+Desktop Shell 负责：
 
 - 进程、窗口、tray、系统通知、文件选择、权限提示；
-- 装配 storage、core、本地服务、hosts；
+- 每进程装配一份 Backend Runtime、Local Integration Server 与 hosts；
 - 暴露 Tauri commands；
 - 桥接领域结果为前端事件。
 
-Svelte UI 负责：
+Desktop Client 中的 Svelte Workbench Client 负责：
 
 - 工作台投影；
 - 人类反馈输入；
 - 草稿、截图、录音、附件交互；
 - 设置中的适配器安装 UX。
 
-UI 不持有唯一事实状态。Tauri events 和系统通知都是提示，不是事实来源。
+Workbench Client 不持有唯一业务事实。Tauri events 和系统通知都是提示，不是事实来源。
+TARGET Web Client 复用该 UI，但不复用 Desktop Shell 或 Native Capability Implementation。
+
+### Workbench Client 生命周期
+
+- 关闭 workspace Tab、关闭或刷新浏览器、Transport 断线，都只结束对应 Client 的 view / projection；
+- 上述行为不得隐式 submit、cancel、archive Request，也不得停止后台 Active Ramble 或未来 Agent /
+  Session Runtime；
+- submit、cancel、archive 与停止 runtime 必须是可审计的显式 application command；
+- Client 应持续 autosave canonical Draft 变更。关闭 workspace view 仍执行既有 save gate；浏览器
+  `unload` 不可靠，因此不能把唯一一次保存或任何终态 mutation 放在 `unload` handler 中；
+- 重连或重新打开 view 时，从 Backend Runtime 重新读取 Request、Draft revision 与运行状态。
+
+### Audio Source 与 Speech Engine
+
+Audio Source 是 device Capability，speech recognition 是 Backend Runtime 使用的 Speech Engine：
+
+- Desktop 的 Native Audio Source 可以把本机音频流直接交给既有 Speech Engine；
+- Browser Audio Source 通过浏览器权限和用户手势取得媒体，首期把 MediaRecorder Blob 或有界分段
+  经 authenticated HTTP 上传到 server-side recognition session；
+- Desktop 与 Web 必须投影同一 SpeechEvent contract，断线、停止、权限拒绝或设备丢失都要显式
+  终结 recognition session；
+- 只有实时 partial transcript 成为明确验收需求时，才新增独立 binary WebSocket；不得复用首期
+  invalidation WebSocket 传 PCM。
 
 ## 事实来源
 
@@ -193,9 +296,13 @@ UI 不持有唯一事实状态。Tauri events 和系统通知都是提示，不�
 | 宿主身份 | adapter-provided `host_id`，服务端可按安装入口覆盖 |
 | 宿主会话关联 | adapter-provided `host_session_id` |
 | 上下文提示 | request `context_refs` / `source_hint` |
-| UI 当前页面/展开项 | 前端内存 |
+| Session tabs、顺序、active view、pane 尺寸 | 每个 Workbench Client 的 client-local workspace snapshot |
 | 系统通知 | best-effort side effect |
 | 局部转写 | speech session 内存；定期 checkpoint 到 Draft |
+
+HTTP snapshot、Tauri query result 和 WebSocket invalidation 都是上述事实的投影或提示，不是
+额外事实源。终态提交、取消等 application operation 必须幂等；CAS 冲突必须保留可见错误，
+不得由任一 Transport Implementation 自动覆盖。
 
 ## 核心流程
 
@@ -206,7 +313,7 @@ MCP request_feedback
   → rambledesk-mcp 映射工具输入
   → rambledesk-core request_feedback
   → rambledesk-storage 持久化请求
-  → 本地服务返回 waiting 结果
+  → Local Integration Server 返回 waiting 结果
   → 宿主智能体结束当前 turn
   → 人类在工作台提交/取消
   → 手动 continuation 提示
@@ -237,7 +344,7 @@ SubmitFeedback(request_id, expected_revision)
   → render package into temp directory
   → flush + hash
   → atomic publish
-  → mark request completed
+  → persist terminal request state + package metadata
   → notify waiters / prepare continuation prompt
 ```
 
@@ -272,9 +379,58 @@ waiting → in_progress → completed
 
 ## 安全边界
 
-- 本地服务只监听 loopback。
-- 所有 `/api` 和 `/mcp` 请求必须通过 bearer token。
-- Host header 必须是 loopback host。
-- Origin 只允许受信任 desktop/webview origin 或空 origin 的本地工具调用。
-- `host_id`、`host_session_id` 不是认证凭据。
-- 返回路径只保证同机、共享文件系统可见。
+### CURRENT：Local Integration Server
+
+- 每个 desktop 进程当前只有一个 `/api` + `/mcp` listener，且只绑定 loopback。
+- Local Integration Server 使用持久的 256-bit hex bearer token，并以 constant-time comparison
+  校验所有 `/api` 与 `/mcp` 请求。
+- token 文件在 Unix 上使用 `0600`；非 Unix 平台当前没有文档化的等价 ACL 保证，因此该凭据
+  不得直接复用为 Web credential。
+- Host 只接受 `127.0.0.1` 或 `localhost`；Origin 缺失时只作为本地非浏览器客户端调用放行，
+  Origin 存在时必须 exact-match allowlist。
+- 当前统一 request body limit 为 96 MiB。
+- 当前 listener 不提供 Web 静态资源或 WebSocket。MCP SSE 不属于 Web event stream。
+- Draft revision/CAS 已存在于 application/storage 路径，但 HTTP command/query parity 尚未实现。
+- `host_id`、`host_session_id` 不是认证凭据；返回路径只保证同机、共享文件系统可见。
+
+### TARGET：Web Access
+
+- Web Access 默认关闭，第一阶段使用独立 listener 且只绑定 `127.0.0.1`；它拥有与 Local
+  Integration Server 分离的 route set、credential、auth domain 和 lifecycle。
+- 静态资源、HTTP API 与 WebSocket 使用 same-origin 且不开放宽泛 CORS。两类 listener 必须复用
+  同一套 security policy/primitives。所有请求严格校验
+  Host；bootstrap、受保护 API 与 WebSocket handshake 还必须 exact-match Origin，以防 DNS
+  rebinding；共享安全实现不表示共享 listener 或 credential。
+- Desktop composition root 装配的 Web Access security Module 在人类显式启用或重新生成 Web
+  credential 时创建并持久化独立的 256-bit durable token；Backend Runtime/core 不拥有 transport
+  credential。只有 Desktop 设置界面可以经人类操作显示或复制 durable token。
+- durable token 优先进入 OS credential store（macOS Keychain、Windows Credential Manager、
+  可用时的 Linux Secret Service），并在平台支持时使用 device-local / non-sync 属性。仅允许回退到
+  通用配置和 RambleDesk backup/export roots 之外的专用 secret file：Unix mode `0600`，Windows
+  使用仅当前用户可读的 DACL，并在平台支持时设置 backup exclusion；无法建立或验证 user-only
+  protection 时 Web Access 必须 fail closed。RambleDesk 不得把 token 复制到通用配置、SQLite、
+  日志、诊断包、自己生成的 backup/export 或 Feedback Package；OS 管理的加密设备/账户备份属于
+  平台安全边界，不宣称应用能够绝对排除。
+- 浏览器以 `Authorization: Bearer <durable-web-token>` 调用 same-origin
+  `POST /api/auth/session` 完成 bootstrap；成功后得到 scope 受限、idle TTL 30 分钟、absolute TTL
+  12 小时的 session token。任一受保护请求或已认证 WebSocket 活动可以刷新 idle TTL，但不能延长
+  absolute TTL。停止 Web Access 必须撤销所有 session；重新生成 durable token 必须同时撤销旧
+  token 与全部 session。
+- session token 只存在 Web Access 进程内存与浏览器当前 JavaScript 内存；durable/session token
+  都不得进入 `sessionStorage`、`localStorage`、IndexedDB、URL、日志或 Feedback Package。刷新或
+  关闭页面后必须重新 bootstrap。服务端比较
+  credential 时使用 constant-time comparison，并对认证 header 和错误上下文做日志脱敏。
+- 浏览器 HTTP 请求使用 `Authorization: Bearer <session-token>`。
+- 浏览器 WebSocket 通过 `Sec-WebSocket-Protocol` 同时提供稳定协议 `rambledesk-events` 与
+  credential-bearing protocol `rambledesk-session.<base64url-no-pad-session-token>`，禁止 query
+  token。服务端校验二者后只选择并回显 `rambledesk-events`，不得把 credential-bearing protocol
+  回显给客户端、代理日志或诊断输出。
+- Web routes 分别设置 body、upload、rate 与 concurrent-connection 上限；不得直接继承当前
+  96 MiB 的统一 body limit 作为完整 Web 资源策略。
+- sensitive command 必须单独分类、授权与审计；Application Transport 可达不等于拥有所有
+  Native Capability 或管理权限。
+- LAN Web Access 延后；启用前必须使用 HTTPS/WSS 或受信任 TLS proxy，并重新审计 origin、
+  credential delivery、设备暴露与文件访问边界。
+
+以上目标决策记录于
+[ADR 005](adr/005-shared-workbench-transport-capabilities.md)。

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -1,6 +1,6 @@
 # RambleDesk 术语表
 
-> 状态：v2 当前基线。
+> 状态：v3 当前基线。
 > 目标：固定产品语言、协议字段和 package 边界。代码、文档、UI 文案、测试命名若与本文冲突，以本文为准。
 
 本文是 RambleDesk 的唯一术语源。其他文档只引用本文，不重新定义产品对象。
@@ -8,13 +8,15 @@
 ## 架构公理
 
 1. RambleDesk 是本地 human-feedback workbench，不是智能体运行时，不内置 shell multiplexer，也不持有源码 checkout 模型。
-2. 核心事实只有两类：反馈请求和反馈包。
+2. 反馈请求和反馈包构成核心闭环；请求、Feedback Draft、反馈包、配置以及未来的 Session Runtime / Timeline 等业务事实只由 Backend Runtime 持有。
 3. 宿主通过适配器接入 RambleDesk；适配器是完整宿主流程，不是图标、label 或单个命令。
-4. `core` 只持有 application contract，不持有 HTTP、JSON、MCP、Pi、本地服务、desktop command 或宿主安装逻辑。
-5. 本地服务是 transport 边界，独立于 `core` 和 `mcp`。
-6. MCP 是通用 MCP 适配器的一种 transport，不是全局基础设施。
-7. 提交后的 continuation 不是适配器。适配器可以选择“不需要 continuation”“手动 continuation”或“原生 continuation”。
-8. RambleDesk 不要求源码 checkout 路径。路径最多是适配器提供的可选 context hint。
+4. `core` 只持有 application contract，不持有 HTTP、JSON、MCP、Pi、Local Integration Server、Web Access、desktop command 或宿主安装逻辑。
+5. Workbench Client 通过 Application Transport Interface 访问 Backend Runtime；Transport 与设备 Capability 是两个独立边界。
+6. Local Integration Server 与 Web Access 必须复用一套安全 policy/primitives，但拥有显式分离的 listener、credential、auth domain、启停生命周期和 route set。
+7. Workbench Client 的 workspace snapshot（view、顺序、active view、pane 尺寸）是 client-local 状态，不是 Backend Runtime 业务事实，也不得缓存 Feedback Draft 正文。
+8. MCP 是通用 MCP 适配器的一种 transport，不是全局基础设施。
+9. 提交后的 continuation 不是适配器。适配器可以选择“不需要 continuation”“手动 continuation”或“原生 continuation”。
+10. RambleDesk 不要求源码 checkout 路径。路径最多是适配器提供的可选 context hint。
 
 ## 核心闭环
 
@@ -31,8 +33,19 @@
 | 人类 | 使用 RambleDesk 产生真实反馈的人。 | 拥有产品判断；不拥有协议状态。 |
 | 智能体 | 发起反馈请求并读取反馈包继续工作的 LLM coding actor。 | 拥有任务推理；不拥有 RambleDesk 持久状态。 |
 | 宿主 | 智能体运行所在的 runtime/container，例如 Pi、Claude Code、Codex、OpenCode。 | 拥有自己的 session、tool、plugin API；不定义 RambleDesk 存储合同。 |
-| 工作台 | RambleDesk 桌面 UI。 | 拥有人类反馈工作流；不实现宿主协议。 |
-| 本地服务 | 桌面进程内的 authenticated loopback server。 | 拥有 auth、listener、JSON API、route mounting 和 guard；不拥有领域语义。 |
+| 工作台 | RambleDesk 的人类反馈工作界面；同一套工作台可以由不同 Workbench Client 呈现。 | 拥有人类反馈工作流；不实现宿主协议，不限定为桌面窗口。 |
+| Workbench Client（工作台客户端） | 承载共享工作台 UI 的客户端角色；当前由 `apps/desktop` 中的 Svelte UI 实现，目标是由 Desktop Client 与 Web Client 复用。 | 只持有 UI 投影和 client-local workspace snapshot；不拥有 Request、Feedback Draft 或 Package 的 canonical 事实。 |
+| Desktop Client（桌面客户端） | 在 Desktop Shell 内运行的 Workbench Client，通过 Tauri IPC 的 Application Transport Implementation 访问 Backend Runtime。 | 是当前已实现的客户端；不把 Tauri API 暴露为共享 UI 的业务合同。 |
+| Web Client（Web 客户端） | 在浏览器中运行的 Workbench Client，通过 Web Access 的 HTTP + WebSocket Application Transport Implementation 访问 Backend Runtime。 | 是目标客户端，当前尚未实现；不得被文档或 UI 描述成已有能力。 |
+| Backend Runtime（后端运行时） | 长期持有 application use cases、storage、配置以及未来 Session Runtime / Timeline 的 Rust 运行角色。 | 是业务事实唯一来源；当前由 desktop composition root 组装，不等同于 HTTP listener，也不预设一个新 crate。 |
+| Application Transport（应用传输） | Workbench Client 调用 application command/query、订阅变化、等待 ready 并读取 capability manifest 的 Interface。 | Tauri IPC 与未来 HTTP + WebSocket 是不同 Implementation，但必须调用同一 Backend Runtime application Module；`capabilities` 只报告可用性，不执行设备能力。 |
+| Local Integration Server（本地集成服务） | 为 Generic MCP、Pi 等 Host Adapter 提供 authenticated loopback listener、JSON API、route mounting 和 guard 的 transport Module。 | 服务宿主集成，不拥有领域语义；其启停和 route set 独立于 Web Access。 |
+| Web Access（Web 访问） | 可选、默认关闭的浏览器访问能力，目标是向 Web Client 提供静态资源、HTTP 和 WebSocket；第一阶段只监听 `127.0.0.1`。 | 当前尚未实现；关闭 Web Access 不得停止 Backend Runtime 或 Local Integration Server，开放 LAN 需要单独的安全决策。 |
+| Desktop Shell（桌面壳层） | Tauri 进程、窗口、托盘、更新器、原生权限和 desktop composition root。 | 组装 Desktop Client、Backend Runtime 与本地能力；不拥有 UI 业务事实。 |
+| Native Capability（原生能力） | 由 Desktop Shell 提供的 OS / device Implementation，例如全局快捷键、系统截图、原生录音、托盘、更新器和原生对话框。 | 独立于 Application Transport；可访问的设备和权限范围不能被 Web Client 假定。 |
+| Browser Capability（浏览器能力） | 由浏览器 API 提供的 device-scoped Implementation，例如受权限和用户手势约束的媒体、剪贴板、文件选择、下载和通知。 | 独立于 Application Transport；受 secure context、浏览器、权限与当前设备限制，不等价于 Native Capability，也不代表服务器文件系统。 |
+| Audio Source（音频源） | 由 Native Capability 或 Browser Capability 提供的音频输入 Interface/Implementation；可以是本机流，也可以是浏览器上传的 Blob 或有界分段。 | 只负责采集、编码与传输，不执行语音识别，不拥有 Feedback Draft。 |
+| Speech Engine（语音识别引擎） | Backend Runtime 使用的识别能力，消费 Audio Source 输入并产生统一 SpeechEvent。 | 与设备采集分离；Desktop 与 Web 不得各自形成不同的识别语义。 |
 | 反馈请求 | 由适配器创建、由人类处理的持久单位，用 `request_id` 标识。 | RambleDesk 的核心输入事实。 |
 | 反馈包 | 请求进入终态后发布的不可变证据，包含 manifest、markdown、附件路径和 hash。 | RambleDesk 的核心输出事实；宿主继续前必须读取。 |
 | 适配器 | 面向一类宿主的完整接入流程：创建请求、读取反馈、处理 continuation。 | 可以由多个 package 或 transport 组成。 |
@@ -139,15 +152,28 @@ Pi 原生适配器不需要提交后的 continuation，因为 Pi 已经在工具
 
 ## Package 边界
 
+下表描述当前代码位置；架构角色不等于新 package 规划。特别是 Backend Runtime 是当前由 desktop composition root 组装的运行角色，Web Client 与 Web Access 仍是目标能力，本文不据此虚构新 crate。
+
+| 架构角色 | 当前映射 | 目标边界 |
+| --- | --- | --- |
+| Backend Runtime | 由 `apps/desktop` composition root 组装 `core`、storage、配置和运行时 controller。 | 保持单一 application Module 和业务事实来源；是否重排 crate 留给后续实现决策。 |
+| Workbench Client | `apps/desktop` 中的 Svelte 工作台 UI。 | Desktop Client 与 Web Client 复用同一 UI 和 Application Transport Interface。 |
+| Desktop Client / Desktop Shell | `apps/desktop`。 | Shell 只保留 desktop composition 与 Native Capability；共享 UI 不依赖 Tauri 细节。 |
+| Tauri Application Transport Implementation | `apps/desktop` 的 Tauri command/event wiring。 | 实现统一 Application Transport Interface，调用同一 Backend Runtime application Module。 |
+| Local Integration Server | `crates/rambledesk-local-server`。 | 继续服务 Host Adapter；不因 Web Access 启停而停止；与 Web Access 共享同一安全 policy/primitives。 |
+| Web Client / HTTP + WebSocket Application Transport Implementation / Web Access | 尚未实现。 | 后续实现必须复用 Backend Runtime 与安全 policy/primitives，并与 Local Integration Server 分离 listener、credential、auth domain、生命周期和 route set；本文不指定新目录或 crate。 |
+| Native Capability Implementation | `apps/desktop` 及 desktop-only crates。 | 与 Application Transport 分离并通过 capability manifest 暴露可用性。 |
+| Browser Capability Implementation | 尚未实现。 | 只承诺浏览器实际允许的能力，不模拟原生或服务器文件系统语义。 |
+
 | Package / 区域 | 职责 | 不应包含 |
 | --- | --- | --- |
-| `crates/rambledesk-core` | 领域 DTO、application use cases、反馈请求/反馈包合同。 | HTTP、JSON、MCP、Pi、desktop commands、host install、local server。 |
+| `crates/rambledesk-core` | 领域 DTO、application use cases、反馈请求/反馈包合同。 | HTTP、JSON、MCP、Pi、desktop commands、host install、Local Integration Server、Web Access。 |
 | `crates/rambledesk-storage` | SQLite 持久化、请求/草稿/附件 metadata、宿主会话关联、反馈包发布。 | 宿主协议、适配器安装、源码 checkout runtime 语义。 |
-| `crates/rambledesk-local-server` | loopback listener、auth token、Host/Origin guard、本地 JSON API、route mounting。 | 领域规则、MCP tool schema、Pi package 代码。 |
+| `crates/rambledesk-local-server` | 当前实现 Local Integration Server：loopback listener、auth token、Host/Origin guard、本地 JSON API、route mounting。 | 领域规则、MCP tool schema、Pi package 代码；不得因未来复用 router Module 而把 Web Access 与 Local Integration Server 的生命周期合并。 |
 | `crates/rambledesk-mcp` | Generic MCP Adapter 完整方案：MCP schema、tool handler、instructions、结果/错误映射、客户端检测/安装执行引擎。 | listener、token path、JSON API、host-specific continuation、per-host 知识。 |
 | `crates/rambledesk-hosts` | 宿主知识注册表（executable/marker/配置路径/ConfigFormat）、Host profile、展示元数据、默认适配器选择、continuation strategy。 | MCP implementation、Pi package、适配器安装/写入执行逻辑。 |
 | `packages/pi-rambledesk` | Pi 原生适配器 package。 | MCP client 行为、desktop UI 状态、storage 逻辑。 |
-| `apps/desktop` | 工作台 UI、Tauri composition root、本地 command wiring、适配器安装 UX。 | 领域存储语义、host package 内部实现、唯一事实状态。 |
+| `apps/desktop` | 当前实现 Workbench Client、Desktop Client、Desktop Shell、Tauri Application Transport Implementation、composition root 和适配器安装 UX。 | 领域存储语义、host package 内部实现；共享 Workbench Client 不应直接依赖 Tauri 或 Native Capability 细节。 |
 
 目标 Cargo 依赖方向：
 
@@ -159,7 +185,7 @@ Pi 原生适配器不需要提交后的 continuation，因为 Pi 已经在工具
 | `rambledesk-local-server` | `rambledesk-core`、`rambledesk-mcp`。 |
 | `rambledesk-hosts` | `rambledesk-core`；宿主知识注册表与续接策略共用其类型。 |
 | `apps/desktop` | `rambledesk-core`、`rambledesk-storage`、`rambledesk-local-server`、`rambledesk-hosts`、`rambledesk-mcp`、desktop-only crates。 |
-| `packages/pi-rambledesk` | 不参与 Cargo workspace；运行时调用本地服务 `/api`。 |
+| `packages/pi-rambledesk` | 不参与 Cargo workspace；运行时调用 Local Integration Server `/api`。 |
 
 ## Host Profile
 
@@ -198,17 +224,32 @@ UI 文案允许：
 - “Pi 原生适配器”
 - “检测到的 Coding 工具”
 - “手动继续”
+- “桌面客户端”与“Web 客户端”
+- “Web 访问”
 
 UI 文案避免：
 
 - 将 transport 可用性提升为产品全局状态。
 - 在 titlebar 或 sidebar 放全局 transport 指示器。
 - 用 “Adapter” 指代宿主图标或宿主 label。
+- 用 “Adapter / 适配器”指代 Application Transport 或 Native / Browser Capability；它们分别称为 Interface 与 Implementation。
+- 把 Backend Runtime 称为“Web Server”，或用“关闭 Web”暗示停止 Backend Runtime / Local Integration Server。
+- 把 Browser Capability 描述成 Native Capability 的等价实现，或把浏览器文件选择描述成服务器工作目录选择。
+
+代码与架构文档命名：
+
+- `Adapter / 适配器` 只用于完整 host-facing 集成，例如 Generic MCP Adapter 与 Pi Native Adapter。
+- Workbench Client 的应用访问 seam 称为 `Application Transport Interface`；Tauri IPC、HTTP + WebSocket 称为其 `Implementation`。
+- OS / device seam 称为 `Native Capability` 或 `Browser Capability`；具体实现称为 `Capability Implementation`，不称为 Adapter。
+- `Web Access` 只表示可独立启停的浏览器访问 feature，不表示 Backend Runtime。
 
 ## 合并标准
 
 - “适配器”只有一个产品含义：完整 host-facing 集成流程。
-- `core` 不包含 JSON、HTTP、MCP、Pi、本地服务或 desktop command 逻辑。
+- `core` 不包含 JSON、HTTP、MCP、Pi、Local Integration Server、Web Access 或 desktop command 逻辑。
+- Backend Runtime 是唯一业务事实来源；Workbench Client 只保存 client-local workspace snapshot，不缓存 canonical Feedback Draft。
+- Application Transport 与 Native / Browser Capability 保持独立，Transport Implementation 不执行设备能力。
+- Local Integration Server 与 Web Access 必须复用同一安全 policy/primitives，同时分离 listener、credential、auth domain、启停生命周期和 route set。
 - 本地 JSON API 位于 `rambledesk-local-server`。
 - MCP 是薄适配层，不持有 listener、token path 或 JSON API。
 - `rambledesk-hosts` 只持有 host profile 和 strategy 选择，不实现完整适配器。

--- a/docs/adr/005-shared-workbench-transport-capabilities.md
+++ b/docs/adr/005-shared-workbench-transport-capabilities.md
@@ -1,0 +1,218 @@
+# ADR 005：共享 Workbench Client 的 Transport、Capability 与 Web 安全边界
+
+- 状态：Accepted
+- 日期：2026-09-01
+- 术语源：[TERMINOLOGY.md](../TERMINOLOGY.md)
+
+## Context
+
+本文使用的 Workbench Client、Backend Runtime、Application Transport、Capability、Local
+Integration Server 与 Web Access 均以唯一术语源为准；这里只记录它们之间的决策和后果。
+
+RambleDesk 当前只有 Desktop Client。Svelte 工作台直接通过 Tauri commands/events 调用由
+desktop composition root 装配的 application；同一进程还启动一个供 Generic MCP 与 Pi Host
+Adapter 使用的 Local Integration Server。为了支持 future Web Client，不能复制业务实现、把
+Desktop 强制改走 HTTP，或把浏览器能力伪装成原生能力。
+
+Transport、设备 Capability 和 listener 生命周期若没有独立边界，会产生以下风险：
+
+- Tauri 与 HTTP 各自形成业务规则和事实状态；
+- Web Access 的启停意外停止 Host Adapter 或 Backend Runtime；
+- 持久的本地集成 token 暴露给浏览器、URL、日志或持久 Web storage；
+- WebSocket 事件被误当成事实源，断线后无法可靠恢复；
+- Browser Capability 被错误描述为 global shortcut、系统截图或服务器文件系统能力。
+
+## Decision
+
+### 1. 一个 Backend Runtime，多种 Workbench Client
+
+Backend Runtime 是 Request、Feedback Draft、Package、配置以及未来 Session Runtime / Timeline
+的唯一业务事实来源。Desktop Client 和 future Web Client 复用同一 Workbench Client，并通过
+同一个 Application Transport Interface 调用同一 application Module。
+
+Backend Runtime 是运行角色，不要求新增同名 crate。当前每个 desktop 进程只装配一份
+`FeedbackApplication` 给 Tauri state 与该进程的 Local Integration Server 使用；本决策不把它
+提升为跨进程全局单例，也不决定 headless composition root。
+
+### 2. Application Transport 是 Interface，Tauri 与 HTTP + WebSocket 是 Implementation
+
+Application Transport Interface 提供 typed command/query、变化订阅、ready barrier 与
+capability manifest。Tauri IPC 是 Desktop Implementation；Web Access 的 HTTP + WebSocket 是
+future Web Implementation。两者只做 DTO、错误和传输映射，不实现领域规则。
+
+Backend Runtime 每次启动生成一个 opaque、进程生命周期内不变且跨启动唯一的
+`runtime_generation`。WebSocket `ready` frame 携带该 generation；Client 只接受当前 local
+connection epoch 的 ready，并原子替换 active generation、清空旧投影、取消或标记旧 in-flight
+HTTP request 为 stale。确认 ready 并建立 active generation 后，才可发出会产生事件或修改状态的
+command。typed command envelope 携带 `expected_runtime_generation`，Web HTTP Implementation
+映射为 `X-RambleDesk-Runtime-Generation`；Web session record 也绑定签发时的 generation。服务端
+在任何领域副作用前原子比较 session、command 与当前 generation，任一不匹配都返回 HTTP `409` /
+typed `stale_generation`。Client 随后重新 bootstrap、连接并 refetch；resource revision/CAS 不能
+替代 runtime generation 检查。
+
+HTTP snapshot/query 是 Backend Runtime 事实的可丢弃投影，每份 snapshot 携带 generation 与相关
+resource revision。WebSocket 只承载 readiness 与 invalidation，invalidation 携带同一 generation
+下可比较的 resource key/revision。Client 只应用与 active ready generation 一致、且 revision 不低于
+已应用投影的 response；来自旧 socket、旧 connection epoch 或旧 generation 的 frame/response
+一律丢弃。fetch 期间收到更高 revision invalidation 时，当前 fetch 完成后必须再次 refetch。断线
+或 stale-generation 后重新建立订阅、确认 ready，再 refetch 完整 snapshot。
+
+首期不实现 sequence replay、ring buffer 或 multiplex protocol。MCP SSE 继续属于 MCP
+transport，不复用为 Web Client event stream。
+
+### 3. Capability 位于 Transport 之外
+
+Native Capability 与 Browser Capability 使用独立 Interface/Implementation。Application
+Transport 的 capability manifest 只报告可用性，不执行设备操作。
+
+- Desktop Shell 可以提供全局快捷键、系统截图、原生录音、tray、updater 与 native dialog；
+- 浏览器只能提供其 secure context、权限、用户手势和当前设备允许的能力；
+- browser file picker 不代表 Backend Runtime 所在机器的 working directory；
+- Workbench Client 必须呈现 capability unavailable/degraded，不能伪造桌面等价性。
+
+`Adapter / 适配器` 继续只表示完整 host-facing integration。Application Transport 与 Capability
+均称为 Interface/Implementation，不称为 Adapter。
+
+### 4. 服务端事实与 client-local 状态分离
+
+Request、Feedback Draft、Package 和 application configuration 属于 Backend Runtime。view
+descriptor、tab 顺序、active view 与 pane 尺寸属于每个 Workbench Client 的 client-local
+workspace snapshot；snapshot 不缓存 canonical Draft 正文。
+
+每个 Workbench Client instance 最多挂载一个可编辑 `RichFeedbackEditor`，继续禁止 per-request 与 hidden
+Editor。多个客户端并发写 Draft 时使用 Backend Runtime revision/CAS，冲突必须显式显示而不是
+last-write-wins。submit/cancel 等终态 operation 必须幂等。
+
+关闭 workspace Tab、关闭或刷新浏览器、Transport 断线都只结束 Client view/projection；这些
+动作不得隐式 submit、cancel、archive Request，也不得停止后台 Active Ramble 或未来 Agent /
+Session Runtime。终态与 runtime lifecycle 只能由可审计的显式 application command 改变。
+Client 应持续 autosave；关闭 workspace view 继续使用 save gate，但不得依赖不可靠的 browser
+`unload` 完成唯一一次保存或终态 mutation。重连/重开后从 Backend Runtime refetch 事实。
+
+### 5. Audio Source 与 Speech Engine 分离
+
+Audio Source 是 Native / Browser Capability，Speech Engine 是 Backend Runtime 使用的识别能力。
+Desktop Native Audio Source 可以直接把本机音频流交给既有 Speech Engine；Browser Audio Source
+通过浏览器权限和用户手势取得媒体，首期使用 authenticated HTTP 上传 MediaRecorder Blob 或
+有界分段到 server-side recognition session。两端投影同一 SpeechEvent contract；断线、停止、
+权限拒绝与设备丢失必须显式终结 recognition session。只有实时 partial transcript 成为明确需求
+时才新增独立 binary WebSocket，不复用 invalidation WebSocket 传输 PCM。
+
+### 6. Local Integration Server 与 Web Access 独立
+
+Local Integration Server 服务 Host Adapter；Web Access 服务浏览器。它们必须复用 server Module
+内同一套 security policy/primitives，但拥有独立 listener handle、route set、credential、auth
+domain 和启停 lifecycle。关闭 Web Access 不得停止 Backend Runtime 或 Local Integration Server。
+
+Web Access 默认关闭，第一阶段只绑定 `127.0.0.1`。本决策不指定新 crate、Web app 目录或
+headless composition root。
+
+### 7. Web Access 使用 bootstrap 后的短期 session credential
+
+Web Access 使用与 Local Integration Server 不同的 credential：
+
+1. Desktop composition root 装配的 Web Access security Module 在人类显式启用或重新生成
+   credential 时创建并持久化独立的 256-bit durable Web token；Backend Runtime/core 不拥有
+   transport credential；只有 Desktop 设置界面可经人类操作显示或复制它；
+2. durable token 优先存入 OS credential store（macOS Keychain、Windows Credential Manager、
+   可用时的 Linux Secret Service），并在平台支持时使用 device-local / non-sync 属性。仅允许回退
+   到通用配置和 RambleDesk backup/export roots 之外的专用 secret file：Unix mode `0600`，
+   Windows 使用仅当前用户可读的 DACL，并在平台支持时设置 backup exclusion；无法建立或验证
+   user-only protection 时 Web Access 必须 fail closed。RambleDesk 不得把 token 复制到通用配置、
+   SQLite、日志、诊断包、自己生成的 backup/export 或 Feedback Package；OS 管理的加密设备/账户
+   备份属于平台安全边界，不宣称应用能够绝对排除；
+3. 浏览器以 `Authorization: Bearer <durable-web-token>` 调用 same-origin
+   `POST /api/auth/session`；成功后签发 scope 受限、idle TTL 30 分钟、absolute TTL 12 小时的
+   session token；任一受保护请求或已认证 WebSocket 活动可以刷新 idle TTL，但不能延长 absolute
+   TTL；
+4. session token 只存在 Web Access 进程内存与浏览器当前 JavaScript 内存；页面刷新或关闭后必须
+   重新 bootstrap；
+5. durable/session token 禁止进入 `sessionStorage`、`localStorage`、IndexedDB、URL、日志或
+   Feedback Package；
+6. 停止 Web Access 必须撤销全部 session；重新生成 durable token 必须撤销旧 durable token 与
+   全部 session；
+7. HTTP 使用 `Authorization: Bearer <session-token>`，服务端使用 constant-time comparison 并
+   对认证 header 与错误上下文做日志脱敏；
+8. WebSocket 通过 `Sec-WebSocket-Protocol` 同时 offer `rambledesk-events` 与
+   `rambledesk-session.<base64url-no-pad-session-token>`，禁止 query token；
+9. 服务端校验两个 protocol 后只选择并回显 `rambledesk-events`，不得回显 credential-bearing
+   protocol，也不得把它写入代理日志或诊断输出。
+
+静态资源、HTTP API 与 WebSocket 使用 same-origin，不开放宽泛 CORS。所有请求严格校验 Host；
+bootstrap、受保护 API 与 WebSocket handshake 还必须 exact-match Origin，以防 DNS rebinding。
+Web routes 分别设置 body、upload、rate 与 concurrent-connection 上限。敏感 command 单独分类、
+授权与审计。
+
+## Current vs Target
+
+### Current
+
+- `apps/desktop` 是 composition root；每个 desktop 进程装配一份 `FeedbackApplication`。
+- Desktop Client 使用 Tauri commands/events；Desktop Shell 提供 Native Capability。
+- 一个 loopback listener 同时承载 `/api` 与 `/mcp`，不提供 Web static/WS route。
+- Local Integration Server 使用持久 256-bit hex bearer token，并 constant-time compare。
+- token 文件在 Unix 为 `0600`；非 Unix 当前没有等价 ACL 保证。
+- Host 只接受 `127.0.0.1` 或 `localhost`；Origin 缺失供本地非浏览器客户端，存在时 exact
+  allowlist；统一 body limit 为 96 MiB。
+- Draft CAS 已存在，但 HTTP application command/query parity 尚未实现。
+
+### Target
+
+- future Web Client 复用 Workbench Client 与 Backend Runtime。
+- Web Access 提供 HTTP snapshot/commands 与 WebSocket readiness/invalidation。
+- Web Access 默认关闭、独立监听 `127.0.0.1`，使用独立 Web credential 与 auth domain。
+- Native/Browser Capability 均在 Application Transport 外，通过 manifest 呈现差异。
+
+## Rejected
+
+- **让 Desktop Client 也通过 HTTP：** 增加本地 listener 依赖和序列化成本，不能替代 Tauri
+  对 desktop lifecycle 的直接组合。
+- **为 Web Client 建第二套后端或领域实现：** 会产生事实、状态机和安全规则漂移。
+- **把 Capability 调用并入 Application Transport：** 会让共享 UI 把浏览器权限误认为后端或
+  desktop 能力。
+- **让 Web Access 复用 Local Integration Server 的 listener/credential/auth domain：** 无法
+  独立关闭 Web，也会把持久本地集成 credential 暴露给浏览器。
+- **WebSocket 发送完整 canonical state 或依赖 replay：** 增加协议复杂度，并让事件流变成脆弱的
+  第二事实源。
+- **在 URL query 传 token：** credential 会泄漏到历史、日志、代理和错误报告。
+- **把 Browser Capability 描述为 Native Capability 等价实现：** 与浏览器权限和设备边界不符。
+
+## Deferred
+
+- LAN Web Access；启用前必须采用 HTTPS/WSS 或受信任 TLS proxy，并重新安全审计；
+- headless Backend Runtime / composition root；
+- Web app 最终目录、新 crate 或 deployment packaging；
+- credential revocation UI 与浏览器重新认证恢复流程；
+- sequence replay、ring buffer、multiplex protocol；
+- 实时二进制音频 WebSocket；
+- ACP、Router 或全局 client state framework。
+
+## Consequences
+
+正向：
+
+- Desktop/Web 共享 UI 与业务合同，不产生第二 Backend Runtime 实现；
+- listener、credential、auth domain 和 capability 权限均可独立审计；
+- WebSocket 断线后可从 Backend Runtime snapshot 恢复；
+- 浏览器功能可以诚实降级，不污染原生实现。
+
+代价：
+
+- 需要实现 Application Transport Interface、HTTP parity、ready/refetch 协议和 Web credential
+  bootstrap/session lifecycle；
+- 多客户端会暴露真实 CAS 冲突，UI 必须提供恢复而非静默重试；
+- Desktop 与 Web 需要分别验收设备权限和安全策略。
+
+## 与 ADR 001–004 的兼容性
+
+- **ADR 001：** 保持 `core`、storage、transport 与 composition root 分离；Backend Runtime 是运行
+  角色，不创建隐含新 crate，也不把领域规则或 transport credential 放入 core。两个 listener
+  必须复用同一套 security policy/primitives，延续“本地安全策略只有一处实现”，但分离 credential、
+  auth domain 与 lifecycle。
+- **ADR 002：** 保留 `cpal` / speech crate 的 Native Capability 实现；未来浏览器音频只能通过
+  Browser Capability 接入，不改写现有 speech/application contract。
+- **ADR 003：** Ramble 仍是统一采集状态，但 Web Client 必须按 capability manifest 显示缺失或
+  降级的全局快捷键、系统截图和剪贴板能力。
+- **ADR 004：** 本 ADR 修订其“整个应用最多一个 Editor”的所有权作用域为“每个 Workbench Client
+  instance 最多一个 Editor”。canonical Draft 仍在 Backend Runtime/SQLite；跨客户端并发只由
+  revision/CAS 仲裁，不共享 Editor handle、不引入 hidden Editor。


### PR DESCRIPTION
## Summary
- establish Workbench Client, Backend Runtime, Application Transport, Web Access, Capability, Audio Source, and Speech Engine terminology
- record current versus target runtime topology without inventing a new crate or claiming Web Access exists
- accept ADR 005 for shared client transport, snapshot/invalidation recovery, client lifecycle, multi-client CAS, and browser audio boundaries
- define independent Web Access lifecycle and a concrete loopback credential, bootstrap, WebSocket, generation, and at-rest security model

## Commit boundaries
1. Terminology only
2. Architecture and ADR 005 only

## Verification
- pnpm check:terminology
- git diff --check
- parallel Standards and Spec reviews with no findings