### PR TITLE
Add authenticated HTTP application transport parity

### DIFF
--- a/apps/desktop/src-tauri/tests/application_transport_parity.rs
+++ b/apps/desktop/src-tauri/tests/application_transport_parity.rs
@@ -208,6 +208,16 @@ async fn tauri_facade_and_http_implementation_have_equivalent_contract_outcomes(
     let server = start_http(commands.clone()).await?;
     let client = reqwest::Client::new();
 
+    let direct_profiles = commands.list_host_profiles();
+    let http_profiles = client
+        .post(server.url("listHostProfiles"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<serde_json::Value>()
+        .await?;
+    assert_eq!(serde_json::to_value(direct_profiles)?, http_profiles);
+
     let direct_workspace = commands
         .get_feedback_workspace(GetFeedbackInput {
             request_id: REQUEST_ID.into(),

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -29,6 +29,7 @@
   import type { ApplicationTransport } from './lib/application/applicationTransport'
 
   export let applicationTransport: ApplicationTransport
+  export let previewMode = false
 
   import type {
     ApproveFeedbackInput,
@@ -124,6 +125,7 @@
     type AttachmentMessageTone,
   } from './lib/workbench/attachmentController'
   import { createNavigationController } from './lib/workbench/navigationController'
+  import { ensureDesktopNavigationPolling } from './lib/workbench/navigationPolling'
   import { resolvedRamblePhase } from './lib/workbench/rambleSessionState'
   import type {
     FeedbackEditorHandle,
@@ -231,10 +233,6 @@
   let workbenchInitialized = false
   const isTauri = '__TAURI_INTERNALS__' in window
   const isMac = currentDesktopPlatform() === 'macOS'
-  const previewMode =
-    import.meta.env.DEV &&
-    !isTauri &&
-    new URLSearchParams(window.location.search).get('preview') === 'fixtures'
   const previewWorkspaceScenario = previewMode
     ? seedPreviewWorkspaceScenario(
         new URLSearchParams(window.location.search).get('workspace'),
@@ -400,7 +398,7 @@
   const sessionViewRecoveryResolver = createSessionViewRecoveryResolver({
     loadArchived: async () => {
       const sessions =
-        previewMode || !isTauri
+        previewMode
           ? previewWorkspaceScenario === 'unknown'
             ? await Promise.reject(new Error('Preview archived catalog unavailable'))
             : previewFixtures.archivedHostSessions
@@ -730,12 +728,18 @@
   function startWorkbench() {
     if (workbenchInitialized) return
     workbenchInitialized = true
+    inboxTimer = ensureDesktopNavigationPolling(
+      isTauri,
+      inboxTimer,
+      setInterval,
+      () => void navigation.refreshNavigation(true),
+    )
     void (async () => {
-      await navigation.initialize(initialWorkspaceSnapshot === null)
+      const initialized = await navigation.initialize(initialWorkspaceSnapshot === null)
+      if (!initialized) return
       await refreshSessionViewRecovery()
       if (initialWorkspaceSnapshot) await restoreInitialWorkspaceSnapshot()
     })()
-    if (isTauri) inboxTimer = setInterval(() => void navigation.refreshNavigation(true), 5_000)
   }
 
   function closeOnboarding() {
@@ -1940,7 +1944,6 @@
 
 <ArchivedSessionsDialog
   bind:open={archivedSessionsOpen}
-  {isTauri}
   transport={applicationTransport}
   {previewMode}
   {resolveHostProfile}

--- a/apps/desktop/src/lib/application/applicationTransportConformance.ts
+++ b/apps/desktop/src/lib/application/applicationTransportConformance.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { defineApplicationStream, type ApplicationTransport } from './applicationTransport'
+import type {
+  ApplicationCommandInput,
+  ApplicationCommandName,
+  ApplicationCommandResult,
+} from './contracts'
+
+export const APPLICATION_CONFORMANCE_INPUTS = {
+  listFeedbackInbox: undefined,
+  listHostSessions: undefined,
+  listArchivedHostSessions: { search: null },
+  listHostProfiles: undefined,
+  listFeedbackRequests: {
+    host_id: null,
+    host_session_id: null,
+    status: null,
+    archived: null,
+    search: null,
+    limit: null,
+    cursor: null,
+  },
+  getFeedbackWorkspace: { request_id: 'request-1' },
+  readPublishedFeedback: { request_id: 'request-1' },
+  saveFeedbackDraft: {
+    request_id: 'request-1',
+    document_json: '{}',
+    body_markdown: 'draft',
+    expected_revision: 1,
+  },
+  addFeedbackAttachment: {
+    request_id: 'request-1',
+    file_name: 'note.txt',
+    contents: new Uint8Array([1, 2, 3]).buffer,
+    expected_revision: 1,
+  },
+  removeFeedbackAttachment: {
+    request_id: 'request-1',
+    attachment_id: 'attachment-1',
+    expected_revision: 1,
+  },
+  reorderFeedbackAttachments: {
+    request_id: 'request-1',
+    attachment_ids: ['attachment-1'],
+    expected_revision: 1,
+  },
+  submitFeedback: { request_id: 'request-1', expected_revision: 1 },
+  approveFeedbackRequest: { request_id: 'request-1' },
+  cancelFeedbackRequest: { request_id: 'request-1', reason: 'cancelled' },
+  renameHostSession: {
+    host_id: 'codex',
+    host_session_id: 'session-1',
+    title: 'Renamed',
+  },
+  setHostSessionPinned: {
+    host_id: 'codex',
+    host_session_id: 'session-1',
+    pinned: true,
+  },
+  archiveHostSession: { host_id: 'codex', host_session_id: 'session-1' },
+  unarchiveHostSession: { host_id: 'codex', host_session_id: 'session-1' },
+  deleteHostSession: { host_id: 'codex', host_session_id: 'session-1' },
+  deleteFeedbackRequest: { request_id: 'request-1' },
+  setHostPinned: { host_id: 'codex', pinned: true },
+  readFeedbackAttachment: { request_id: 'request-1', attachment_id: 'attachment-1' },
+  readRequestAttachment: { request_id: 'request-1', attachment_id: 'attachment-1' },
+} satisfies { [Name in ApplicationCommandName]: ApplicationCommandInput<Name> }
+
+export const APPLICATION_COMMAND_NAMES = Object.freeze(
+  Object.keys(APPLICATION_CONFORMANCE_INPUTS) as ApplicationCommandName[],
+)
+
+const SAFE_TERMINAL_PROJECTION = Object.freeze({
+  request_id: 'request-1',
+  status: 'completed',
+  feedback: { available: true },
+})
+
+export function applicationConformanceResult<Name extends ApplicationCommandName>(
+  name: Name,
+): ApplicationCommandResult<Name> {
+  let result: unknown
+  if (name === 'readFeedbackAttachment' || name === 'readRequestAttachment') {
+    result = new Uint8Array([4, 5, 6]).buffer
+  } else if (name === 'deleteHostSession' || name === 'deleteFeedbackRequest') {
+    result = undefined
+  } else if (
+    name === 'listFeedbackInbox' ||
+    name === 'listHostSessions' ||
+    name === 'listArchivedHostSessions' ||
+    name === 'listHostProfiles'
+  ) {
+    result = []
+  } else if (name === 'submitFeedback') {
+    result = SAFE_TERMINAL_PROJECTION
+  } else {
+    result = { operation: name }
+  }
+  return result as ApplicationCommandResult<Name>
+}
+
+export type ApplicationTransportConformanceFixture = Readonly<{
+  transport: ApplicationTransport
+  expectWireCall: <Name extends ApplicationCommandName>(
+    index: number,
+    name: Name,
+    input: ApplicationCommandInput<Name>,
+  ) => void | Promise<void>
+  rejectNext: (error: unknown) => void
+}>
+
+function assertNoServerStorageLocations(value: unknown): void {
+  const serialized = JSON.stringify(value)
+  for (const forbidden of [
+    'directory_path',
+    'markdown_path',
+    'manifest_path',
+    'package_uri',
+    'file://',
+  ]) {
+    expect(serialized).not.toContain(forbidden)
+  }
+}
+
+export function runApplicationTransportConformance(
+  implementationName: string,
+  createFixture: () => ApplicationTransportConformanceFixture,
+): void {
+  describe(`${implementationName} ApplicationTransport conformance`, () => {
+    it('maps all 23 query mutation multipart binary and void operations', async () => {
+      const fixture = createFixture()
+      expect(APPLICATION_COMMAND_NAMES).toHaveLength(23)
+
+      for (const [index, name] of APPLICATION_COMMAND_NAMES.entries()) {
+        const input = APPLICATION_CONFORMANCE_INPUTS[name]
+        const result = await fixture.transport.call(name, input)
+        expect(result).toEqual(applicationConformanceResult(name))
+        await fixture.expectWireCall(index, name, input)
+      }
+    })
+
+    it('preserves typed CAS errors and safe terminal projections', async () => {
+      const fixture = createFixture()
+      const conflict = {
+        code: 'DRAFT_CONFLICT',
+        message: 'draft revision changed',
+        retryable: false,
+      } as const
+      fixture.rejectNext(conflict)
+      await expect(
+        fixture.transport.call('saveFeedbackDraft', APPLICATION_CONFORMANCE_INPUTS.saveFeedbackDraft),
+      ).rejects.toEqual(conflict)
+
+      const terminal = await fixture.transport.call(
+        'submitFeedback',
+        APPLICATION_CONFORMANCE_INPUTS.submitFeedback,
+      )
+      expect(terminal).toEqual(SAFE_TERMINAL_PROJECTION)
+      assertNoServerStorageLocations(terminal)
+    })
+
+    it('provides readiness and a synchronous idempotent unsubscribe', async () => {
+      const fixture = createFixture()
+      await expect(fixture.transport.waitUntilReady()).resolves.toBeUndefined()
+      const unsubscribe = fixture.transport.subscribe(
+        defineApplicationStream('conformance:unavailable'),
+        vi.fn(),
+        vi.fn(),
+      )
+      expect(unsubscribe).toEqual(expect.any(Function))
+      expect(() => {
+        unsubscribe()
+        unsubscribe()
+      }).not.toThrow()
+      await Promise.resolve()
+    })
+  })
+}

--- a/apps/desktop/src/lib/application/contracts.test.ts
+++ b/apps/desktop/src/lib/application/contracts.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
   isApplicationError,
   isApplicationErrorCode,
+  type ApplicationAddAttachmentInput,
   type ApplicationCommandInput,
   type ApplicationCommandName,
   type ApplicationCommandResult,
@@ -54,6 +55,10 @@ describe('application command contracts', () => {
     type HasStoragePaths = 'attachment_paths' extends keyof FeedbackPackageView ? true : false
     expectTypeOf<HasStoragePaths>().toEqualTypeOf<false>()
     expectTypeOf<ApplicationCommandResult<'saveFeedbackDraft'>>().toEqualTypeOf<DraftView>()
+    expectTypeOf<ApplicationCommandInput<'addFeedbackAttachment'>>().toEqualTypeOf<
+      ApplicationAddAttachmentInput
+    >()
+    expectTypeOf<ApplicationAddAttachmentInput['contents']>().toEqualTypeOf<ArrayBuffer>()
     expectTypeOf<ApplicationCommandInput<'readFeedbackAttachment'>>().toEqualTypeOf<
       ReadAttachmentInput
     >()

--- a/apps/desktop/src/lib/application/contracts.ts
+++ b/apps/desktop/src/lib/application/contracts.ts
@@ -34,6 +34,13 @@ type ApplicationCommandContract<Input, Output> = Readonly<{
 }>
 
 /**
+ * The cross-client attachment contract keeps bytes binary. Rust's generated
+ * DTO remains the Tauri wire shape, where serde receives a number array.
+ */
+export type ApplicationAddAttachmentInput = Omit<AddAttachmentInput, 'contents'> &
+  Readonly<{ contents: ArrayBuffer }>
+
+/**
  * Cross-client application operations. Inputs are domain/transport contracts,
  * never a Tauri `{ input }` envelope or camelCase invoke argument object.
  */
@@ -46,7 +53,7 @@ export type ApplicationCommandMap = Readonly<{
   getFeedbackWorkspace: ApplicationCommandContract<GetFeedbackInput, ApplicationFeedbackWorkspaceView>
   readPublishedFeedback: ApplicationCommandContract<GetFeedbackInput, FeedbackPackageView | null>
   saveFeedbackDraft: ApplicationCommandContract<SaveDraftInput, DraftView>
-  addFeedbackAttachment: ApplicationCommandContract<AddAttachmentInput, ApplicationFeedbackWorkspaceView>
+  addFeedbackAttachment: ApplicationCommandContract<ApplicationAddAttachmentInput, ApplicationFeedbackWorkspaceView>
   removeFeedbackAttachment: ApplicationCommandContract<RemoveAttachmentInput, ApplicationFeedbackWorkspaceView>
   reorderFeedbackAttachments: ApplicationCommandContract<ReorderAttachmentsInput, ApplicationFeedbackWorkspaceView>
   submitFeedback: ApplicationCommandContract<SubmitFeedbackInput, ApplicationFeedbackRequestView>

--- a/apps/desktop/src/lib/application/httpApplicationTransport.test.ts
+++ b/apps/desktop/src/lib/application/httpApplicationTransport.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { defineApplicationStream } from './applicationTransport'
+import {
+  HTTP_APPLICATION_OPERATIONS,
+  HttpApplicationSession,
+  HttpApplicationStreamUnavailableError,
+  HttpApplicationTransport,
+  StaleHttpApplicationLeaseError,
+} from './httpApplicationTransport'
+
+function authenticatedSession(fetchImplementation: typeof fetch) {
+  return HttpApplicationSession.authenticated({
+    accessToken: 'short-lived-session-token',
+    pageUrl: 'https://workbench.example/app',
+    fetch: fetchImplementation,
+  })
+}
+
+describe('HttpApplicationSession', () => {
+  it('restricts the application endpoint to the Workbench page origin', () => {
+    expect(() =>
+      HttpApplicationSession.authenticated({
+        accessToken: 'session-token',
+        pageUrl: 'https://workbench.example/app',
+        applicationBaseUrl: 'https://attacker.example/api/application/',
+        fetch,
+      }),
+    ).toThrow('must use the Workbench page origin')
+  })
+
+  it('keeps the token in Authorization and out of the request URL', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>().mockResolvedValue(Response.json([]))
+    const session = authenticatedSession(fetchImplementation)
+    const transport = new HttpApplicationTransport(session.lease())
+
+    await transport.call('listFeedbackInbox', undefined)
+
+    const [url, init] = fetchImplementation.mock.calls[0]!
+    expect(String(url)).toBe('https://workbench.example/api/application/listFeedbackInbox')
+    expect(String(url)).not.toContain('short-lived-session-token')
+    expect(new Headers(init?.headers).get('Authorization')).toBe(
+      'Bearer short-lived-session-token',
+    )
+    expect(init).toMatchObject({ credentials: 'same-origin', redirect: 'error' })
+    expect(JSON.stringify(session)).not.toContain('short-lived-session-token')
+  })
+
+  it('rejects absolute and protocol-relative operations before sending credentials', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>()
+    const lease = authenticatedSession(fetchImplementation).lease()
+
+    await expect(
+      lease.request('https://attacker.example/collect' as never),
+    ).rejects.toThrow('Invalid HTTP application operation')
+    await expect(lease.request('//attacker.example/collect' as never)).rejects.toThrow(
+      'Invalid HTTP application operation',
+    )
+    expect(fetchImplementation).not.toHaveBeenCalled()
+  })
+
+  it('rejects responses that arrive after the authenticated lease becomes stale', async () => {
+    let resolveResponse: ((response: Response) => void) | undefined
+    const fetchImplementation = vi.fn<typeof fetch>().mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveResponse = resolve
+      }),
+    )
+    const session = authenticatedSession(fetchImplementation)
+    const transport = new HttpApplicationTransport(session.lease())
+    const pending = transport.call('listHostSessions', undefined)
+
+    session.invalidate()
+    resolveResponse?.(Response.json([]))
+
+    await expect(pending).rejects.toBeInstanceOf(StaleHttpApplicationLeaseError)
+    await expect(transport.waitUntilReady()).rejects.toBeInstanceOf(
+      StaleHttpApplicationLeaseError,
+    )
+  })
+})
+
+describe('HttpApplicationTransport', () => {
+  it('defines one complete HTTP operation mapping', () => {
+    expect(Object.keys(HTTP_APPLICATION_OPERATIONS)).toHaveLength(23)
+    expect(new Set(Object.values(HTTP_APPLICATION_OPERATIONS)).size).toBe(23)
+  })
+
+  it('encodes JSON, multipart bytes, binary responses, and no-content outcomes', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async (url) => {
+      const operation = String(url).split('/').at(-1)
+      if (operation === 'readFeedbackAttachment') {
+        return new Response(new Uint8Array([4, 5, 6]), {
+          headers: { 'Content-Type': 'application/octet-stream' },
+        })
+      }
+      if (operation === 'deleteFeedbackRequest') return new Response(null, { status: 204 })
+      return Response.json({ ok: true })
+    })
+    const transport = new HttpApplicationTransport(
+      authenticatedSession(fetchImplementation).lease(),
+    )
+
+    await transport.call('saveFeedbackDraft', {
+      request_id: 'request-1',
+      document_json: '{}',
+      body_markdown: 'draft',
+      expected_revision: 2,
+    })
+    await transport.call('addFeedbackAttachment', {
+      request_id: 'request-1',
+      file_name: 'note.txt',
+      contents: new Uint8Array([1, 2, 3]).buffer,
+      expected_revision: 2,
+    })
+    await expect(
+      transport.call('readFeedbackAttachment', {
+        request_id: 'request-1',
+        attachment_id: 'attachment-1',
+      }),
+    ).resolves.toEqual(new Uint8Array([4, 5, 6]).buffer)
+    await expect(
+      transport.call('deleteFeedbackRequest', { request_id: 'request-1' }),
+    ).resolves.toBeUndefined()
+
+    const jsonInit = fetchImplementation.mock.calls[0]![1]!
+    expect(new Headers(jsonInit.headers).get('Content-Type')).toBe('application/json')
+    expect(JSON.parse(String(jsonInit.body))).toMatchObject({ request_id: 'request-1' })
+    const multipart = fetchImplementation.mock.calls[1]![1]!.body
+    expect(multipart).toBeInstanceOf(FormData)
+    expect((multipart as FormData).get('request_id')).toBe('request-1')
+    expect((multipart as FormData).get('expected_revision')).toBe('2')
+    await expect(((multipart as FormData).get('file') as Blob).arrayBuffer()).resolves.toEqual(
+      new Uint8Array([1, 2, 3]).buffer,
+    )
+  })
+
+  it('rejects typed ApplicationError responses without normalizing them', async () => {
+    const applicationError = {
+      code: 'DRAFT_CONFLICT',
+      message: 'draft revision changed',
+      retryable: false,
+    } as const
+    const fetchImplementation = vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json(applicationError, { status: 409 }),
+    )
+    const transport = new HttpApplicationTransport(
+      authenticatedSession(fetchImplementation).lease(),
+    )
+
+    await expect(
+      transport.call('saveFeedbackDraft', {
+        request_id: 'request-1',
+        document_json: '{}',
+        body_markdown: 'draft',
+        expected_revision: 1,
+      }),
+    ).rejects.toEqual(applicationError)
+  })
+
+  it('prefers stale-lease rejection when an error body finishes after invalidation', async () => {
+    let bodyStarted: (() => void) | undefined
+    const readingBody = new Promise<void>((resolve) => {
+      bodyStarted = resolve
+    })
+    let resolveBody: ((body: unknown) => void) | undefined
+    const body = new Promise<unknown>((resolve) => {
+      resolveBody = resolve
+    })
+    const response = Response.json({}, { status: 409 })
+    vi.spyOn(response, 'json').mockImplementation(async () => {
+      bodyStarted?.()
+      return body
+    })
+    const session = authenticatedSession(
+      vi.fn<typeof fetch>().mockResolvedValue(response),
+    )
+    const transport = new HttpApplicationTransport(session.lease())
+    const pending = transport.call('saveFeedbackDraft', {
+      request_id: 'request-1',
+      document_json: '{}',
+      body_markdown: 'draft',
+      expected_revision: 1,
+    })
+
+    await readingBody
+    session.invalidate()
+    resolveBody?.({ code: 'DRAFT_CONFLICT', message: 'stale error', retryable: false })
+
+    await expect(pending).rejects.toBeInstanceOf(StaleHttpApplicationLeaseError)
+  })
+
+  it('prefers stale-lease rejection when successful JSON decoding rejects after invalidation', async () => {
+    let decodingStarted: (() => void) | undefined
+    const started = new Promise<void>((resolve) => {
+      decodingStarted = resolve
+    })
+    let rejectDecode: ((cause: unknown) => void) | undefined
+    const decoding = new Promise<unknown>((_resolve, reject) => {
+      rejectDecode = reject
+    })
+    const response = Response.json({})
+    vi.spyOn(response, 'json').mockImplementation(async () => {
+      decodingStarted?.()
+      return decoding
+    })
+    const session = authenticatedSession(vi.fn<typeof fetch>().mockResolvedValue(response))
+    const transport = new HttpApplicationTransport(session.lease())
+    const pending = transport.call('listFeedbackInbox', undefined)
+
+    await started
+    session.invalidate()
+    rejectDecode?.(new SyntaxError('invalid JSON'))
+
+    await expect(pending).rejects.toBeInstanceOf(StaleHttpApplicationLeaseError)
+  })
+
+  it('prefers stale-lease rejection when successful binary decoding rejects after invalidation', async () => {
+    let decodingStarted: (() => void) | undefined
+    const started = new Promise<void>((resolve) => {
+      decodingStarted = resolve
+    })
+    let rejectDecode: ((cause: unknown) => void) | undefined
+    const decoding = new Promise<ArrayBuffer>((_resolve, reject) => {
+      rejectDecode = reject
+    })
+    const response = new Response(new Uint8Array([1, 2, 3]))
+    vi.spyOn(response, 'arrayBuffer').mockImplementation(async () => {
+      decodingStarted?.()
+      return decoding
+    })
+    const session = authenticatedSession(vi.fn<typeof fetch>().mockResolvedValue(response))
+    const transport = new HttpApplicationTransport(session.lease())
+    const pending = transport.call('readFeedbackAttachment', {
+      request_id: 'request-1',
+      attachment_id: 'attachment-1',
+    })
+
+    await started
+    session.invalidate()
+    rejectDecode?.(new TypeError('binary stream failed'))
+
+    await expect(pending).rejects.toBeInstanceOf(StaleHttpApplicationLeaseError)
+  })
+
+  it('reports streams as unavailable and only marks an active authenticated lease ready', async () => {
+    const session = authenticatedSession(vi.fn<typeof fetch>())
+    const transport = new HttpApplicationTransport(session.lease())
+    await expect(transport.waitUntilReady()).resolves.toBeUndefined()
+
+    const onError = vi.fn()
+    const unsubscribe = transport.subscribe(
+      defineApplicationStream('request:changed'),
+      vi.fn(),
+      onError,
+    )
+    await Promise.resolve()
+    expect(onError).toHaveBeenCalledWith(expect.any(HttpApplicationStreamUnavailableError))
+    unsubscribe()
+    unsubscribe()
+  })
+})

--- a/apps/desktop/src/lib/application/httpApplicationTransport.test.ts
+++ b/apps/desktop/src/lib/application/httpApplicationTransport.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { defineApplicationStream } from './applicationTransport'
+import type { ApplicationCommandInput, ApplicationCommandName } from './contracts'
+import {
+  APPLICATION_CONFORMANCE_INPUTS,
+  applicationConformanceResult,
+  runApplicationTransportConformance,
+} from './applicationTransportConformance'
 import {
   HTTP_APPLICATION_OPERATIONS,
   HttpApplicationSession,
@@ -16,6 +22,66 @@ function authenticatedSession(fetchImplementation: typeof fetch) {
     fetch: fetchImplementation,
   })
 }
+
+runApplicationTransportConformance('HTTP', () => {
+  const calls: Array<readonly [URL | RequestInfo, RequestInit | undefined]> = []
+  let rejection: unknown
+  const semanticNameByOperation = new Map<string, ApplicationCommandName>(
+    Object.entries(HTTP_APPLICATION_OPERATIONS).map(([name, operation]) => [
+      operation,
+      name as ApplicationCommandName,
+    ]),
+  )
+  const fetchImplementation = vi.fn<typeof fetch>(async (url, init) => {
+    calls.push([url, init])
+    if (rejection !== undefined) {
+      const error = rejection
+      rejection = undefined
+      return Response.json(error, { status: 409 })
+    }
+    const operation = String(url).split('/').at(-1) ?? ''
+    const name = semanticNameByOperation.get(operation)
+    if (!name) return Response.json({ message: 'unknown operation' }, { status: 404 })
+    const result = applicationConformanceResult(name)
+    if (name === 'deleteHostSession' || name === 'deleteFeedbackRequest') {
+      return new Response(null, { status: 204 })
+    }
+    if (result instanceof ArrayBuffer) return new Response(result)
+    return Response.json(result)
+  })
+
+  return {
+    transport: new HttpApplicationTransport(authenticatedSession(fetchImplementation).lease()),
+    expectWireCall: async <Name extends ApplicationCommandName>(
+      index: number,
+      name: Name,
+      input: ApplicationCommandInput<Name>,
+    ) => {
+      const [url, init] = calls[index]!
+      expect(String(url).split('/').at(-1)).toBe(HTTP_APPLICATION_OPERATIONS[name])
+      expect(init?.method).toBe('POST')
+      if (
+        name === 'listFeedbackInbox' ||
+        name === 'listHostSessions' ||
+        name === 'listHostProfiles'
+      ) {
+        expect(init?.body).toBeUndefined()
+      } else if (name === 'addFeedbackAttachment') {
+        const attachment = input as ApplicationCommandInput<'addFeedbackAttachment'>
+        const form = init?.body as FormData
+        expect(form.get('request_id')).toBe(attachment.request_id)
+        expect(form.get('file_name')).toBe(attachment.file_name)
+        expect(form.get('expected_revision')).toBe(String(attachment.expected_revision))
+        await expect((form.get('file') as Blob).arrayBuffer()).resolves.toEqual(attachment.contents)
+      } else {
+        expect(JSON.parse(String(init?.body))).toEqual(input)
+      }
+    },
+    rejectNext: (error) => {
+      rejection = error
+    },
+  }
+})
 
 describe('HttpApplicationSession', () => {
   it('restricts the application endpoint to the Workbench page origin', () => {
@@ -258,5 +324,27 @@ describe('HttpApplicationTransport', () => {
     expect(onError).toHaveBeenCalledWith(expect.any(HttpApplicationStreamUnavailableError))
     unsubscribe()
     unsubscribe()
+  })
+
+  it('does not report ready before its lease readiness barrier resolves', async () => {
+    let releaseReady: (() => void) | undefined
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve
+    })
+    const transport = new HttpApplicationTransport({
+      request: () => Promise.reject(new Error('not used')),
+      assertActive: () => undefined,
+      waitUntilReady: () => ready,
+    })
+    let settled = false
+    const waiting = transport.waitUntilReady().then(() => {
+      settled = true
+    })
+
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    releaseReady?.()
+    await waiting
+    expect(settled).toBe(true)
   })
 })

--- a/apps/desktop/src/lib/application/httpApplicationTransport.ts
+++ b/apps/desktop/src/lib/application/httpApplicationTransport.ts
@@ -1,0 +1,274 @@
+import type {
+  ApplicationCommandInput,
+  ApplicationCommandName,
+  ApplicationCommandResult,
+} from './contracts'
+import { isApplicationError } from './contracts'
+import type {
+  ApplicationStream,
+  ApplicationTransport,
+  SubscriptionErrorHandler,
+  Unsubscribe,
+} from './applicationTransport'
+
+export const HTTP_APPLICATION_OPERATIONS = {
+  listFeedbackInbox: 'listFeedbackInbox',
+  listHostSessions: 'listHostSessions',
+  listArchivedHostSessions: 'listArchivedHostSessions',
+  listHostProfiles: 'listHostProfiles',
+  listFeedbackRequests: 'listFeedbackRequests',
+  getFeedbackWorkspace: 'getFeedbackWorkspace',
+  readPublishedFeedback: 'readPublishedFeedback',
+  saveFeedbackDraft: 'saveFeedbackDraft',
+  addFeedbackAttachment: 'addFeedbackAttachment',
+  removeFeedbackAttachment: 'removeFeedbackAttachment',
+  reorderFeedbackAttachments: 'reorderFeedbackAttachments',
+  submitFeedback: 'submitFeedback',
+  approveFeedbackRequest: 'approveFeedbackRequest',
+  cancelFeedbackRequest: 'cancelFeedbackRequest',
+  renameHostSession: 'renameHostSession',
+  setHostSessionPinned: 'setHostSessionPinned',
+  archiveHostSession: 'archiveHostSession',
+  unarchiveHostSession: 'unarchiveHostSession',
+  deleteHostSession: 'deleteHostSession',
+  deleteFeedbackRequest: 'deleteFeedbackRequest',
+  setHostPinned: 'setHostPinned',
+  readFeedbackAttachment: 'readFeedbackAttachment',
+  readRequestAttachment: 'readRequestAttachment',
+} as const satisfies Record<ApplicationCommandName, string>
+
+export type HttpApplicationOperation =
+  (typeof HTTP_APPLICATION_OPERATIONS)[ApplicationCommandName]
+
+const NO_ARGUMENT_COMMANDS: ReadonlySet<ApplicationCommandName> = new Set([
+  'listFeedbackInbox',
+  'listHostSessions',
+  'listHostProfiles',
+])
+
+const VOID_COMMANDS: ReadonlySet<ApplicationCommandName> = new Set([
+  'deleteHostSession',
+  'deleteFeedbackRequest',
+])
+
+const BINARY_COMMANDS: ReadonlySet<ApplicationCommandName> = new Set([
+  'readFeedbackAttachment',
+  'readRequestAttachment',
+])
+
+export class StaleHttpApplicationLeaseError extends Error {
+  constructor() {
+    super('The authenticated application session is no longer active.')
+    this.name = 'StaleHttpApplicationLeaseError'
+  }
+}
+
+export class HttpApplicationStreamUnavailableError extends Error {
+  constructor() {
+    super('Application event streams are unavailable until WebSocket transport is implemented.')
+    this.name = 'HttpApplicationStreamUnavailableError'
+  }
+}
+
+export interface HttpApplicationLease {
+  request(operation: HttpApplicationOperation, init?: RequestInit): Promise<Response>
+  assertActive(): void
+  waitUntilReady(): Promise<void>
+}
+
+export type AuthenticatedHttpApplicationSessionOptions = Readonly<{
+  accessToken: string
+  applicationBaseUrl?: string | URL
+  pageUrl?: string | URL
+  fetch?: typeof globalThis.fetch
+}>
+
+export class HttpApplicationSession {
+  readonly #applicationBaseUrl: URL
+  readonly #accessToken: string
+  readonly #fetch: typeof globalThis.fetch
+  #generation = 1
+  #active = true
+
+  private constructor(options: AuthenticatedHttpApplicationSessionOptions) {
+    if (!options.accessToken || /[\r\n]/u.test(options.accessToken)) {
+      throw new Error('An authenticated application session requires a valid access token.')
+    }
+    const pageUrl = new URL(
+      options.pageUrl ?? globalThis.location?.href ?? 'http://localhost/',
+    )
+    const applicationBaseUrl = new URL(
+      options.applicationBaseUrl ?? '/api/application/',
+      pageUrl,
+    )
+    if (applicationBaseUrl.origin !== pageUrl.origin) {
+      throw new Error('The HTTP application transport must use the Workbench page origin.')
+    }
+    if (!applicationBaseUrl.pathname.endsWith('/')) {
+      applicationBaseUrl.pathname += '/'
+    }
+
+    this.#applicationBaseUrl = applicationBaseUrl
+    this.#accessToken = options.accessToken
+    this.#fetch = options.fetch ?? globalThis.fetch.bind(globalThis)
+  }
+
+  static authenticated(
+    options: AuthenticatedHttpApplicationSessionOptions,
+  ): HttpApplicationSession {
+    return new HttpApplicationSession(options)
+  }
+
+  lease(): HttpApplicationLease {
+    const generation = this.#generation
+    const assertActive = () => {
+      if (!this.#active || generation !== this.#generation) {
+        throw new StaleHttpApplicationLeaseError()
+      }
+    }
+
+    return Object.freeze({
+      request: async (operation: HttpApplicationOperation, init: RequestInit = {}) => {
+        assertActive()
+        const targetUrl = new URL(operation, this.#applicationBaseUrl)
+        const expectedPath = `${this.#applicationBaseUrl.pathname}${operation}`
+        if (
+          targetUrl.origin !== this.#applicationBaseUrl.origin ||
+          targetUrl.pathname !== expectedPath ||
+          targetUrl.search !== '' ||
+          targetUrl.hash !== ''
+        ) {
+          throw new Error('Invalid HTTP application operation.')
+        }
+        const headers = new Headers(init.headers)
+        headers.set('Authorization', `Bearer ${this.#accessToken}`)
+        const response = await this.#fetch(targetUrl, {
+          ...init,
+          headers,
+          credentials: 'same-origin',
+          redirect: 'error',
+        })
+        assertActive()
+        return response
+      },
+      assertActive,
+      waitUntilReady: async () => assertActive(),
+    })
+  }
+
+  invalidate(): void {
+    if (!this.#active) return
+    this.#active = false
+    this.#generation += 1
+  }
+}
+
+function requestInit<Name extends ApplicationCommandName>(
+  name: Name,
+  input: ApplicationCommandInput<Name>,
+): RequestInit {
+  if (NO_ARGUMENT_COMMANDS.has(name)) return { method: 'POST' }
+
+  if (name === 'addFeedbackAttachment') {
+    const attachment = input as ApplicationCommandInput<'addFeedbackAttachment'>
+    const form = new FormData()
+    form.set('request_id', attachment.request_id)
+    form.set('file_name', attachment.file_name)
+    form.set('expected_revision', String(attachment.expected_revision))
+    form.set('file', new Blob([attachment.contents]))
+    return { method: 'POST', body: form }
+  }
+
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  }
+}
+
+async function applicationFailure(
+  name: ApplicationCommandName,
+  response: Response,
+  lease: HttpApplicationLease,
+): Promise<never> {
+  let payload: unknown
+  try {
+    payload = await decodeWithActiveLease(lease, () => response.json())
+  } catch {
+    lease.assertActive()
+    throw new Error(`Application operation ${name} failed with HTTP ${response.status}.`)
+  }
+  if (isApplicationError(payload)) throw payload
+  throw new Error(`Application operation ${name} failed with HTTP ${response.status}.`)
+}
+
+async function decodeWithActiveLease<Result>(
+  lease: HttpApplicationLease,
+  decode: () => Promise<Result>,
+): Promise<Result> {
+  let result: Result
+  try {
+    result = await decode()
+  } catch (cause) {
+    lease.assertActive()
+    throw cause
+  }
+  lease.assertActive()
+  return result
+}
+
+export class HttpApplicationTransport<CapabilityManifest = unknown>
+  implements ApplicationTransport<CapabilityManifest>
+{
+  constructor(
+    private readonly lease: HttpApplicationLease,
+    private readonly capabilityManifest: CapabilityManifest = undefined as CapabilityManifest,
+  ) {}
+
+  async call<Name extends ApplicationCommandName>(
+    name: Name,
+    input: ApplicationCommandInput<Name>,
+  ): Promise<ApplicationCommandResult<Name>> {
+    const response = await this.lease.request(
+      HTTP_APPLICATION_OPERATIONS[name],
+      requestInit(name, input),
+    )
+    if (!response.ok) return applicationFailure(name, response, this.lease)
+
+    let result: unknown
+    if (VOID_COMMANDS.has(name)) {
+      if (response.status !== 204) {
+        throw new Error(`Application operation ${name} returned HTTP ${response.status}, not 204.`)
+      }
+      result = undefined
+    } else if (BINARY_COMMANDS.has(name)) {
+      result = await decodeWithActiveLease(this.lease, () => response.arrayBuffer())
+    } else {
+      result = await decodeWithActiveLease(this.lease, () => response.json())
+    }
+    if (VOID_COMMANDS.has(name)) this.lease.assertActive()
+    return result as ApplicationCommandResult<Name>
+  }
+
+  subscribe<Event>(
+    _stream: ApplicationStream<Event>,
+    _handler: (event: Event) => void,
+    onError: SubscriptionErrorHandler,
+  ): Unsubscribe {
+    let active = true
+    queueMicrotask(() => {
+      if (active) onError(new HttpApplicationStreamUnavailableError())
+    })
+    return () => {
+      active = false
+    }
+  }
+
+  waitUntilReady(): Promise<void> {
+    return this.lease.waitUntilReady()
+  }
+
+  capabilities(): CapabilityManifest {
+    return this.capabilityManifest
+  }
+}

--- a/apps/desktop/src/lib/application/tauriApplicationTransport.test.ts
+++ b/apps/desktop/src/lib/application/tauriApplicationTransport.test.ts
@@ -47,7 +47,7 @@ const commandInputs = {
   addFeedbackAttachment: {
     request_id: 'request-1',
     file_name: 'note.txt',
-    contents: [1, 2, 3],
+    contents: new Uint8Array([1, 2, 3]).buffer,
     expected_revision: 1,
   },
   removeFeedbackAttachment: {
@@ -86,6 +86,9 @@ function expectedArguments(name: ApplicationCommandName): Record<string, unknown
   const input = commandInputs[name]
   if (name === 'listFeedbackInbox' || name === 'listHostSessions' || name === 'listHostProfiles') {
     return undefined
+  }
+  if (name === 'addFeedbackAttachment') {
+    return { input: { ...input, contents: [1, 2, 3] } }
   }
   return { input }
 }

--- a/apps/desktop/src/lib/application/tauriApplicationTransport.test.ts
+++ b/apps/desktop/src/lib/application/tauriApplicationTransport.test.ts
@@ -12,78 +12,20 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }))
 vi.mock('@tauri-apps/api/event', () => ({ listen: mocks.listen }))
 
-import type {
-  ApplicationCommandInput,
-  ApplicationCommandName,
-} from './contracts'
+import type { ApplicationCommandInput, ApplicationCommandName } from './contracts'
 import { defineApplicationStream } from './applicationTransport'
+import {
+  APPLICATION_CONFORMANCE_INPUTS,
+  applicationConformanceResult,
+  runApplicationTransportConformance,
+} from './applicationTransportConformance'
 import {
   TAURI_APPLICATION_COMMANDS,
   TauriApplicationTransport,
 } from './tauriApplicationTransport'
 
-const commandInputs = {
-  listFeedbackInbox: undefined,
-  listHostSessions: undefined,
-  listArchivedHostSessions: { search: null },
-  listHostProfiles: undefined,
-  listFeedbackRequests: {
-    host_id: null,
-    host_session_id: null,
-    status: null,
-    archived: null,
-    search: null,
-    limit: null,
-    cursor: null,
-  },
-  getFeedbackWorkspace: { request_id: 'request-1' },
-  readPublishedFeedback: { request_id: 'request-1' },
-  saveFeedbackDraft: {
-    request_id: 'request-1',
-    document_json: '{}',
-    body_markdown: '',
-    expected_revision: 1,
-  },
-  addFeedbackAttachment: {
-    request_id: 'request-1',
-    file_name: 'note.txt',
-    contents: new Uint8Array([1, 2, 3]).buffer,
-    expected_revision: 1,
-  },
-  removeFeedbackAttachment: {
-    request_id: 'request-1',
-    attachment_id: 'attachment-1',
-    expected_revision: 1,
-  },
-  reorderFeedbackAttachments: {
-    request_id: 'request-1',
-    attachment_ids: ['attachment-1'],
-    expected_revision: 1,
-  },
-  submitFeedback: { request_id: 'request-1', expected_revision: 1 },
-  approveFeedbackRequest: { request_id: 'request-1' },
-  cancelFeedbackRequest: { request_id: 'request-1', reason: 'cancelled' },
-  renameHostSession: {
-    host_id: 'codex',
-    host_session_id: 'session-1',
-    title: 'Renamed',
-  },
-  setHostSessionPinned: {
-    host_id: 'codex',
-    host_session_id: 'session-1',
-    pinned: true,
-  },
-  archiveHostSession: { host_id: 'codex', host_session_id: 'session-1' },
-  unarchiveHostSession: { host_id: 'codex', host_session_id: 'session-1' },
-  deleteHostSession: { host_id: 'codex', host_session_id: 'session-1' },
-  deleteFeedbackRequest: { request_id: 'request-1' },
-  setHostPinned: { host_id: 'codex', pinned: true },
-  readFeedbackAttachment: { request_id: 'request-1', attachment_id: 'attachment-1' },
-  readRequestAttachment: { request_id: 'request-1', attachment_id: 'attachment-1' },
-} satisfies { [Name in ApplicationCommandName]: ApplicationCommandInput<Name> }
-
 function expectedArguments(name: ApplicationCommandName): Record<string, unknown> | undefined {
-  const input = commandInputs[name]
+  const input = APPLICATION_CONFORMANCE_INPUTS[name]
   if (name === 'listFeedbackInbox' || name === 'listHostSessions' || name === 'listHostProfiles') {
     return undefined
   }
@@ -92,6 +34,44 @@ function expectedArguments(name: ApplicationCommandName): Record<string, unknown
   }
   return { input }
 }
+
+runApplicationTransportConformance('Tauri', () => {
+  mocks.invoke.mockReset()
+  mocks.listen.mockReset()
+  mocks.listen.mockResolvedValue(vi.fn())
+  let rejection: unknown
+  const semanticNameByCommand = new Map<string, ApplicationCommandName>(
+    Object.entries(TAURI_APPLICATION_COMMANDS).map(([name, command]) => [
+      command,
+      name as ApplicationCommandName,
+    ]),
+  )
+  mocks.invoke.mockImplementation((command: string) => {
+    if (rejection !== undefined) {
+      const cause = rejection
+      rejection = undefined
+      return Promise.reject(cause)
+    }
+    const name = semanticNameByCommand.get(command)
+    if (!name) return Promise.reject(new Error(`Unexpected command: ${command}`))
+    return Promise.resolve(applicationConformanceResult(name))
+  })
+
+  return {
+    transport: new TauriApplicationTransport(),
+    expectWireCall: (index, name) => {
+      const args = expectedArguments(name)
+      expect(mocks.invoke).toHaveBeenNthCalledWith(
+        index + 1,
+        TAURI_APPLICATION_COMMANDS[name],
+        ...(args === undefined ? [] : [args]),
+      )
+    },
+    rejectNext: (error) => {
+      rejection = error
+    },
+  }
+})
 
 async function sourceFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true })
@@ -110,21 +90,6 @@ describe('TauriApplicationTransport', () => {
     mocks.invoke.mockReset()
     mocks.listen.mockReset()
     mocks.invoke.mockResolvedValue(undefined)
-  })
-
-  it('maps every semantic command to its complete Tauri command and payload shape', async () => {
-    const transport = new TauriApplicationTransport()
-    const names = Object.keys(TAURI_APPLICATION_COMMANDS) as ApplicationCommandName[]
-
-    for (const name of names) {
-      await transport.call(name, commandInputs[name])
-      const args = expectedArguments(name)
-      expect(mocks.invoke).toHaveBeenLastCalledWith(
-        TAURI_APPLICATION_COMMANDS[name],
-        ...(args === undefined ? [] : [args]),
-      )
-    }
-    expect(mocks.invoke).toHaveBeenCalledTimes(names.length)
   })
 
   it('returns a synchronous idempotent unsubscribe before async listen resolves', async () => {

--- a/apps/desktop/src/lib/application/tauriApplicationTransport.ts
+++ b/apps/desktop/src/lib/application/tauriApplicationTransport.ts
@@ -50,6 +50,15 @@ function tauriArguments<Name extends ApplicationCommandName>(
   input: ApplicationCommandInput<Name>,
 ): Record<string, unknown> | undefined {
   if (NO_ARGUMENT_COMMANDS.has(name)) return undefined
+  if (name === 'addFeedbackAttachment') {
+    const attachment = input as ApplicationCommandInput<'addFeedbackAttachment'>
+    return {
+      input: {
+        ...attachment,
+        contents: Array.from(new Uint8Array(attachment.contents)),
+      },
+    }
+  }
   return { input }
 }
 

--- a/apps/desktop/src/lib/application/workbenchComposition.test.ts
+++ b/apps/desktop/src/lib/application/workbenchComposition.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { HttpApplicationSession, HttpApplicationTransport } from './httpApplicationTransport'
+import { TestApplicationTransport } from './testApplicationTransport'
+import { UnavailableApplicationTransport } from './unavailableApplicationTransport'
+import { createWorkbenchComposition } from './workbenchComposition'
+
+describe('createWorkbenchComposition', () => {
+  it('selects the Tauri implementation supplied by the desktop composition root', () => {
+    const desktopTransport = new TestApplicationTransport(undefined, { initiallyReady: true })
+    const composition = createWorkbenchComposition({
+      environment: 'desktop',
+      previewMode: false,
+      desktopTransport,
+    })
+
+    expect(composition.applicationTransport).toBe(desktopTransport)
+  })
+
+  it('selects HTTP only for an explicit authenticated browser session', () => {
+    const session = HttpApplicationSession.authenticated({
+      accessToken: 'session-token',
+      pageUrl: 'https://workbench.example/app',
+      fetch: vi.fn<typeof fetch>(),
+    })
+    const composition = createWorkbenchComposition({
+      environment: 'browser',
+      previewMode: false,
+      authenticatedWebSession: session,
+    })
+
+    expect(composition.applicationTransport).toBeInstanceOf(HttpApplicationTransport)
+  })
+
+  it('keeps preview fixtures offline even if a web session is present', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>()
+    const session = HttpApplicationSession.authenticated({
+      accessToken: 'session-token',
+      pageUrl: 'https://workbench.example/app',
+      fetch: fetchImplementation,
+    })
+    const composition = createWorkbenchComposition({
+      environment: 'browser',
+      previewMode: true,
+      authenticatedWebSession: session,
+    })
+
+    expect(composition.applicationTransport).toBeInstanceOf(UnavailableApplicationTransport)
+    await expect(composition.applicationTransport.waitUntilReady()).rejects.toThrow('unavailable')
+    expect(fetchImplementation).not.toHaveBeenCalled()
+  })
+
+  it('uses the unavailable implementation for an ordinary browser without a session', () => {
+    const composition = createWorkbenchComposition({
+      environment: 'browser',
+      previewMode: false,
+    })
+
+    expect(composition.applicationTransport).toBeInstanceOf(UnavailableApplicationTransport)
+  })
+})

--- a/apps/desktop/src/lib/application/workbenchComposition.ts
+++ b/apps/desktop/src/lib/application/workbenchComposition.ts
@@ -1,0 +1,46 @@
+import type { ApplicationTransport } from './applicationTransport'
+import {
+  HttpApplicationTransport,
+  type HttpApplicationSession,
+} from './httpApplicationTransport'
+import { UnavailableApplicationTransport } from './unavailableApplicationTransport'
+
+export type WorkbenchCompositionInput = Readonly<{
+  environment: 'desktop' | 'browser'
+  previewMode: boolean
+  desktopTransport?: ApplicationTransport
+  authenticatedWebSession?: HttpApplicationSession
+}>
+
+export type WorkbenchComposition = Readonly<{
+  applicationTransport: ApplicationTransport
+  previewMode: boolean
+}>
+
+/** Selects implementations only; credentials and native bindings are composed outside. */
+export function createWorkbenchComposition(
+  input: WorkbenchCompositionInput,
+): WorkbenchComposition {
+  if (input.previewMode) {
+    return {
+      applicationTransport: new UnavailableApplicationTransport(),
+      previewMode: true,
+    }
+  }
+  if (input.environment === 'desktop') {
+    if (!input.desktopTransport) {
+      throw new Error('Desktop composition requires a Tauri ApplicationTransport implementation.')
+    }
+    return { applicationTransport: input.desktopTransport, previewMode: false }
+  }
+  if (input.authenticatedWebSession) {
+    return {
+      applicationTransport: new HttpApplicationTransport(input.authenticatedWebSession.lease()),
+      previewMode: false,
+    }
+  }
+  return {
+    applicationTransport: new UnavailableApplicationTransport(),
+    previewMode: false,
+  }
+}

--- a/apps/desktop/src/lib/components/navigation/ArchivedSessionsDialog.svelte
+++ b/apps/desktop/src/lib/components/navigation/ArchivedSessionsDialog.svelte
@@ -40,7 +40,6 @@
   }
 
   export let open = false
-  export let isTauri = false
   export let transport: ApplicationTransport
   export let previewMode = false
   export let resolveHostProfile: (hostId: string) => HostProfile
@@ -214,7 +213,7 @@
   }
 
   async function fetchSessionRequests(session: HostSessionSummary) {
-    if (previewMode || !isTauri) return previewArchivedRequests(session, search)
+    if (previewMode) return previewArchivedRequests(session, search)
     return (
       await transport.call('listFeedbackRequests', {
         host_id: session.host_id,
@@ -232,7 +231,7 @@
     loading = true
     try {
       const nextSessions =
-        previewMode || !isTauri
+        previewMode
           ? previewArchivedSessions(search)
           : await transport.call('listArchivedHostSessions', {
               search: search.trim() || null,
@@ -302,7 +301,7 @@
     detailLoadingRequestId = request.request_id
     try {
       const workspace =
-        previewMode || !isTauri
+        previewMode
           ? previewWorkspaceFor(request.request_id)
           : await transport.call('getFeedbackWorkspace', {
               request_id: request.request_id,
@@ -310,7 +309,7 @@
       if (!workspace) throw new Error(tr('This feedback request could not be found.'))
       const publishedFeedback =
         workspace.request.status === 'completed' && workspace.feedback
-          ? previewMode || !isTauri
+          ? previewMode
             ? {
                 markdown: workspace.draft.body_markdown,
                 uncooked_markdown: workspace.draft.body_markdown,
@@ -348,7 +347,7 @@
 
   async function unarchiveSession(session: HostSessionSummary) {
     await runAction(`unarchive:${session.host_id}:${session.host_session_id}`, async () => {
-      if (!(previewMode || !isTauri)) {
+      if (!previewMode) {
         await transport.call('unarchiveHostSession', {
           host_id: session.host_id,
           host_session_id: session.host_session_id,
@@ -360,7 +359,7 @@
   async function deleteSession(session: HostSessionSummary) {
     if (!confirm(tr('Delete this archived session permanently?'))) return
     await runAction(`delete-session:${session.host_id}:${session.host_session_id}`, async () => {
-      if (!(previewMode || !isTauri)) {
+      if (!previewMode) {
         await transport.call('deleteHostSession', {
           host_id: session.host_id,
           host_session_id: session.host_session_id,
@@ -372,7 +371,7 @@
   async function deleteRequest(request: FeedbackRequestSummary) {
     if (!confirm(tr('Delete this archived request permanently?'))) return
     await runAction(`delete-request:${request.request_id}`, async () => {
-      if (!(previewMode || !isTauri)) {
+      if (!previewMode) {
         await transport.call('deleteFeedbackRequest', { request_id: request.request_id })
       }
     })

--- a/apps/desktop/src/lib/workbench/attachmentController.ts
+++ b/apps/desktop/src/lib/workbench/attachmentController.ts
@@ -5,8 +5,8 @@ import { tick } from 'svelte'
 
 import { isImageMediaType } from '../attachmentMarkdown'
 import type { ApplicationTransport } from '../application/applicationTransport'
+import type { ApplicationAddAttachmentInput } from '../application/contracts'
 import type {
-  AddAttachmentInput,
   AttachmentView,
   FeedbackWorkspaceView,
   RemoveAttachmentInput,
@@ -154,10 +154,10 @@ export function createAttachmentController(context: AttachmentControllerContext)
         if (file.size > 20 * 1024 * 1024) {
           throw new Error(context.tr('{name} exceeds the 20 MiB limit', { name: file.name }))
         }
-        const input: AddAttachmentInput = {
+        const input: ApplicationAddAttachmentInput = {
           request_id: requestId,
           file_name: file.name || `attachment-${Date.now()}`,
-          contents: Array.from(new Uint8Array(await file.arrayBuffer())),
+          contents: await file.arrayBuffer(),
           expected_revision: next.draft.saved_revision,
         }
         next = await context.transport.call('addFeedbackAttachment', input)

--- a/apps/desktop/src/lib/workbench/navigationController.test.ts
+++ b/apps/desktop/src/lib/workbench/navigationController.test.ts
@@ -67,7 +67,7 @@ function hostSession(overrides: Partial<HostSessionSummary> = {}): HostSessionSu
 function createController(
   overrides: Partial<Parameters<typeof createNavigationController>[0]> = {},
 ) {
-  const transport = new TestApplicationTransport(undefined)
+  const transport = new TestApplicationTransport(undefined, { initiallyReady: true })
     .handle('listFeedbackInbox', (input) => mocks.applicationCall('listFeedbackInbox', input))
     .handle('listHostSessions', (input) => mocks.applicationCall('listHostSessions', input))
     .handle('listHostProfiles', (input) => mocks.applicationCall('listHostProfiles', input))
@@ -124,6 +124,69 @@ describe('navigationController', () => {
     await expect(controller.initialize(false)).resolves.toBe(true)
 
     expect(openRequest).not.toHaveBeenCalled()
+  })
+
+  it('waits for transport readiness before loading application facts', async () => {
+    const transport = new TestApplicationTransport(undefined)
+      .handle('listFeedbackInbox', (input) => mocks.applicationCall('listFeedbackInbox', input))
+      .handle('listHostSessions', (input) => mocks.applicationCall('listHostSessions', input))
+      .handle('listHostProfiles', (input) => mocks.applicationCall('listHostProfiles', input))
+      .handle('listFeedbackRequests', (input) => mocks.applicationCall('listFeedbackRequests', input))
+    mocks.applicationCall.mockImplementation(async (command: string) => {
+      if (command === 'listHostSessions') return [hostSession()]
+      if (command === 'listFeedbackRequests') {
+        return { requests: [], next_cursor: null } satisfies ListFeedbackRequestsOutput
+      }
+      return []
+    })
+    const controller = createController({ transport })
+    const initializing = controller.initialize(false)
+
+    await Promise.resolve()
+    expect(mocks.applicationCall).not.toHaveBeenCalled()
+    transport.markReady()
+    await expect(initializing).resolves.toBe(true)
+    expect(mocks.applicationCall).toHaveBeenCalledWith('listHostSessions', undefined)
+  })
+
+  it('preserves existing navigation facts when a later readiness check fails', async () => {
+    class ToggleReadyTransport extends TestApplicationTransport {
+      failReadiness = false
+
+      override waitUntilReady(): Promise<void> {
+        return this.failReadiness
+          ? Promise.reject(new Error('authenticated session expired'))
+          : super.waitUntilReady()
+      }
+    }
+    const transport = new ToggleReadyTransport(undefined, { initiallyReady: true })
+      .handle('listFeedbackInbox', (input) => mocks.applicationCall('listFeedbackInbox', input))
+      .handle('listHostSessions', (input) => mocks.applicationCall('listHostSessions', input))
+      .handle('listHostProfiles', (input) => mocks.applicationCall('listHostProfiles', input))
+      .handle('listFeedbackRequests', (input) => mocks.applicationCall('listFeedbackRequests', input))
+    mocks.applicationCall.mockImplementation(async (command: string) => {
+      if (command === 'listHostSessions') return [hostSession()]
+      if (command === 'listFeedbackRequests') {
+        return { requests: [], next_cursor: null } satisfies ListFeedbackRequestsOutput
+      }
+      return []
+    })
+    const onPageError = vi.fn()
+    const controller = createController({ transport, onPageError })
+    let state: NavigationState | undefined
+    const unsubscribe = controller.subscribe((next) => (state = next))
+
+    try {
+      await expect(controller.initialize(false)).resolves.toBe(true)
+      transport.failReadiness = true
+      await expect(controller.initialize(false)).resolves.toBe(false)
+
+      expect(state?.hostSessions).toEqual([hostSession()])
+      expect(state?.hostSessionFactsStatus).toBe('failed')
+      expect(onPageError).toHaveBeenCalledWith('Error: authenticated session expired')
+    } finally {
+      unsubscribe()
+    }
   })
 
   it('reports when initial navigation facts could not be loaded', async () => {

--- a/apps/desktop/src/lib/workbench/navigationController.ts
+++ b/apps/desktop/src/lib/workbench/navigationController.ts
@@ -143,26 +143,23 @@ export function createNavigationController(context: NavigationControllerContext)
     context.onPageError('')
     patch({ loadingNavigation: true, loadingRequests: true })
 
-    if (!context.isTauri) {
-      if (context.previewMode) {
-        patch({
-          pendingRequests: previewFixtures.requests.filter(
-            (request) => request.status === 'waiting' || request.status === 'in_progress',
-          ),
-          requests: previewFixtures.requests,
-          hostProfiles: Object.fromEntries(
-            previewFixtures.hostProfiles.map((profile) => [profile.id, profile]),
-          ),
-        })
-        applyHostSessionFacts(previewFixtures.hostSessions, hostSessionFactsIntent)
-      } else {
-        failHostSessionFacts(hostSessionFactsIntent)
-      }
+    if (context.previewMode) {
+      patch({
+        pendingRequests: previewFixtures.requests.filter(
+          (request) => request.status === 'waiting' || request.status === 'in_progress',
+        ),
+        requests: previewFixtures.requests,
+        hostProfiles: Object.fromEntries(
+          previewFixtures.hostProfiles.map((profile) => [profile.id, profile]),
+        ),
+      })
+      applyHostSessionFacts(previewFixtures.hostSessions, hostSessionFactsIntent)
       patch({ loadingNavigation: false, loadingRequests: false })
       return true
     }
 
     try {
+      await context.transport.waitUntilReady()
       const [nextInbox, nextHostSessions, profiles] = await Promise.all([
         context.transport.call('listFeedbackInbox', undefined),
         context.transport.call('listHostSessions', undefined),
@@ -236,9 +233,11 @@ export function createNavigationController(context: NavigationControllerContext)
   function applyInboxSnapshot(nextInbox: FeedbackRequestSummary[]) {
     const arrivals = notificationTracker.observe(nextInbox)
     patch({ pendingRequests: nextInbox })
-    void invoke('set_pending_count', { count: nextInbox.length }).catch(() => {
-      // Tray updates are a convenience; the inbox remains authoritative.
-    })
+    if (context.isTauri) {
+      void invoke('set_pending_count', { count: nextInbox.length }).catch(() => {
+        // Tray updates are a native convenience; the inbox remains authoritative.
+      })
+    }
     if (arrivals.length === 0) return
 
     if (
@@ -437,7 +436,7 @@ export function createNavigationController(context: NavigationControllerContext)
     const trimmed = title.trim()
     if (!trimmed || trimmed === session.title) return
     try {
-      if (context.previewMode || !context.isTauri) {
+      if (context.previewMode) {
         replaceHostSession({ ...session, title: trimmed })
         return
       }
@@ -455,7 +454,7 @@ export function createNavigationController(context: NavigationControllerContext)
 
   async function setHostSessionPinned(session: HostSessionSummary, pinned: boolean) {
     try {
-      if (context.previewMode || !context.isTauri) {
+      if (context.previewMode) {
         replaceHostSession({
           ...session,
           pinned_at: pinned ? new Date().toISOString() : null,
@@ -482,7 +481,7 @@ export function createNavigationController(context: NavigationControllerContext)
     }
     if (context.isDirty() && !(await context.saveDraftNow())) return
     try {
-      if (!(context.previewMode || !context.isTauri)) {
+      if (!context.previewMode) {
         await context.transport.call('archiveHostSession', {
           host_id: session.host_id,
           host_session_id: session.host_session_id,
@@ -496,7 +495,7 @@ export function createNavigationController(context: NavigationControllerContext)
         patch({ selectedHostId: session.host_id, selectedHostSessionId: null })
         context.clearWorkspace()
       }
-      if (context.previewMode || !context.isTauri) {
+      if (context.previewMode) {
         applyHostSessionFacts(
           get(store).hostSessions.filter(
             (candidate) =>
@@ -516,7 +515,7 @@ export function createNavigationController(context: NavigationControllerContext)
 
   async function setHostPinned(hostId: string, pinned: boolean) {
     try {
-      if (context.previewMode || !context.isTauri) {
+      if (context.previewMode) {
         const pinnedAt = pinned ? new Date().toISOString() : null
         applyHostSessionFacts(
           get(store).hostSessions.map((session) =>

--- a/apps/desktop/src/lib/workbench/navigationPolling.test.ts
+++ b/apps/desktop/src/lib/workbench/navigationPolling.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DESKTOP_NAVIGATION_POLL_INTERVAL_MS,
+  ensureDesktopNavigationPolling,
+} from './navigationPolling'
+
+describe('ensureDesktopNavigationPolling', () => {
+  it('installs one desktop retry timer independently of initial navigation success', () => {
+    const refresh = vi.fn()
+    let scheduledCallback: (() => void) | undefined
+    const schedule = vi.fn((callback: () => void, delayMs: number) => {
+      scheduledCallback = callback
+      expect(delayMs).toBe(DESKTOP_NAVIGATION_POLL_INTERVAL_MS)
+      return 17
+    })
+
+    const timer = ensureDesktopNavigationPolling(true, undefined, schedule, refresh)
+    const sameTimer = ensureDesktopNavigationPolling(true, timer, schedule, refresh)
+    scheduledCallback?.()
+
+    expect(timer).toBe(17)
+    expect(sameTimer).toBe(17)
+    expect(schedule).toHaveBeenCalledTimes(1)
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not poll browser or preview compositions', () => {
+    const schedule = vi.fn(() => 17)
+
+    expect(ensureDesktopNavigationPolling(false, undefined, schedule, vi.fn())).toBeUndefined()
+    expect(schedule).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/workbench/navigationPolling.ts
+++ b/apps/desktop/src/lib/workbench/navigationPolling.ts
@@ -1,0 +1,11 @@
+export const DESKTOP_NAVIGATION_POLL_INTERVAL_MS = 5_000
+
+export function ensureDesktopNavigationPolling<Timer>(
+  isDesktop: boolean,
+  currentTimer: Timer | undefined,
+  schedule: (callback: () => void, delayMs: number) => Timer,
+  refresh: () => void,
+): Timer | undefined {
+  if (!isDesktop || currentTimer !== undefined) return currentTimer
+  return schedule(refresh, DESKTOP_NAVIGATION_POLL_INTERVAL_MS)
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,7 +1,7 @@
 import { mount } from 'svelte'
 
 import { initializePreferences } from './lib/preferences'
-import { UnavailableApplicationTransport } from './lib/application/unavailableApplicationTransport'
+import { createWorkbenchComposition } from './lib/application/workbenchComposition'
 import './app.css'
 
 function reportFrontendError(context: string, message: string) {
@@ -98,8 +98,18 @@ if (captureMode) {
   mount(RambleConsole, { target })
 } else {
   const { default: App } = await import('./App.svelte')
-  const applicationTransport = '__TAURI_INTERNALS__' in window
+  const isTauri = '__TAURI_INTERNALS__' in window
+  const previewMode =
+    import.meta.env.DEV &&
+    !isTauri &&
+    new URLSearchParams(window.location.search).get('preview') === 'fixtures'
+  const desktopTransport = isTauri
     ? new (await import('./lib/application/tauriApplicationTransport')).TauriApplicationTransport()
-    : new UnavailableApplicationTransport()
-  mount(App, { target, props: { applicationTransport } })
+    : undefined
+  const composition = createWorkbenchComposition({
+    environment: isTauri ? 'desktop' : 'browser',
+    previewMode,
+    desktopTransport,
+  })
+  mount(App, { target, props: composition })
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -390,7 +390,9 @@ waiting → in_progress → completed
   Origin 存在时必须 exact-match allowlist。
 - 当前统一 request body limit 为 96 MiB。
 - 当前 listener 不提供 Web 静态资源或 WebSocket。MCP SSE 不属于 Web event stream。
-- Draft revision/CAS 已存在于 application/storage 路径，但 HTTP command/query parity 尚未实现。
+- Draft revision/CAS 已存在于 application/storage 路径。可复用的 application HTTP router、浏览器
+  HTTP Application Transport Implementation 与 Tauri/HTTP conformance tests 已实现，但尚未挂载到
+  production Web Access listener；Local Integration Server 仍不暴露这些 application routes。
 - `host_id`、`host_session_id` 不是认证凭据；返回路径只保证同机、共享文件系统可见。
 
 ### TARGET：Web Access


### PR DESCRIPTION
## Summary
- add an authenticated same-origin HTTP ApplicationTransport for all 23 Workbench operations
- preserve binary attachment semantics across HTTP and Tauri boundaries
- share conformance coverage between Tauri and HTTP implementations
- select transports explicitly at the Workbench composition root without treating every browser as Preview
- preserve Desktop polling while leaving Browser reconnect to the next event-stream PR

## Security and scope
- bearer tokens are memory-only Authorization headers and cannot be redirected outside the application route
- stale leases take precedence across successful and failed body decoding
- no production Web Access listener, bootstrap credential, WebSocket, or browser native capability is introduced

## Verification
- pnpm test (288 tests)
- pnpm check
- pnpm build:web
- pnpm contracts:check
- pnpm check:terminology
- pnpm check:rust-size
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- fixed-point Standards and Spec reviews: no findings