### PR TITLE
Add browser image attachments and separate path imports

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1803,7 +1803,7 @@
     onApplyWorkspaceMutation={applyWorkspaceMutation}
     onRefreshAttachmentPreviews={attachmentController.refreshPreviews}
     onStartScreenCapture={attachmentController.startScreenCapture}
-    onImportAttachmentPaths={attachmentController.importAttachmentPaths}
+    onImportServerAttachmentPaths={attachmentController.importServerAttachmentPaths}
     onRouteDraftOperation={routeDraftOperation}
     getActiveAction={activeActionFor}
   />

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -2020,6 +2020,8 @@
             onStartScreenCapture={() => void attachmentController.startScreenCapture()}
             onImportClipboard={() => void importClipboardNow()}
             onFileSelection={attachmentController.handleFileSelection}
+            onPasteFiles={attachmentController.acceptClientFiles}
+            onPasteError={attachmentController.reportClientFileError}
             onRemoveAttachment={(attachment) => void attachmentController.removeAttachment(attachment)}
             onOpenPackage={() => void openFeedbackPackage()}
             packageActionLabel={tr(publishedFeedbackAction.label)}

--- a/apps/desktop/src/RambleConsole.svelte
+++ b/apps/desktop/src/RambleConsole.svelte
@@ -77,7 +77,10 @@
         dragActive = event.payload.type === 'enter' || event.payload.type === 'over'
         if (event.payload.type === 'drop') {
           dragActive = false
-          void send({ type: 'import-files', paths: event.payload.paths })
+          void send({
+            type: 'import-server-paths',
+            serverPaths: event.payload.paths,
+          })
         } else if (event.payload.type === 'leave') {
           dragActive = false
         }
@@ -122,7 +125,9 @@
     try {
       const selected = await open({ multiple: true, directory: false })
       const paths = selected ? (Array.isArray(selected) ? selected : [selected]) : []
-      if (paths.length > 0) await send({ type: 'import-files', paths })
+      if (paths.length > 0) {
+        await send({ type: 'import-server-paths', serverPaths: paths })
+      }
     } catch (cause) {
       errorMessage = cause instanceof Error ? cause.message : String(cause)
     } finally {

--- a/apps/desktop/src/lib/capabilities/__snapshots__/capabilities.test.ts.snap
+++ b/apps/desktop/src/lib/capabilities/__snapshots__/capabilities.test.ts.snap
@@ -32,6 +32,11 @@ exports[`capability contracts > keeps the unavailable manifest complete and immu
     "reason": "unsupported_environment",
     "source": "none",
   },
+  "imagePaste": {
+    "availability": "unavailable",
+    "reason": "unsupported_environment",
+    "source": "none",
+  },
   "notifications": {
     "availability": "unavailable",
     "reason": "unsupported_environment",

--- a/apps/desktop/src/lib/capabilities/browser/browserCapabilities.test.ts
+++ b/apps/desktop/src/lib/capabilities/browser/browserCapabilities.test.ts
@@ -5,7 +5,7 @@ import { CapabilityUnavailableError } from '../workbenchCapabilities'
 import { createBrowserWorkbenchCapabilities } from './browserCapabilities'
 
 describe('browser Workbench capabilities', () => {
-  it('advertises only the implemented browser external-link capability', async () => {
+  it('advertises the implemented external-link and image-paste capabilities', async () => {
     const open = vi.fn(() => null)
     const capabilities = createBrowserWorkbenchCapabilities({
       pageUrl: 'https://workbench.example/app',
@@ -16,7 +16,13 @@ describe('browser Workbench capabilities', () => {
       availability: 'available',
       source: 'browser',
     })
-    for (const name of CAPABILITY_NAMES.filter((name) => name !== 'externalLinks')) {
+    expect(capabilities.manifest.imagePaste).toEqual({
+      availability: 'available',
+      source: 'browser',
+    })
+    for (const name of CAPABILITY_NAMES.filter(
+      (name) => name !== 'externalLinks' && name !== 'imagePaste',
+    )) {
       expect(capabilities.manifest[name]).toEqual({
         availability: 'unavailable',
         source: 'none',

--- a/apps/desktop/src/lib/capabilities/browser/browserCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/browser/browserCapabilities.ts
@@ -6,6 +6,7 @@ import {
   type WorkbenchCapabilities,
 } from '../workbenchCapabilities'
 import { createUnavailableWorkbenchCapabilities } from '../unavailableCapabilities'
+import { createBrowserImagePasteCapability } from './imagePasteCapability'
 
 export type BrowserWindowOpen = (
   url?: string | URL,
@@ -42,9 +43,9 @@ export function createBrowserExternalLinkCapability(
 }
 
 /**
- * Browser registry for WEB-7. Only an ordinary external link is implemented;
- * native paths, capture, clipboard, speech, and desktop administration remain
- * explicitly unavailable until their focused browser capabilities exist.
+ * Browser registry. Ordinary external links and DOM-scoped image paste are
+ * available; native paths, native capture, speech, and Desktop administration
+ * remain explicitly unavailable.
  */
 export function createBrowserWorkbenchCapabilities(
   environment: BrowserCapabilityEnvironment = browserEnvironment(),
@@ -54,6 +55,7 @@ export function createBrowserWorkbenchCapabilities(
   return createWorkbenchCapabilities({
     ...slots,
     externalLinks: browserSlot(createBrowserExternalLinkCapability(environment)),
+    imagePaste: browserSlot(createBrowserImagePasteCapability()),
   })
 }
 

--- a/apps/desktop/src/lib/capabilities/browser/imagePasteCapability.test.ts
+++ b/apps/desktop/src/lib/capabilities/browser/imagePasteCapability.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ClientAttachmentFile } from '../clientAttachmentFile'
+import { createBrowserImagePasteCapability } from './imagePasteCapability'
+
+type PasteEventFixture = Event & {
+  clipboardData: {
+    items: Array<{ kind: string; type: string; getAsFile: () => File | null }>
+    files: File[]
+  }
+}
+
+function file(name: string, type: string, bytes = [1, 2, 3]): File {
+  return new File([new Uint8Array(bytes)], name, { type, lastModified: 123 })
+}
+
+function pasteEvent(input: {
+  items?: PasteEventFixture['clipboardData']['items']
+  files?: File[]
+}): PasteEventFixture {
+  const event = new Event('paste', { bubbles: true, cancelable: true }) as PasteEventFixture
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      items: input.items ?? [],
+      files: input.files ?? [],
+    },
+  })
+  return event
+}
+
+describe('browser image-paste capability', () => {
+  it('uses image items before files, deduplicates them, and owns accepted mixed image and text paste', async () => {
+    const target = new EventTarget()
+    const image = file('screen.png', 'image/png')
+    const fallback = file('fallback.png', 'image/png', [4])
+    const handler = vi.fn((_files: readonly ClientAttachmentFile[]) => true)
+
+    const unsubscribe = createBrowserImagePasteCapability().subscribe(
+      target,
+      handler,
+      vi.fn(),
+    )
+    const event = pasteEvent({
+      items: [
+        { kind: 'file', type: 'image/png', getAsFile: () => image },
+        { kind: 'file', type: 'image/png', getAsFile: () => image },
+        { kind: 'string', type: 'text/plain', getAsFile: () => null },
+      ],
+      files: [fallback],
+    })
+    const stopPropagation = vi.spyOn(event, 'stopPropagation')
+
+    target.dispatchEvent(event)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    const [files] = handler.mock.calls[0]!
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatchObject({
+      fileName: 'screen.png',
+      mediaType: 'image/png',
+      byteLength: 3,
+    })
+    expect(files[0]).not.toHaveProperty('path')
+    await expect(files[0]!.readBytes()).resolves.toEqual(new Uint8Array([1, 2, 3]).buffer)
+    expect(event.defaultPrevented).toBe(true)
+    expect(stopPropagation).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    target.dispatchEvent(pasteEvent({ files: [image] }))
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to clipboard files and leaves rejected image paste untouched', () => {
+    const target = new EventTarget()
+    const image = file('fallback.png', 'image/png')
+    const handler = vi.fn((_files: readonly ClientAttachmentFile[]) => false)
+    const bubbleListener = vi.fn()
+    target.addEventListener('paste', bubbleListener)
+    createBrowserImagePasteCapability().subscribe(target, handler, vi.fn())
+    const event = pasteEvent({ files: [image, file('notes.txt', 'text/plain')] })
+
+    target.dispatchEvent(event)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0]![0]).toHaveLength(1)
+    expect(event.defaultPrevented).toBe(false)
+    expect(bubbleListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves ordinary text paste untouched and reports extraction failures without intercepting', () => {
+    const target = new EventTarget()
+    const handler = vi.fn((_files: readonly ClientAttachmentFile[]) => true)
+    const onError = vi.fn()
+    const bubbleListener = vi.fn()
+    target.addEventListener('paste', bubbleListener)
+    createBrowserImagePasteCapability().subscribe(target, handler, onError)
+
+    const textEvent = pasteEvent({
+      items: [{ kind: 'string', type: 'text/plain', getAsFile: () => null }],
+    })
+    target.dispatchEvent(textEvent)
+    const failedEvent = pasteEvent({
+      items: [{ kind: 'file', type: 'image/png', getAsFile: () => { throw new Error('clipboard failed') } }],
+    })
+    target.dispatchEvent(failedEvent)
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(textEvent.defaultPrevented).toBe(false)
+    expect(failedEvent.defaultPrevented).toBe(false)
+    expect(bubbleListener).toHaveBeenCalledTimes(2)
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'clipboard failed' }))
+  })
+})

--- a/apps/desktop/src/lib/capabilities/browser/imagePasteCapability.ts
+++ b/apps/desktop/src/lib/capabilities/browser/imagePasteCapability.ts
@@ -1,0 +1,53 @@
+import {
+  clientAttachmentFile,
+  type ClientAttachmentFile,
+} from '../clientAttachmentFile'
+import type { ImagePasteCapability } from '../workbenchCapabilities'
+
+export function createBrowserImagePasteCapability(): ImagePasteCapability {
+  return {
+    subscribe(target, handler, onError) {
+      let active = true
+      const listener = (event: Event) => {
+        if (!active) return
+        try {
+          const files = pastedImageFiles(event)
+          if (files.length === 0 || !handler(files)) return
+          event.preventDefault()
+          event.stopPropagation()
+        } catch (cause) {
+          onError(cause)
+        }
+      }
+      target.addEventListener('paste', listener, true)
+      return () => {
+        if (!active) return
+        active = false
+        target.removeEventListener('paste', listener, true)
+      }
+    },
+  }
+}
+
+function pastedImageFiles(event: Event): readonly ClientAttachmentFile[] {
+  if (!('clipboardData' in event)) return []
+  const clipboardData = (event as ClipboardEvent).clipboardData
+  if (!clipboardData) return []
+
+  const itemFiles = uniqueFiles(
+    Array.from(clipboardData.items)
+      .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => file !== null),
+  )
+  const files = itemFiles.length > 0
+    ? itemFiles
+    : uniqueFiles(
+        Array.from(clipboardData.files).filter((file) => file.type.startsWith('image/')),
+      )
+  return files.map(clientAttachmentFile)
+}
+
+function uniqueFiles(files: readonly File[]): File[] {
+  return [...new Set(files)]
+}

--- a/apps/desktop/src/lib/capabilities/capabilityManifest.ts
+++ b/apps/desktop/src/lib/capabilities/capabilityManifest.ts
@@ -30,6 +30,7 @@ export const CAPABILITY_NAMES = [
   'externalLinks',
   'screenCapture',
   'clipboardCapture',
+  'imagePaste',
   'serverPaths',
   'globalShortcuts',
   'speech',

--- a/apps/desktop/src/lib/capabilities/clientAttachmentFile.ts
+++ b/apps/desktop/src/lib/capabilities/clientAttachmentFile.ts
@@ -1,0 +1,25 @@
+export type ClientAttachmentFile = Readonly<{
+  fileName: string
+  mediaType: string
+  byteLength: number
+  readBytes: () => Promise<ArrayBuffer>
+}>
+
+export type ClientAttachmentFileSource = Readonly<{
+  name: string
+  type: string
+  size: number
+  arrayBuffer: () => Promise<ArrayBuffer>
+}>
+
+/** A Client-local file projection. It deliberately cannot carry a Server path. */
+export function clientAttachmentFile(
+  file: ClientAttachmentFileSource,
+): ClientAttachmentFile {
+  return Object.freeze({
+    fileName: file.name,
+    mediaType: file.type,
+    byteLength: file.size,
+    readBytes: () => file.arrayBuffer(),
+  })
+}

--- a/apps/desktop/src/lib/capabilities/tauri/captureCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/captureCapabilities.ts
@@ -15,32 +15,7 @@ export function createTauriScreenCaptureCapability(
       subscribeToTauriEvent(api, 'screen-capture-finished', handler, onError),
     onShortcut: (handler, onError) =>
       subscribeToTauriEvent(api, 'screen-capture-shortcut', handler, onError),
-    onFileDrop(handler, onError) {
-      let active = true
-      let unlisten: (() => void) | undefined
-      void api
-        .currentWebview()
-        .onDragDropEvent(({ payload }) => handler(payload))
-        .then((nextUnlisten) => {
-          if (active) unlisten = nextUnlisten
-          else nextUnlisten()
-        })
-        .catch((cause) => {
-          if (active) onError(cause)
-        })
-      return () => {
-        if (!active) return
-        active = false
-        unlisten?.()
-      }
-    },
     begin: () => api.invoke<void>('begin_screen_capture'),
-    importServerPath: (input) =>
-      api.invoke('import_feedback_attachment_path', {
-        requestId: input.requestId,
-        path: input.path,
-        expectedRevision: input.expectedRevision,
-      }),
     complete: (input) =>
       api.invoke('add_completed_screen_capture', {
         requestId: input.requestId,

--- a/apps/desktop/src/lib/capabilities/tauri/index.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/index.ts
@@ -4,6 +4,7 @@ import {
   type CapabilitySlot,
   type WorkbenchCapabilities,
 } from '../workbenchCapabilities'
+import { createBrowserImagePasteCapability } from '../browser/imagePasteCapability'
 import {
   createTauriDataStorageCapability,
   createTauriDiagnosticsCapability,
@@ -36,10 +37,21 @@ const NATIVE_AVAILABLE: CapabilityStatus = Object.freeze({
   source: 'native',
 })
 
+const BROWSER_AVAILABLE: CapabilityStatus = Object.freeze({
+  availability: 'available',
+  source: 'browser',
+})
+
 function nativeSlot<Implementation>(
   implementation: Implementation,
 ): CapabilitySlot<Implementation> {
   return Object.freeze({ status: NATIVE_AVAILABLE, implementation })
+}
+
+function browserSlot<Implementation>(
+  implementation: Implementation,
+): CapabilitySlot<Implementation> {
+  return Object.freeze({ status: BROWSER_AVAILABLE, implementation })
 }
 
 /** Creates the executable Desktop capability registry; its manifest is derived from these slots. */
@@ -53,6 +65,7 @@ export function createTauriWorkbenchCapabilities(
     externalLinks: nativeSlot(createTauriExternalLinkCapability(api)),
     screenCapture: nativeSlot(createTauriScreenCaptureCapability(api)),
     clipboardCapture: nativeSlot(createTauriClipboardCaptureCapability(api)),
+    imagePaste: browserSlot(createBrowserImagePasteCapability()),
     serverPaths: nativeSlot(createTauriServerPathCapability(api)),
     globalShortcuts: nativeSlot(createTauriShortcutCapability(api)),
     speech: nativeSlot(createTauriSpeechCapability(api)),

--- a/apps/desktop/src/lib/capabilities/tauri/navigationCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/navigationCapabilities.ts
@@ -45,6 +45,31 @@ export function createTauriServerPathCapability(
       api.invoke<string>('reveal_feedback_attachment', {
         input: attachmentInput(input),
       }),
+    onFileDrop(handler, onError) {
+      let active = true
+      let unlisten: (() => void) | undefined
+      void api
+        .currentWebview()
+        .onDragDropEvent(({ payload }) => handler(payload))
+        .then((nextUnlisten) => {
+          if (active) unlisten = nextUnlisten
+          else nextUnlisten()
+        })
+        .catch((cause) => {
+          if (active) onError(cause)
+        })
+      return () => {
+        if (!active) return
+        active = false
+        unlisten?.()
+      }
+    },
+    importAttachmentPath: (input) =>
+      api.invoke('import_feedback_attachment_path', {
+        requestId: input.requestId,
+        path: input.path,
+        expectedRevision: input.expectedRevision,
+      }),
   }
 }
 

--- a/apps/desktop/src/lib/capabilities/tauri/tauriCapabilities.test.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/tauriCapabilities.test.ts
@@ -67,11 +67,14 @@ function createFakeApi(responses: Record<string, unknown> = {}): FakeApi {
 }
 
 describe('Tauri Workbench capabilities', () => {
-  it('derives a complete native manifest from executable slots', () => {
+  it('derives native slots plus the shared browser image-paste slot', () => {
     const capabilities = createTauriWorkbenchCapabilities(createFakeApi())
     expect(Object.keys(capabilities.manifest).sort()).toEqual([...CAPABILITY_NAMES].sort())
     for (const name of CAPABILITY_NAMES) {
-      expect(capabilities[name].status).toEqual({ availability: 'available', source: 'native' })
+      expect(capabilities[name].status).toEqual({
+        availability: 'available',
+        source: name === 'imagePaste' ? 'browser' : 'native',
+      })
       expect(capabilities.manifest[name]).toEqual(capabilities[name].status)
     }
   })

--- a/apps/desktop/src/lib/capabilities/tauri/tauriCapabilities.test.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/tauriCapabilities.test.ts
@@ -31,7 +31,13 @@ function fakeWindow() {
 }
 
 function fakeWebview() {
-  return { onDragDropEvent: vi.fn(async () => vi.fn()) }
+  return {
+    onDragDropEvent: vi.fn(
+      async (
+        _handler: Parameters<ReturnType<TauriCapabilityApi['currentWebview']>['onDragDropEvent']>[0],
+      ): Promise<TauriUnlisten> => () => undefined,
+    ),
+  }
 }
 
 function createFakeApi(responses: Record<string, unknown> = {}): FakeApi {
@@ -134,11 +140,51 @@ describe('Tauri Workbench capabilities', () => {
     })
   })
 
-  it('maps capture and speech inputs to the existing native wire shape', async () => {
+  it('owns native file-drop subscription in the server-path implementation', async () => {
+    const api = createFakeApi()
+    const capabilities = createTauriWorkbenchCapabilities(api)
+    const handler = vi.fn()
+    const onError = vi.fn()
+    const unsubscribe = capabilities.serverPaths.implementation.onFileDrop(handler, onError)
+    await vi.waitFor(() => expect(api.webview.onDragDropEvent).toHaveBeenCalledOnce())
+    const listener = api.webview.onDragDropEvent.mock.calls[0]?.[0] as
+      | ((event: TauriEvent<{ type: 'drop'; paths: string[] }>) => void)
+      | undefined
+
+    listener?.({ payload: { type: 'drop', paths: ['/tmp/notes.txt'] } })
+
+    expect(handler).toHaveBeenCalledWith({ type: 'drop', paths: ['/tmp/notes.txt'] })
+    expect(onError).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('cancels a server-path file-drop subscription before async registration completes', async () => {
+    const lateUnlisten = vi.fn()
+    let resolveDrop: ((unlisten: TauriUnlisten) => void) | undefined
+    const api = createFakeApi()
+    api.webview.onDragDropEvent.mockImplementationOnce(
+      () => new Promise<TauriUnlisten>((resolve) => (resolveDrop = resolve)),
+    )
+    const capabilities = createTauriWorkbenchCapabilities(api)
+    const onError = vi.fn()
+
+    const unsubscribe = capabilities.serverPaths.implementation.onFileDrop(
+      vi.fn(),
+      onError,
+    )
+    unsubscribe()
+    resolveDrop?.(lateUnlisten)
+    await Promise.resolve()
+
+    expect(lateUnlisten).toHaveBeenCalledOnce()
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('maps server-path import, capture, and speech inputs to the existing native wire shape', async () => {
     const api = createFakeApi()
     const capabilities = createTauriWorkbenchCapabilities(api)
 
-    await capabilities.screenCapture.implementation.importServerPath({
+    await capabilities.serverPaths.implementation.importAttachmentPath({
       requestId: 'request-1',
       path: '/tmp/example.png',
       expectedRevision: 7,

--- a/apps/desktop/src/lib/capabilities/unavailableCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/unavailableCapabilities.ts
@@ -74,6 +74,10 @@ const UNAVAILABLE_WORKBENCH_CAPABILITIES = createWorkbenchCapabilities({
     completeImage: () => rejected('clipboardCapture'),
     discardImage: () => rejected('clipboardCapture'),
   }),
+  imagePaste: slot({
+    subscribe: (_target, _handler, onError) =>
+      unavailableSubscription('imagePaste', onError),
+  }),
   serverPaths: slot({
     chooseDirectory: () => rejected('serverPaths'),
     chooseFile: () => rejected('serverPaths'),

--- a/apps/desktop/src/lib/capabilities/unavailableCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/unavailableCapabilities.ts
@@ -63,9 +63,7 @@ const UNAVAILABLE_WORKBENCH_CAPABILITIES = createWorkbenchCapabilities({
     onReady: (_handler, onError) => unavailableSubscription('screenCapture', onError),
     onFinished: (_handler, onError) => unavailableSubscription('screenCapture', onError),
     onShortcut: (_handler, onError) => unavailableSubscription('screenCapture', onError),
-    onFileDrop: (_handler, onError) => unavailableSubscription('screenCapture', onError),
     begin: () => rejected('screenCapture'),
-    importServerPath: () => rejected('screenCapture'),
     complete: () => rejected('screenCapture'),
     discard: () => rejected('screenCapture'),
   }),
@@ -85,6 +83,8 @@ const UNAVAILABLE_WORKBENCH_CAPABILITIES = createWorkbenchCapabilities({
     reveal: () => rejected('serverPaths'),
     openAttachment: () => rejected('serverPaths'),
     revealAttachment: () => rejected('serverPaths'),
+    onFileDrop: (_handler, onError) => unavailableSubscription('serverPaths', onError),
+    importAttachmentPath: () => rejected('serverPaths'),
   }),
   globalShortcuts: slot({
     read: () => rejected('globalShortcuts'),

--- a/apps/desktop/src/lib/capabilities/workbenchCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/workbenchCapabilities.ts
@@ -6,6 +6,7 @@ import type { RambleConsoleCommand, RambleConsoleState } from '$lib/rambleConsol
 import type { ScreenCaptureReady } from '$lib/screenCapture'
 import type { ShortcutAction, ShortcutConfig } from '$lib/shortcutSettings'
 import type { SpeechEvent, VoiceRambleSessionView } from '$lib/speech'
+import type { ClientAttachmentFile } from './clientAttachmentFile'
 
 import {
   capabilityManifest,
@@ -136,6 +137,14 @@ export interface ClipboardCaptureCapability {
     expectedRevision: number
   }>): Promise<FeedbackWorkspaceView>
   discardImage(captureId: string): Promise<void>
+}
+
+export interface ImagePasteCapability {
+  subscribe(
+    target: EventTarget,
+    handler: (files: readonly ClientAttachmentFile[]) => boolean,
+    onError: CapabilityErrorHandler,
+  ): CapabilityUnsubscribe
 }
 
 export interface ShortcutCapability {
@@ -300,6 +309,7 @@ export type WorkbenchCapabilitySlots = Readonly<{
   externalLinks: CapabilitySlot<ExternalLinkCapability>
   screenCapture: CapabilitySlot<ScreenCaptureCapability>
   clipboardCapture: CapabilitySlot<ClipboardCaptureCapability>
+  imagePaste: CapabilitySlot<ImagePasteCapability>
   serverPaths: CapabilitySlot<ServerPathCapability>
   globalShortcuts: CapabilitySlot<ShortcutCapability>
   speech: CapabilitySlot<SpeechCapability & SpeechAdministrationCapability>

--- a/apps/desktop/src/lib/capabilities/workbenchCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/workbenchCapabilities.ts
@@ -86,6 +86,15 @@ export interface ServerPathCapability {
     attachmentId: string
     kind: 'request' | 'workspace'
   }>): Promise<string>
+  onFileDrop(
+    handler: (event: NativeFileDropEvent) => void,
+    onError: CapabilityErrorHandler,
+  ): CapabilityUnsubscribe
+  importAttachmentPath(input: Readonly<{
+    requestId: string
+    path: string
+    expectedRevision: number
+  }>): Promise<FeedbackWorkspaceView>
 }
 
 export type CaptureFinished = Readonly<{
@@ -106,16 +115,7 @@ export interface ScreenCaptureCapability {
     onError: CapabilityErrorHandler,
   ): CapabilityUnsubscribe
   onShortcut(handler: () => void, onError: CapabilityErrorHandler): CapabilityUnsubscribe
-  onFileDrop(
-    handler: (event: NativeFileDropEvent) => void,
-    onError: CapabilityErrorHandler,
-  ): CapabilityUnsubscribe
   begin(): Promise<void>
-  importServerPath(input: Readonly<{
-    requestId: string
-    path: string
-    expectedRevision: number
-  }>): Promise<FeedbackWorkspaceView>
   complete(input: Readonly<{
     requestId: string
     captureSessionId: string

--- a/apps/desktop/src/lib/rambleConsole.ts
+++ b/apps/desktop/src/lib/rambleConsole.ts
@@ -28,5 +28,5 @@ export type RambleConsoleCommand =
   | { type: 'toggle-recording' }
   | { type: 'capture-screen' }
   | { type: 'import-clipboard' }
-  | { type: 'import-files'; paths: string[] }
+  | { type: 'import-server-paths'; serverPaths: string[] }
   | { type: 'exit' }

--- a/apps/desktop/src/lib/workbench/RambleSessionController.svelte
+++ b/apps/desktop/src/lib/workbench/RambleSessionController.svelte
@@ -64,7 +64,7 @@
   export let onApplyWorkspaceMutation: (next: FeedbackWorkspaceView) => void = () => {}
   export let onRefreshAttachmentPreviews: (next: FeedbackWorkspaceView) => Promise<void> = async () => {}
   export let onStartScreenCapture: () => Promise<void> = async () => {}
-  export let onImportAttachmentPaths: (paths: string[]) => Promise<void> = async () => {}
+  export let onImportServerAttachmentPaths: (paths: string[]) => Promise<void> = async () => {}
   export let onRouteDraftOperation: (requestId: string, operation: DraftOperation) => Promise<void> = async () => {}
   export let getActiveAction: (requestId: string) => ActiveAction = () => null
 
@@ -541,8 +541,10 @@
       case 'import-clipboard':
         await importClipboardNow()
         break
-      case 'import-files':
-        if (!interactionLocked) await onImportAttachmentPaths(command.paths)
+      case 'import-server-paths':
+        if (!interactionLocked) {
+          await onImportServerAttachmentPaths(command.serverPaths)
+        }
         break
       case 'exit':
         await exitRamble()

--- a/apps/desktop/src/lib/workbench/SessionWorkbench.svelte
+++ b/apps/desktop/src/lib/workbench/SessionWorkbench.svelte
@@ -5,6 +5,7 @@
   import { Skeleton } from '$lib/components/ui/skeleton'
   import type { JSONContent } from '@tiptap/core'
   import type { ApplicationTransport } from '$lib/application/applicationTransport'
+  import type { ClientAttachmentFile } from '$lib/capabilities/clientAttachmentFile'
   import type { WorkbenchCapabilities } from '$lib/capabilities/workbenchCapabilities'
 
   import type {
@@ -35,12 +36,18 @@
   import RequestAttachmentPreview from './RequestAttachmentPreview.svelte'
   import TaskBriefPanel from './TaskBriefPanel.svelte'
   import WorkspaceHeader from './WorkspaceHeader.svelte'
+  import { canAcceptImagePaste } from './imagePasteAcceptance'
 
   export let loadingWorkspace = false
   export let transport: ApplicationTransport
   export let capabilities: Pick<
     WorkbenchCapabilities,
-    'serverPaths' | 'speech' | 'rambleConsole' | 'screenCapture' | 'clipboardCapture'
+    | 'serverPaths'
+    | 'speech'
+    | 'rambleConsole'
+    | 'screenCapture'
+    | 'clipboardCapture'
+    | 'imagePaste'
   >
   export let view: SessionViewDescriptor | null = null
   export let workspace: FeedbackWorkspaceView | null = null
@@ -99,6 +106,8 @@
   export let onStartScreenCapture: () => void = () => {}
   export let onImportClipboard: () => void = () => {}
   export let onFileSelection: (event: Event) => void = () => {}
+  export let onPasteFiles: (files: readonly ClientAttachmentFile[]) => boolean = () => false
+  export let onPasteError: (cause: unknown) => void = () => {}
   export let onRemoveAttachment: (attachment: AttachmentView) => void = () => {}
   export let onOpenPackage: () => void = () => {}
   export let packageActionLabel = 'Open feedback package'
@@ -124,6 +133,7 @@
   let documentPaneGroup: { setLayout: (layout: number[]) => void } | undefined
   let documentLayoutReady = false
   let autoOpenedTaskRequestId = ''
+  let workspaceRoot: HTMLElement
 
   $: if (taskBriefPane) {
     if (taskBriefOpen && taskBriefPane.isCollapsed()) taskBriefPane.expand()
@@ -146,11 +156,28 @@
   }
 
   onMount(() => {
+    const imagePaste = capabilities.imagePaste
+    const unsubscribePaste = imagePaste.status.availability === 'unavailable'
+      ? undefined
+      : imagePaste.implementation.subscribe(
+          workspaceRoot,
+          (files) => {
+            if (!canAcceptImagePaste({
+              loadingWorkspace,
+              requestStatus: workspace?.request.status ?? null,
+              interactionLocked,
+              attachmentBusy,
+            })) return false
+            return onPasteFiles(files)
+          },
+          onPasteError,
+        )
     void tick().then(() => {
       if (!documentPaneGroup) return
       documentLayoutReady = true
       if (savedDocumentLayout) documentPaneGroup.setLayout(savedDocumentLayout)
     })
+    return () => unsubscribePaste?.()
   })
 
   function tr(source: string, values: Record<string, string | number> = {}) {
@@ -192,6 +219,7 @@
 </script>
 
 <section
+  bind:this={workspaceRoot}
   class="workspace-panel relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background"
   data-workspace-view-key={view ? workspaceViewKey(view) : undefined}
 >

--- a/apps/desktop/src/lib/workbench/attachmentController.test.ts
+++ b/apps/desktop/src/lib/workbench/attachmentController.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
 
 import { createAttachmentController } from './attachmentController'
 import { TestApplicationTransport } from '../application/testApplicationTransport'
+import { clientAttachmentFile } from '../capabilities/clientAttachmentFile'
 import { createUnavailableWorkbenchCapabilities } from '../capabilities/unavailableCapabilities'
 import type { WorkbenchCapabilities } from '../capabilities/workbenchCapabilities'
 import type { ScreenCaptureReady } from '../screenCapture'
@@ -51,13 +52,6 @@ function availableCapabilities(): Pick<WorkbenchCapabilities, 'screenCapture' | 
         restart: mocks.restart,
       },
     },
-  }
-}
-
-function browserCapabilities(): Pick<WorkbenchCapabilities, 'screenCapture' | 'windowControls'> {
-  return {
-    screenCapture: unavailableCapabilities.screenCapture,
-    windowControls: unavailableCapabilities.windowControls,
   }
 }
 
@@ -128,13 +122,127 @@ describe('attachmentController screen capture state', () => {
     vi.unstubAllGlobals()
   })
 
-  it('does not claim browser image-paste support before the browser capability lands', () => {
+  it('never registers a global paste listener', () => {
     const { context } = controllerContext()
-    context.capabilities = browserCapabilities()
     const dispose = createAttachmentController(context).mount()
 
     expect(window.addEventListener).not.toHaveBeenCalledWith('paste', expect.any(Function))
     dispose()
+  })
+
+  it.each([
+    ['missing workspace', null, false, false],
+    ['completed workspace', 'completed', false, false],
+    ['cancelled workspace', 'cancelled', false, false],
+    ['locked workspace', 'in_progress', true, false],
+    ['busy workspace', 'in_progress', false, true],
+  ] as const)('rejects pasted files synchronously for a %s', (_label, status, locked, busy) => {
+    const { context } = controllerContext()
+    context.getWorkspace = () => status === null
+      ? null
+      : ({ request: { request_id: 'request-1', status }, attachments: [], draft: { saved_revision: 1 } }) as never
+    context.getInteractionLocked = () => locked
+    context.getBusy = () => busy
+    const source = clientAttachmentFile({
+      name: 'screen.png',
+      type: 'image/png',
+      size: 1,
+      arrayBuffer: async () => new Uint8Array([1]).buffer,
+    })
+
+    expect(createAttachmentController(context).acceptClientFiles([source])).toBe(false)
+    expect(context.saveDraftNow).not.toHaveBeenCalled()
+  })
+
+  it('accepts an editable pasted file synchronously and reuses the attachment upload flow', async () => {
+    const workspace = {
+      request: { request_id: 'request-1', status: 'in_progress' },
+      attachments: [],
+      draft: { saved_revision: 3 },
+    }
+    const inserted = {
+      ...workspace,
+      draft: { saved_revision: 4 },
+      attachments: [
+        { attachment_id: 'att-1', file_name: 'screen.png', media_type: 'application/octet-stream' },
+      ],
+    }
+    const { context } = controllerContext()
+    context.getWorkspace = () => workspace as never
+    mocks.applicationCall.mockImplementation(async (command: string) => {
+      if (command === 'getFeedbackWorkspace') return workspace
+      if (command === 'addFeedbackAttachment') return inserted
+      return undefined
+    })
+    const source = clientAttachmentFile({
+      name: 'screen.png',
+      type: 'image/png',
+      size: 3,
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    })
+    const controller = createAttachmentController(context)
+
+    expect(controller.acceptClientFiles([source])).toBe(true)
+    expect(controller.acceptClientFiles([source])).toBe(false)
+
+    await vi.waitFor(() => {
+      expect(mocks.applicationCall).toHaveBeenCalledWith('addFeedbackAttachment', {
+        request_id: 'request-1',
+        file_name: 'screen.png',
+        contents: new Uint8Array([1, 2, 3]).buffer,
+        expected_revision: 3,
+      })
+    })
+    await vi.waitFor(() => expect(context.routeDraftOperation).toHaveBeenCalled())
+  })
+
+  it('allows exactly 20 MiB and rejects larger client files before reading bytes', async () => {
+    const workspace = {
+      request: { request_id: 'request-1', status: 'in_progress' },
+      attachments: [],
+      draft: { saved_revision: 3 },
+    }
+    const { context } = controllerContext()
+    context.getWorkspace = () => workspace as never
+    context.tr = (source, values) => source.replace('{name}', String(values?.name ?? ''))
+    mocks.applicationCall.mockImplementation(async (command: string) => {
+      if (command === 'getFeedbackWorkspace' || command === 'addFeedbackAttachment') {
+        return workspace
+      }
+      return undefined
+    })
+    const exactRead = vi.fn(async () => new ArrayBuffer(0))
+    const tooLargeRead = vi.fn(async () => new ArrayBuffer(0))
+    const controller = createAttachmentController(context)
+
+    await controller.importClientFiles([{
+      fileName: 'exact.png',
+      mediaType: 'image/png',
+      byteLength: 20 * 1024 * 1024,
+      readBytes: exactRead,
+    }])
+    expect(exactRead).toHaveBeenCalledOnce()
+    expect(mocks.applicationCall).toHaveBeenCalledWith(
+      'addFeedbackAttachment',
+      expect.objectContaining({ file_name: 'exact.png' }),
+    )
+
+    mocks.applicationCall.mockClear()
+    await controller.importClientFiles([{
+      fileName: 'too-large.png',
+      mediaType: 'image/png',
+      byteLength: 20 * 1024 * 1024 + 1,
+      readBytes: tooLargeRead,
+    }])
+    expect(tooLargeRead).not.toHaveBeenCalled()
+    expect(mocks.applicationCall).not.toHaveBeenCalledWith(
+      'addFeedbackAttachment',
+      expect.anything(),
+    )
+    expect(context.setMessage).toHaveBeenCalledWith(
+      expect.stringContaining('too-large.png exceeds the 20 MiB limit'),
+      'error',
+    )
   })
 
   it('keeps capture busy until the capture finishes and blocks duplicate starts', async () => {
@@ -331,13 +439,14 @@ describe('attachmentController screen capture state', () => {
       if (command === 'addFeedbackAttachment') return inserted
       return undefined
     })
-    const file = {
+    const file = clientAttachmentFile({
       name: 'notes.txt',
+      type: 'text/plain',
       size: 4,
       arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
-    } as File
+    })
 
-    await createAttachmentController(context).importFiles([file])
+    await createAttachmentController(context).importClientFiles([file])
 
     expect(context.routeDraftOperation).toHaveBeenCalledWith(
       'request-1',

--- a/apps/desktop/src/lib/workbench/attachmentController.test.ts
+++ b/apps/desktop/src/lib/workbench/attachmentController.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   beginCapture: vi.fn(),
   completeCapture: vi.fn(),
   discardCapture: vi.fn(),
-  importServerPath: vi.fn(),
+  importAttachmentPath: vi.fn(),
   leaveFullscreen: vi.fn(),
   restart: vi.fn(),
   listeners: new Map<string, (payload: unknown) => void>(),
@@ -20,7 +20,10 @@ import type { ScreenCaptureReady } from '../screenCapture'
 
 const unavailableCapabilities = createUnavailableWorkbenchCapabilities()
 
-function availableCapabilities(): Pick<WorkbenchCapabilities, 'screenCapture' | 'windowControls'> {
+function availableCapabilities(): Pick<
+  WorkbenchCapabilities,
+  'screenCapture' | 'serverPaths' | 'windowControls'
+> {
   return {
     screenCapture: {
       status: { availability: 'available', source: 'native' },
@@ -34,14 +37,20 @@ function availableCapabilities(): Pick<WorkbenchCapabilities, 'screenCapture' | 
           mocks.listeners.set('screen-capture-finished', handler as (payload: unknown) => void)
           return vi.fn()
         },
+        begin: mocks.beginCapture,
+        complete: mocks.completeCapture,
+        discard: mocks.discardCapture,
+      },
+    },
+    serverPaths: {
+      status: { availability: 'available', source: 'native' },
+      implementation: {
+        ...unavailableCapabilities.serverPaths.implementation,
         onFileDrop: (handler) => {
           mocks.listeners.set('file-drop', handler as (payload: unknown) => void)
           return vi.fn()
         },
-        begin: mocks.beginCapture,
-        importServerPath: mocks.importServerPath,
-        complete: mocks.completeCapture,
-        discard: mocks.discardCapture,
+        importAttachmentPath: mocks.importAttachmentPath,
       },
     },
     windowControls: {
@@ -106,7 +115,7 @@ describe('attachmentController screen capture state', () => {
     mocks.completeCapture.mockReset()
     mocks.discardCapture.mockReset()
     mocks.discardCapture.mockResolvedValue(undefined)
-    mocks.importServerPath.mockReset()
+    mocks.importAttachmentPath.mockReset()
     mocks.leaveFullscreen.mockReset()
     mocks.leaveFullscreen.mockResolvedValue(undefined)
     mocks.restart.mockReset()
@@ -127,6 +136,46 @@ describe('attachmentController screen capture state', () => {
     const dispose = createAttachmentController(context).mount()
 
     expect(window.addEventListener).not.toHaveBeenCalledWith('paste', expect.any(Function))
+    dispose()
+  })
+
+  it('subscribes and imports file drops when server paths are available without screen capture', async () => {
+    const workspace = {
+      request: { request_id: 'request-1', status: 'in_progress' },
+      attachments: [],
+      draft: { saved_revision: 1 },
+    }
+    const inserted = {
+      ...workspace,
+      draft: { saved_revision: 2 },
+      attachments: [
+        { attachment_id: 'att-1', file_name: 'notes.txt', media_type: 'text/plain' },
+      ],
+    }
+    const { context } = controllerContext()
+    context.capabilities = {
+      ...context.capabilities,
+      screenCapture: unavailableCapabilities.screenCapture,
+    }
+    context.getWorkspace = () => workspace as never
+    mocks.applicationCall.mockImplementation(async (operation: string) => {
+      if (operation === 'getFeedbackWorkspace') return workspace
+      return undefined
+    })
+    mocks.importAttachmentPath.mockResolvedValue(inserted)
+
+    const dispose = createAttachmentController(context).mount()
+    expect(mocks.listeners.has('screen-capture-ready')).toBe(false)
+    expect(mocks.listeners.has('file-drop')).toBe(true)
+    mocks.listeners.get('file-drop')?.({ type: 'drop', paths: ['/tmp/notes.txt'] })
+
+    await vi.waitFor(() => {
+      expect(mocks.importAttachmentPath).toHaveBeenCalledWith({
+        requestId: 'request-1',
+        path: '/tmp/notes.txt',
+        expectedRevision: 1,
+      })
+    })
     dispose()
   })
 
@@ -273,7 +322,7 @@ describe('attachmentController screen capture state', () => {
     expect(context.saveDraftNow).toHaveBeenCalled()
   })
 
-  it('imports a native file-drop path through the screen-capture capability with CAS', async () => {
+  it('imports multiple server attachment paths with a continuing CAS revision', async () => {
     const workspace = {
       request: { request_id: 'request-1' },
       attachments: [],
@@ -286,23 +335,41 @@ describe('attachmentController screen capture state', () => {
         { attachment_id: 'att-1', file_name: 'notes.txt', media_type: 'text/plain' },
       ],
     }
+    const insertedAgain = {
+      ...inserted,
+      draft: { saved_revision: 5 },
+      attachments: [
+        ...inserted.attachments,
+        { attachment_id: 'att-2', file_name: 'other.txt', media_type: 'text/plain' },
+      ],
+    }
     const { context } = controllerContext()
     context.getWorkspace = () => workspace as never
     mocks.applicationCall.mockImplementation(async (operation: string) => {
       if (operation === 'getFeedbackWorkspace') return workspace
       return undefined
     })
-    mocks.importServerPath.mockResolvedValue(inserted)
+    mocks.importAttachmentPath
+      .mockResolvedValueOnce(inserted)
+      .mockResolvedValueOnce(insertedAgain)
 
-    await createAttachmentController(context).importAttachmentPaths(['/tmp/notes.txt'])
+    await createAttachmentController(context).importServerAttachmentPaths([
+      '/tmp/notes.txt',
+      '/tmp/other.txt',
+    ])
 
     expect(context.saveDraftNow).toHaveBeenCalled()
-    expect(mocks.importServerPath).toHaveBeenCalledWith({
+    expect(mocks.importAttachmentPath).toHaveBeenCalledWith({
       requestId: 'request-1',
       path: '/tmp/notes.txt',
       expectedRevision: 3,
     })
-    expect(context.applyWorkspaceMutation).toHaveBeenCalledWith(inserted)
+    expect(mocks.importAttachmentPath).toHaveBeenCalledWith({
+      requestId: 'request-1',
+      path: '/tmp/other.txt',
+      expectedRevision: 4,
+    })
+    expect(context.applyWorkspaceMutation).toHaveBeenLastCalledWith(insertedAgain)
   })
 
   it('clears capture busy without changing attachment busy on cancel or pin', async () => {

--- a/apps/desktop/src/lib/workbench/attachmentController.ts
+++ b/apps/desktop/src/lib/workbench/attachmentController.ts
@@ -21,7 +21,7 @@ import type { FeedbackEditorHandle } from './types'
 export type AttachmentMessageTone = 'info' | 'success' | 'error'
 
 type AttachmentControllerContext = {
-  capabilities: Pick<WorkbenchCapabilities, 'screenCapture' | 'windowControls'>
+  capabilities: Pick<WorkbenchCapabilities, 'screenCapture' | 'serverPaths' | 'windowControls'>
   transport: ApplicationTransport
   tr: (source: string, values?: Record<string, string | number>) => string
   messageFrom: (cause: unknown) => string
@@ -79,12 +79,16 @@ export function createAttachmentController(context: AttachmentControllerContext)
           // A failed cancellation listener does not affect capture or attachment storage.
         },
       )
-      dragUnlisten = screenCapture.implementation.onFileDrop(
+    }
+
+    const serverPaths = context.capabilities.serverPaths
+    if (serverPaths.status.availability !== 'unavailable') {
+      dragUnlisten = serverPaths.implementation.onFileDrop(
         (event) => {
           context.setDragActive(event.type === 'enter' || event.type === 'over')
           if (event.type === 'drop') {
             context.setDragActive(false)
-            void importAttachmentPaths(event.paths)
+            void importServerAttachmentPaths(event.paths)
           } else if (event.type === 'leave') {
             context.setDragActive(false)
           }
@@ -192,7 +196,7 @@ export function createAttachmentController(context: AttachmentControllerContext)
     context.setMessage(context.messageFrom(cause), 'error')
   }
 
-  async function importAttachmentPaths(paths: readonly string[]) {
+  async function importServerAttachmentPaths(paths: readonly string[]) {
     const workspace = context.getWorkspace()
     const requestId = context.getRambleRequestId() || workspace?.request.request_id || ''
     if (context.getInteractionLocked() || !requestId || paths.length === 0 || context.getBusy()) return
@@ -207,7 +211,7 @@ export function createAttachmentController(context: AttachmentControllerContext)
       if (!next) throw new Error(context.tr('This feedback request could not be found.'))
       const existingIds = new Set(next.attachments.map((item) => item.attachment_id))
       for (const path of paths) {
-        next = await context.capabilities.screenCapture.implementation.importServerPath({
+        next = await context.capabilities.serverPaths.implementation.importAttachmentPath({
           requestId,
           path,
           expectedRevision: next.draft.saved_revision,
@@ -470,7 +474,7 @@ export function createAttachmentController(context: AttachmentControllerContext)
     acceptClientFiles,
     importClientFiles,
     reportClientFileError,
-    importAttachmentPaths,
+    importServerAttachmentPaths,
     startScreenCapture,
     removeAttachment,
     insertExistingAttachment,

--- a/apps/desktop/src/lib/workbench/attachmentController.ts
+++ b/apps/desktop/src/lib/workbench/attachmentController.ts
@@ -4,6 +4,10 @@ import { isImageMediaType } from '../attachmentMarkdown'
 import type { ApplicationTransport } from '../application/applicationTransport'
 import type { ApplicationAddAttachmentInput } from '../application/contracts'
 import type { WorkbenchCapabilities } from '../capabilities/workbenchCapabilities'
+import {
+  clientAttachmentFile,
+  type ClientAttachmentFile,
+} from '../capabilities/clientAttachmentFile'
 import type {
   AttachmentView,
   FeedbackWorkspaceView,
@@ -46,6 +50,7 @@ export type AttachmentController = ReturnType<typeof createAttachmentController>
 export function createAttachmentController(context: AttachmentControllerContext) {
   let screenCaptureRequestId = ''
   let screenCaptureAction: ActiveAction = null
+  let clientFileImportPending = false
 
   function mount() {
     let dragUnlisten: (() => void) | undefined
@@ -93,37 +98,51 @@ export function createAttachmentController(context: AttachmentControllerContext)
       )
     }
 
-    const nativePasteEnabled = screenCapture.status.source === 'native'
-    if (nativePasteEnabled) window.addEventListener('paste', handlePaste)
     return () => {
       dragUnlisten?.()
       captureReadyUnlisten?.()
       captureFinishedUnlisten?.()
-      if (nativePasteEnabled) window.removeEventListener('paste', handlePaste)
       releasePreviews()
     }
   }
 
-  function handlePaste(event: ClipboardEvent) {
-    if (context.getInteractionLocked() || !context.getWorkspace() || context.getBusy() || !event.clipboardData) return
-    const images = Array.from(event.clipboardData.files).filter((file) =>
-      file.type.startsWith('image/'),
-    )
-    if (images.length === 0) return
-    event.preventDefault()
-    void importFiles(images)
+  function canImportClientFiles(files: readonly ClientAttachmentFile[]): boolean {
+    const workspace = context.getWorkspace()
+    return files.length > 0
+      && !clientFileImportPending
+      && !context.getInteractionLocked()
+      && !context.getBusy()
+      && workspace !== null
+      && workspace.request.status !== 'completed'
+      && workspace.request.status !== 'cancelled'
+  }
+
+  function acceptClientFiles(files: readonly ClientAttachmentFile[]): boolean {
+    if (!canImportClientFiles(files)) return false
+    clientFileImportPending = true
+    void importClientFiles(files).finally(() => {
+      clientFileImportPending = false
+    })
+    return true
   }
 
   function handleFileSelection(event: Event) {
     const input = event.currentTarget as HTMLInputElement
-    const files = Array.from(input.files ?? [])
+    const files = Array.from(input.files ?? [], clientAttachmentFile)
     input.value = ''
-    void importFiles(files)
+    acceptClientFiles(files)
   }
 
-  async function importFiles(files: File[]) {
+  async function importClientFiles(files: readonly ClientAttachmentFile[]) {
     const workspace = context.getWorkspace()
-    if (context.getInteractionLocked() || !workspace || files.length === 0 || context.getBusy()) return
+    if (
+      context.getInteractionLocked()
+      || !workspace
+      || workspace.request.status === 'completed'
+      || workspace.request.status === 'cancelled'
+      || files.length === 0
+      || context.getBusy()
+    ) return
     const requestId = workspace.request.request_id
     const action = context.activeActionFor(requestId)
     if (!(await context.saveDraftNow())) return
@@ -135,13 +154,13 @@ export function createAttachmentController(context: AttachmentControllerContext)
       if (!next) throw new Error(context.tr('This feedback request could not be found.'))
       const existingIds = new Set(next.attachments.map((item) => item.attachment_id))
       for (const file of files) {
-        if (file.size > 20 * 1024 * 1024) {
-          throw new Error(context.tr('{name} exceeds the 20 MiB limit', { name: file.name }))
+        if (file.byteLength > 20 * 1024 * 1024) {
+          throw new Error(context.tr('{name} exceeds the 20 MiB limit', { name: file.fileName }))
         }
         const input: ApplicationAddAttachmentInput = {
           request_id: requestId,
-          file_name: file.name || `attachment-${Date.now()}`,
-          contents: await file.arrayBuffer(),
+          file_name: file.fileName || `attachment-${Date.now()}`,
+          contents: await file.readBytes(),
           expected_revision: next.draft.saved_revision,
         }
         next = await context.transport.call('addFeedbackAttachment', input)
@@ -167,6 +186,10 @@ export function createAttachmentController(context: AttachmentControllerContext)
     } finally {
       context.setBusy(false)
     }
+  }
+
+  function reportClientFileError(cause: unknown) {
+    context.setMessage(context.messageFrom(cause), 'error')
   }
 
   async function importAttachmentPaths(paths: readonly string[]) {
@@ -444,7 +467,9 @@ export function createAttachmentController(context: AttachmentControllerContext)
   return {
     mount,
     handleFileSelection,
-    importFiles,
+    acceptClientFiles,
+    importClientFiles,
+    reportClientFileError,
     importAttachmentPaths,
     startScreenCapture,
     removeAttachment,

--- a/apps/desktop/src/lib/workbench/imagePasteAcceptance.test.ts
+++ b/apps/desktop/src/lib/workbench/imagePasteAcceptance.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { canAcceptImagePaste } from './imagePasteAcceptance'
+
+describe('image-paste acceptance', () => {
+  const editable = {
+    loadingWorkspace: false,
+    requestStatus: 'in_progress',
+    interactionLocked: false,
+    attachmentBusy: false,
+  } as const
+
+  it('accepts only an editable active workspace', () => {
+    expect(canAcceptImagePaste(editable)).toBe(true)
+  })
+
+  it.each([
+    ['loading', { loadingWorkspace: true }],
+    ['completed', { requestStatus: 'completed' }],
+    ['cancelled', { requestStatus: 'cancelled' }],
+    ['missing', { requestStatus: null }],
+    ['interaction locked', { interactionLocked: true }],
+    ['attachment busy', { attachmentBusy: true }],
+  ] as const)('rejects %s workspaces before the DOM event is intercepted', (_label, override) => {
+    expect(canAcceptImagePaste({ ...editable, ...override })).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/workbench/imagePasteAcceptance.ts
+++ b/apps/desktop/src/lib/workbench/imagePasteAcceptance.ts
@@ -1,0 +1,17 @@
+import type { FeedbackStatus } from '../feedback'
+
+export type ImagePasteAcceptanceState = Readonly<{
+  loadingWorkspace: boolean
+  requestStatus: FeedbackStatus | null
+  interactionLocked: boolean
+  attachmentBusy: boolean
+}>
+
+export function canAcceptImagePaste(state: ImagePasteAcceptanceState): boolean {
+  return !state.loadingWorkspace
+    && state.requestStatus !== null
+    && state.requestStatus !== 'completed'
+    && state.requestStatus !== 'cancelled'
+    && !state.interactionLocked
+    && !state.attachmentBusy
+}


### PR DESCRIPTION
## Summary
- add DOM-scoped image paste for active editable Session workspaces in Browser and Desktop
- route browser file picker and paste through path-free client byte uploads
- move native drag/drop and Ramble Console path imports from screen capture into serverPaths
- preserve the existing three-column Workbench, attachment UI, native Clipboard, and screenshot flows

## Verification
- `pnpm --dir apps/desktop test` (74 files, 405 tests)
- `pnpm --dir apps/desktop check`
- `pnpm --dir apps/desktop build:web`
- `pnpm check:terminology`
- `pnpm contracts:check`
- `pnpm check:rust-size`
- `git diff --check`
- residual scans for old path-import names