### PR TITLE
WEB9: run speech recognition at the browser edge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 web/.astro/
 apps/*/node_modules/
 apps/*/dist/
+apps/desktop/public/browser-speech/runtime/
 apps/*/src-tauri/gen/
 apps/*/src-tauri/icons/android/
 apps/*/src-tauri/icons/ios/

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "tauri dev",
+    "predev:web": "node ../../scripts/prepare-sherpa-web.mjs",
     "dev:web": "vite dev",
     "build": "tauri build",
+    "prebuild:web": "node ../../scripts/prepare-sherpa-web.mjs",
     "build:web": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "test": "vitest run",

--- a/apps/desktop/public/browser-speech/pcm-capture.worklet.js
+++ b/apps/desktop/public/browser-speech/pcm-capture.worklet.js
@@ -1,0 +1,80 @@
+class RamblePcmCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super()
+    this.pcmPort = null
+    this.sessionId = ''
+    this.credits = 0
+    this.seq = 0
+    this.droppedFrames = 0
+    this.batch = []
+    this.batchLength = 0
+    this.targetFrames = Math.max(128, Math.round(sampleRate * 0.05))
+    this.lastLevelFrame = -sampleRate
+    this.port.onmessage = ({ data }) => {
+      if (data?.type === 'bind' && data.port) {
+        this.sessionId = data.sessionId
+        this.credits = data.credits
+        this.pcmPort = data.port
+        this.pcmPort.onmessage = ({ data: ack }) => {
+          if (ack?.v === 1 && ack.type === 'ack' && ack.sessionId === this.sessionId) {
+            this.credits += ack.credit
+          }
+        }
+        this.pcmPort.start()
+      } else if (data?.type === 'flush') {
+        this.flush()
+        this.port.postMessage({ type: 'flushed', lastSeq: this.seq, droppedFrames: this.droppedFrames })
+      }
+    }
+  }
+
+  process(inputs) {
+    const channels = inputs[0]
+    if (!this.pcmPort || !channels || channels.length === 0) return true
+    const length = channels[0].length
+    const mono = new Float32Array(length)
+    let energy = 0
+    for (let index = 0; index < length; index += 1) {
+      let sample = 0
+      for (const channel of channels) sample += channel[index] / channels.length
+      mono[index] = sample
+      energy += sample * sample
+    }
+    if (currentFrame - this.lastLevelFrame >= sampleRate / 10) {
+      this.lastLevelFrame = currentFrame
+      this.port.postMessage({ type: 'level', rms: Math.sqrt(energy / Math.max(1, length)) })
+    }
+    this.batch.push(mono)
+    this.batchLength += mono.length
+    if (this.batchLength >= this.targetFrames) this.flush()
+    return true
+  }
+
+  flush() {
+    if (this.batchLength === 0 || !this.pcmPort) return
+    const samples = new Float32Array(this.batchLength)
+    let offset = 0
+    for (const chunk of this.batch) {
+      samples.set(chunk, offset)
+      offset += chunk.length
+    }
+    this.batch = []
+    this.batchLength = 0
+    if (this.credits <= 0) {
+      this.droppedFrames += samples.length
+      return
+    }
+    this.credits -= 1
+    this.seq += 1
+    this.pcmPort.postMessage({
+      v: 1,
+      type: 'pcm',
+      sessionId: this.sessionId,
+      seq: this.seq,
+      sampleRate,
+      samples: samples.buffer,
+    }, [samples.buffer])
+  }
+}
+
+registerProcessor('rambledesk-pcm-capture', RamblePcmCaptureProcessor)

--- a/apps/desktop/public/browser-speech/sherpa.worker.js
+++ b/apps/desktop/public/browser-speech/sherpa.worker.js
@@ -1,0 +1,300 @@
+/* global SherpaOnnx, createOnlineRecognizer */
+'use strict'
+
+const V = 1
+let sessionId = ''
+let pcmPort = null
+let Module = null
+let recognizer = null
+let stream = null
+let resampler = null
+let queue = Promise.resolve()
+let processedSeq = 0
+let stopAfterSeq = null
+let segmentIndex = 0
+let lastText = ''
+let disposed = false
+let initStage = 'not_started'
+const engineDiagnostics = []
+
+self.onmessage = ({ data }) => {
+  if (!data || data.v !== V || typeof data.sessionId !== 'string') return
+  if (data.type === 'init' && !sessionId) {
+    sessionId = data.sessionId
+    queue = initialize(data).catch((cause) => fatal('model_load_failed', cause))
+    return
+  }
+  if (data.sessionId !== sessionId || disposed) return
+  if (data.type === 'bindPcm' && data.port) {
+    pcmPort = data.port
+    pcmPort.onmessage = ({ data: pcm }) => {
+      if (!pcm || pcm.v !== V || pcm.type !== 'pcm' || pcm.sessionId !== sessionId) return
+      queue = queue.then(() => processPcm(pcm)).catch((cause) => fatal('worker_processing_failed', cause))
+    }
+    pcmPort.start()
+  } else if (data.type === 'stop') {
+    stopAfterSeq = data.lastSeq
+    queue = queue.then(maybeStop).catch((cause) => fatal('shutdown_failed', cause))
+  } else if (data.type === 'cancel') {
+    disposed = true
+    queue = queue.then(() => dispose('cancelled')).catch(() => post({ type: 'disposed', reason: 'cancelled' }))
+  }
+}
+
+async function initialize(command) {
+  initStage = 'runtime_fetch'
+  const wasmResponse = await fetch(command.runtime.wasm, { credentials: 'same-origin', cache: 'force-cache' })
+  if (!wasmResponse.ok) throw coded('runtime_asset_unavailable', `Wasm request failed with HTTP ${wasmResponse.status}.`)
+  const wasmBinary = new Uint8Array(await wasmResponse.arrayBuffer())
+  if (wasmBinary.byteLength !== command.runtime.wasmBytes) throw coded('runtime_asset_hash_mismatch', 'Wasm size mismatch.')
+  const wasmDigest = await subtleSha256(wasmBinary)
+  if (wasmDigest !== command.runtime.wasmSha256) throw coded('runtime_asset_hash_mismatch', `Wasm SHA-256 mismatch: ${wasmDigest}.`)
+  if (!WebAssembly.validate(wasmBinary)) throw coded('wasm_simd_unsupported', 'This browser cannot validate the sherpa-onnx SIMD Wasm runtime.')
+
+  initStage = 'runtime_import'
+  importScripts(command.runtime.glue, command.runtime.wrapper)
+  if (typeof SherpaOnnx !== 'function' || typeof createOnlineRecognizer !== 'function') {
+    throw coded('runtime_asset_unavailable', 'The sherpa-onnx Web wrapper did not expose its runtime contract.')
+  }
+  initStage = 'runtime_instantiate'
+  Module = await SherpaOnnx({
+    wasmBinary,
+    print: captureEngineDiagnostic,
+    printErr: captureEngineDiagnostic,
+  })
+  const runtimeVersion = runtimeString('_SherpaOnnxGetVersionStr')
+  const runtimeGitSha = runtimeString('_SherpaOnnxGetGitSha1')
+  const ortVersion = runtimeString('_SherpaOnnxGetOnnxruntimeVersionStr')
+  if (runtimeVersion !== command.runtime.version || !runtimeGitMatches(command.runtime.gitSha, runtimeGitSha)) {
+    throw coded('runtime_version_mismatch', `Expected sherpa-onnx ${command.runtime.version} (${command.runtime.gitSha}), received ${runtimeVersion} (${runtimeGitSha}).`)
+  }
+
+  initStage = 'model_fs_prepare'
+  try { Module.FS.mkdir('/models') } catch (cause) {
+    if (!String(cause).includes('File exists')) throw cause
+  }
+  const cache = await caches.open(command.cacheName)
+  for (const file of command.files) {
+    initStage = `model_copy:${file.name}`
+    await copyCachedModelFile(cache, file, command.markerUrl)
+  }
+  initStage = 'recognizer_create'
+  recognizer = createOnlineRecognizer(Module, recognizerConfig(command.options.vadSilenceMs))
+  if (!recognizer || !recognizer.handle) throw coded('model_load_failed', 'sherpa-onnx rejected the browser streaming recognizer configuration.')
+  initStage = 'stream_create'
+  stream = recognizer.createStream()
+  initStage = 'ready'
+  post({ type: 'ready', runtimeVersion, runtimeGitSha, ortVersion })
+}
+
+function runtimeGitMatches(expected, actual) {
+  return typeof actual === 'string' && actual.length >= 8 && expected.startsWith(actual)
+}
+
+async function copyCachedModelFile(cache, file, markerUrl) {
+  const response = await cache.match(file.url)
+  if (!response) throw coded('model_not_installed', `Cached model file is missing: ${file.name}.`)
+  const path = `/models/${file.name}`
+  const bytes = new Uint8Array(await response.arrayBuffer())
+  const digest = await subtleSha256(bytes)
+  if (bytes.byteLength !== file.bytes || digest !== file.sha256) {
+    await Promise.all([
+      cache.delete(file.url),
+      typeof markerUrl === 'string' ? cache.delete(markerUrl) : Promise.resolve(false),
+    ])
+    throw coded(
+      bytes.byteLength !== file.bytes ? 'model_size_mismatch' : 'model_sha256_mismatch',
+      `Cached ${file.name} failed integrity verification (${bytes.byteLength} bytes, SHA-256 ${digest}).`,
+    )
+  }
+  Module.FS.writeFile(path, bytes)
+}
+
+function recognizerConfig(vadSilenceMs) {
+  return {
+    featConfig: { sampleRate: 16000, featureDim: 80 },
+    modelConfig: {
+      zipformer2Ctc: {
+        model: '/models/ctc-chunk-32-left-128.int8.onnx',
+      },
+      tokens: '/models/tokens.txt',
+      numThreads: 1,
+      provider: 'cpu',
+      debug: 0,
+      modelType: '',
+      modelingUnit: '',
+      bpeVocab: '',
+    },
+    decodingMethod: 'greedy_search',
+    maxActivePaths: 4,
+    enableEndpoint: 1,
+    rule1MinTrailingSilence: 2.4,
+    rule2MinTrailingSilence: Math.max(0.2, Math.min(3, vadSilenceMs / 1000)),
+    rule3MinUtteranceLength: 10,
+  }
+}
+
+async function processPcm(message) {
+  try {
+    if (disposed) return
+    if (!resampler) resampler = new StreamingResampler(message.sampleRate, 16000)
+    if (message.sampleRate !== resampler.inputRate) throw coded('input_sample_rate_changed', 'The microphone sample rate changed during recognition.')
+    const samples = resampler.push(new Float32Array(message.samples))
+    if (samples.length > 0) acceptAndDecode(samples)
+    processedSeq = Math.max(processedSeq, message.seq)
+    await maybeStop()
+  } finally {
+    pcmPort?.postMessage({ v: V, type: 'ack', sessionId, seq: message.seq, credit: 1 })
+  }
+}
+
+function acceptAndDecode(samples) {
+  stream.acceptWaveform(16000, samples)
+  let decoded = false
+  while (recognizer.isReady(stream)) {
+    recognizer.decode(stream)
+    decoded = true
+  }
+  if (decoded) updateResult()
+  if (recognizer.isEndpoint(stream)) finishSegment()
+}
+
+function updateResult() {
+  const text = String(recognizer.getResult(stream)?.text || '').trim()
+  if (text && text !== lastText) {
+    lastText = text
+    post({ type: 'partial', text })
+  }
+}
+
+function finishSegment() {
+  updateResult()
+  if (lastText) {
+    post({ type: 'processing', segmentIndex })
+    post({ type: 'stable', segmentIndex, text: lastText })
+    segmentIndex += 1
+  }
+  lastText = ''
+  recognizer.reset(stream)
+}
+
+async function maybeStop() {
+  if (stopAfterSeq === null || processedSeq < stopAfterSeq || disposed) return
+  stopAfterSeq = null
+  if (resampler) {
+    const tail = resampler.flush()
+    if (tail.length) acceptAndDecode(tail)
+  }
+  // Supply bounded silence so endpoint rules can finish the user's final utterance.
+  acceptAndDecode(new Float32Array(16_000))
+  stream.inputFinished()
+  let iterations = 0
+  while (recognizer.isReady(stream) && iterations < 1000) {
+    recognizer.decode(stream)
+    iterations += 1
+  }
+  updateResult()
+  if (lastText) finishSegment()
+  disposed = true
+  await dispose('stopped')
+}
+
+async function dispose(reason) {
+  pcmPort?.close()
+  pcmPort = null
+  try { stream?.free() } catch {}
+  try { recognizer?.free() } catch {}
+  stream = null
+  recognizer = null
+  post({ type: 'disposed', reason })
+}
+
+function fatal(fallbackCode, cause) {
+  if (disposed) return
+  disposed = true
+  const code = cause?.code || fallbackCode
+  const engineMessage = engineDiagnostics.at(-1)
+  const message = cause instanceof Error
+    ? cause.message
+    : engineMessage || `sherpa-onnx native exception during ${initStage} (${String(cause)}).`
+  post({ type: 'fatal', code, message })
+  void dispose('cancelled')
+}
+
+function captureEngineDiagnostic(value) {
+  const line = String(value).trim()
+  if (!line) return
+  engineDiagnostics.push(line)
+  if (engineDiagnostics.length > 12) engineDiagnostics.shift()
+}
+
+function runtimeString(exportName) {
+  const fn = Module[exportName]
+  if (typeof fn !== 'function') return ''
+  return Module.UTF8ToString(fn())
+}
+
+function post(message) {
+  self.postMessage({ v: V, sessionId, ...message })
+}
+
+function coded(code, message) {
+  const error = new Error(message)
+  error.code = code
+  return error
+}
+
+async function subtleSha256(bytes) {
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, '0')).join('')
+}
+
+class StreamingResampler {
+  constructor(inputRate, outputRate) {
+    this.inputRate = inputRate
+    this.outputRate = outputRate
+    this.buffer = new Float32Array(0)
+    this.bufferStart = 0
+    this.totalInput = 0
+    this.nextOutput = 0
+  }
+  push(input) {
+    const data = new Float32Array(this.buffer.length + input.length)
+    data.set(this.buffer)
+    data.set(input, this.buffer.length)
+    this.totalInput += input.length
+    const output = []
+    let position = this.sourcePosition()
+    while (position + 1 < this.totalInput) {
+      const absoluteIndex = Math.floor(position)
+      const index = absoluteIndex - this.bufferStart
+      const fraction = position - absoluteIndex
+      output.push(data[index] + (data[index + 1] - data[index]) * fraction)
+      this.nextOutput += 1
+      position = this.sourcePosition()
+    }
+    const nextRequired = Math.min(Math.floor(position), this.totalInput - 1)
+    const consumed = Math.max(0, nextRequired - this.bufferStart)
+    this.buffer = data.slice(consumed)
+    this.bufferStart += consumed
+    return Float32Array.from(output)
+  }
+  flush() {
+    const output = []
+    let position = this.sourcePosition()
+    while (position < this.totalInput) {
+      const index = Math.floor(position) - this.bufferStart
+      const next = Math.min(index + 1, this.buffer.length - 1)
+      const fraction = position - Math.floor(position)
+      output.push(this.buffer[index] + (this.buffer[next] - this.buffer[index]) * fraction)
+      this.nextOutput += 1
+      position = this.sourcePosition()
+    }
+    this.buffer = new Float32Array(0)
+    this.bufferStart = 0
+    this.totalInput = 0
+    this.nextOutput = 0
+    return Float32Array.from(output)
+  }
+  sourcePosition() { return this.nextOutput * this.inputRate / this.outputRate }
+}

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@ use rambledesk_core::{
     AddAttachmentInput, ApplicationError, ApplicationFeedbackRequestView,
     ApplicationFeedbackWorkspaceView, ApplicationHostProfileView, ApproveFeedbackInput,
     CancelFeedbackInput, DeleteFeedbackRequestInput, DraftView, FeedbackPackageView,
-    FeedbackRequestSummary, FeedbackStatus, GetFeedbackInput, HostSessionInput, HostSessionSummary,
+    FeedbackRequestSummary, GetFeedbackInput, HostSessionInput, HostSessionSummary,
     ListFeedbackRequestsInput, ListFeedbackRequestsOutput, ListHostSessionsInput,
     MAX_ATTACHMENT_BYTES, ReadAttachmentInput, RemoveAttachmentInput, RenameHostSessionInput,
     ReorderAttachmentsInput, SaveDraftInput, SetHostPinnedInput, SetHostSessionPinnedInput,
@@ -18,33 +18,20 @@ use rambledesk_speech::{
     ensure_vad_model, list_input_devices,
     model::{SpeechModelInfo, delete_model, download_model, list_models, model_dir, model_info},
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tauri::{Emitter, Manager, ipc::Response};
 
 use rambledesk_mcp::{McpHostView, McpInstallResult, detect_hosts, install_hosts};
 
 use super::{
-    TRAY_ID, WorkbenchState, clipboard_capture::ClipboardCaptureState, diagnostics,
-    migrate_library, pending_tray_icon, pi_install, save_library_path,
+    TRAY_ID, WorkbenchState,
+    clipboard_capture::ClipboardCaptureState,
+    diagnostics, migrate_library, pending_tray_icon, pi_install, save_library_path,
     screen_capture::ScreenCaptureState,
+    speech_plugin::{
+        SpeechRecognitionEventView, SpeechRecognitionSessionView, StartVoiceRambleInput,
+    },
 };
-
-#[derive(Debug, Deserialize)]
-pub(super) struct StartVoiceRambleInput {
-    request_id: String,
-    input_device: Option<String>,
-    model_id: String,
-    vad_threshold: f32,
-    vad_silence_ms: u32,
-    hotwords: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-pub(super) struct VoiceRambleSessionView {
-    voice_session_id: String,
-    provider: String,
-    model_path: String,
-}
 
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct StorageMigrationProgress {
@@ -688,20 +675,7 @@ pub(super) async fn start_voice_ramble(
     input: StartVoiceRambleInput,
     app: tauri::AppHandle,
     state: tauri::State<'_, WorkbenchState>,
-) -> Result<VoiceRambleSessionView, String> {
-    let workspace = state
-        .application
-        .clone()
-        .get_feedback_workspace(input.request_id.clone())
-        .await
-        .map_err(|error| error.to_string())?;
-    if matches!(
-        workspace.request.status,
-        FeedbackStatus::Completed | FeedbackStatus::Cancelled
-    ) {
-        return Err("已结束的反馈请求不能继续录入语音".to_owned());
-    }
-
+) -> Result<SpeechRecognitionSessionView, String> {
     let mut active = state.speech_session.lock().await;
     if active.is_some() {
         return Err("已有语音 Ramble 正在进行，请先停止当前录音".to_owned());
@@ -716,18 +690,23 @@ pub(super) async fn start_voice_ramble(
         ));
     }
     tracing::info!(
-        request_id = %input.request_id,
+        recognition_session_id = %input.recognition_session_id,
         model_id = %input.model_id,
         "start_voice_ramble: starting"
     );
-    let voice_session_id = uuid::Uuid::now_v7().to_string();
+    let recognition_session_id = input.recognition_session_id;
+    if recognition_session_id.trim().is_empty() {
+        return Err("语音识别会话 ID 不能为空".to_owned());
+    }
     let provider =
         SpeechProvider::from_model_id(&input.model_id).map_err(|error| error.to_string())?;
     let model_path = model_dir(&library_root, &input.model_id)?;
     let vad_model_path = ensure_vad_model(&library_root).map_err(|error| error.to_string())?;
     let config = SpeechSessionConfig {
-        request_id: input.request_id,
-        voice_session_id: voice_session_id.clone(),
+        // The native recognizer still uses the legacy internal identity shape,
+        // but the Platform Plugin does not know about Feedback Requests.
+        request_id: String::new(),
+        voice_session_id: recognition_session_id.clone(),
         provider,
         model_path: model_path.clone(),
         vad_model_path,
@@ -738,7 +717,10 @@ pub(super) async fn start_voice_ramble(
     };
     let event_app = app.clone();
     let sink: SpeechEventSink = Arc::new(move |event: SpeechEvent| {
-        if let Err(error) = event_app.emit("voice-ramble-event", event) {
+        if let Err(error) = event_app.emit(
+            "voice-ramble-event",
+            SpeechRecognitionEventView::from(event),
+        ) {
             tracing::warn!(%error, "failed to emit voice ramble event");
         }
     });
@@ -748,8 +730,8 @@ pub(super) async fn start_voice_ramble(
         .map_err(|error| error.to_string())?;
     *active = Some(session);
 
-    Ok(VoiceRambleSessionView {
-        voice_session_id,
+    Ok(SpeechRecognitionSessionView {
+        recognition_session_id,
         provider: provider.id().to_owned(),
         model_path: model_path.to_string_lossy().into_owned(),
     })

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod open_attachment;
 mod pi_install;
 mod screen_capture;
 mod shortcuts;
+mod speech_plugin;
 mod web_access;
 
 use rambledesk_core::{

--- a/apps/desktop/src-tauri/src/speech_plugin.rs
+++ b/apps/desktop/src-tauri/src/speech_plugin.rs
@@ -1,0 +1,135 @@
+use rambledesk_speech::SpeechEvent;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub(super) struct StartVoiceRambleInput {
+    pub recognition_session_id: String,
+    pub input_device: Option<String>,
+    pub model_id: String,
+    pub vad_threshold: f32,
+    pub vad_silence_ms: u32,
+    pub hotwords: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct SpeechRecognitionSessionView {
+    pub recognition_session_id: String,
+    pub provider: String,
+    pub model_path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum SpeechRecognitionEventView {
+    Started {
+        recognition_session_id: String,
+        input_device: String,
+        provider: String,
+    },
+    Partial {
+        recognition_session_id: String,
+        text: String,
+    },
+    Level {
+        recognition_session_id: String,
+        rms: f32,
+    },
+    Processing {
+        recognition_session_id: String,
+        chunk_index: u64,
+    },
+    Stable {
+        recognition_session_id: String,
+        chunk_index: u64,
+        text: String,
+    },
+    Warning {
+        recognition_session_id: String,
+        code: String,
+        message: String,
+    },
+    Stopped {
+        recognition_session_id: String,
+    },
+    Error {
+        recognition_session_id: String,
+        code: String,
+        message: String,
+    },
+}
+
+impl From<SpeechEvent> for SpeechRecognitionEventView {
+    fn from(event: SpeechEvent) -> Self {
+        match event {
+            SpeechEvent::Started {
+                voice_session_id,
+                input_device,
+                provider,
+                ..
+            } => Self::Started {
+                recognition_session_id: voice_session_id,
+                input_device,
+                provider,
+            },
+            SpeechEvent::Partial {
+                voice_session_id,
+                text,
+                ..
+            } => Self::Partial {
+                recognition_session_id: voice_session_id,
+                text,
+            },
+            SpeechEvent::Level {
+                voice_session_id,
+                rms,
+                ..
+            } => Self::Level {
+                recognition_session_id: voice_session_id,
+                rms,
+            },
+            SpeechEvent::Processing {
+                voice_session_id,
+                chunk_index,
+                ..
+            } => Self::Processing {
+                recognition_session_id: voice_session_id,
+                chunk_index,
+            },
+            SpeechEvent::Stable {
+                voice_session_id,
+                chunk_index,
+                text,
+                ..
+            } => Self::Stable {
+                recognition_session_id: voice_session_id,
+                chunk_index,
+                text,
+            },
+            SpeechEvent::Warning {
+                voice_session_id,
+                code,
+                message,
+                ..
+            } => Self::Warning {
+                recognition_session_id: voice_session_id,
+                code,
+                message,
+            },
+            SpeechEvent::Stopped {
+                voice_session_id, ..
+            } => Self::Stopped {
+                recognition_session_id: voice_session_id,
+            },
+            SpeechEvent::Error {
+                voice_session_id,
+                code,
+                message,
+                ..
+            } => Self::Error {
+                recognition_session_id: voice_session_id,
+                code,
+                message,
+            },
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/web_access.rs
+++ b/apps/desktop/src-tauri/src/web_access.rs
@@ -15,6 +15,13 @@ use crate::WorkbenchState;
 
 const CREDENTIAL_SERVICE: &str = "com.rambledesk.desktop.web-access";
 const CREDENTIAL_ACCOUNT: &str = "web-access-durable-token";
+const BROWSER_SPEECH_ASSETS: &[&str] = &[
+    "browser-speech/pcm-capture.worklet.js",
+    "browser-speech/sherpa.worker.js",
+    "browser-speech/runtime/sherpa-onnx-asr.js",
+    "browser-speech/runtime/sherpa-onnx-wasm-web.js",
+    "browser-speech/runtime/sherpa-onnx-wasm-web.wasm",
+];
 
 pub(super) trait WebAccessCredentialStore: Send + Sync {
     fn load_or_create(&self) -> Result<DurableWebAccessToken, String>;
@@ -97,11 +104,12 @@ impl TauriSpaAssets {
                     SpaAssetCachePolicy::NoCache
                 };
                 (
-                    path,
+                    path.clone(),
                     SpaAsset {
                         bytes,
-                        mime_type,
-                        content_security_policy: None,
+                        mime_type: web_asset_mime_type(&path, mime_type),
+                        content_security_policy: (path == "browser-speech/sherpa.worker.js")
+                            .then(|| "default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self'".to_owned()),
                         cache_policy,
                     },
                 )
@@ -121,6 +129,7 @@ fn dev_asset_entries(
     let outputs = vite_manifest_outputs(manifest_bytes)?;
     let mut paths = outputs.into_iter().collect::<Vec<_>>();
     paths.push("index.html".to_owned());
+    paths.extend(BROWSER_SPEECH_ASSETS.iter().map(|path| (*path).to_owned()));
     paths.sort();
     paths.dedup();
     let mut entries = vec![(
@@ -135,6 +144,16 @@ fn dev_asset_entries(
         entries.push((path, bytes, mime_type));
     }
     Ok(entries)
+}
+
+fn web_asset_mime_type(path: &str, resolver_mime_type: String) -> String {
+    if path.ends_with(".wasm") {
+        "application/wasm".to_owned()
+    } else if path.ends_with(".js") {
+        "text/javascript; charset=utf-8".to_owned()
+    } else {
+        resolver_mime_type
+    }
 }
 impl SpaAssetSource for TauriSpaAssets {
     fn load(&self, path: &str) -> Option<SpaAsset> {
@@ -335,11 +354,14 @@ mod tests {
 
     #[test]
     fn dev_manifest_builds_an_exact_cached_inventory_without_request_path_fallback() {
-        let readable = HashMap::from([
+        let mut readable = HashMap::from([
             ("index.html", b"<main>Workbench</main>".to_vec()),
             ("assets/app-abc12345.js", b"export {}".to_vec()),
             ("assets/app-def67890.css", b"body{}".to_vec()),
         ]);
+        for path in BROWSER_SPEECH_ASSETS {
+            readable.insert(path, b"browser speech asset".to_vec());
+        }
         let requested = std::cell::RefCell::new(Vec::new());
         let entries = dev_asset_entries(
             br#"{
@@ -365,13 +387,24 @@ mod tests {
             SpaAssetCachePolicy::Immutable,
         );
         assert!(assets.load("assets/missing.js").is_none());
-        assert_eq!(
-            requested.into_inner(),
-            [
-                "assets/app-abc12345.js",
-                "assets/app-def67890.css",
-                "index.html",
-            ],
+        let requested = requested.into_inner();
+        assert!(requested.contains(&"assets/app-abc12345.js".to_owned()));
+        assert!(requested.contains(&"browser-speech/sherpa.worker.js".to_owned()));
+        let wasm = assets
+            .load("browser-speech/runtime/sherpa-onnx-wasm-web.wasm")
+            .expect("wasm asset");
+        assert_eq!(wasm.mime_type, "application/wasm");
+        let worker = assets
+            .load("browser-speech/sherpa.worker.js")
+            .expect("worker asset");
+        assert!(
+            worker
+                .content_security_policy
+                .as_deref()
+                .is_some_and(|policy| {
+                    policy.contains("script-src 'self' 'wasm-unsafe-eval'")
+                        && policy.contains("connect-src 'self'")
+                })
         );
     }
 

--- a/apps/desktop/src/lib/OnboardingWizard.svelte
+++ b/apps/desktop/src/lib/OnboardingWizard.svelte
@@ -62,6 +62,7 @@
     type CookingReasoningEffort,
     type SpeechModelId,
   } from '$lib/preferences'
+  import { resolveSupportedSpeechModelId } from '$lib/capabilities/speechModelSelection'
 
   export let openWizard = false
   export let onClose: () => void = () => {}
@@ -277,6 +278,8 @@
   async function loadModels() {
     try {
       models = [...await capabilities.speech.implementation.listModels()]
+      const supportedModelId = resolveSupportedSpeechModelId($speechModelId, models)
+      if (supportedModelId && supportedModelId !== $speechModelId) setSpeechModelId(supportedModelId)
     } catch (cause) {
       toast.error(tr('Could not read voice models'), { description: messageFrom(cause) })
     }

--- a/apps/desktop/src/lib/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/SettingsPanel.svelte
@@ -34,6 +34,7 @@
   import { Button } from '$lib/components/ui/button'
   import { createUnavailableWorkbenchCapabilities } from '$lib/capabilities/unavailableCapabilities'
   import type { WorkbenchCapabilities } from '$lib/capabilities/workbenchCapabilities'
+  import { resolveSupportedSpeechModelId } from '$lib/capabilities/speechModelSelection'
   import * as Collapsible from '$lib/components/ui/collapsible'
   import { ScrollArea } from '$lib/components/ui/scroll-area'
   import { toast } from '$lib/components/ui/sonner'
@@ -357,6 +358,8 @@
     modelError = ''
     try {
       speechModels = [...await capabilities.speech.implementation.listModels()]
+      const supportedModelId = resolveSupportedSpeechModelId($speechModelId, speechModels)
+      if (supportedModelId && supportedModelId !== $speechModelId) setSpeechModelId(supportedModelId)
     } catch (cause) {
       modelError = messageFrom(cause)
     }
@@ -1425,7 +1428,7 @@
               <div class="min-w-0 flex-1">
                 <h3 class="m-0 text-sm font-medium">{tr('Voice activity detection (VAD)')}</h3>
                 <p class="m-0 mt-1 text-xs leading-5 text-muted-foreground">
-                  {tr('SenseVoice and FunASR-Nano use bundled Silero VAD to split long recordings; X-ASR continues to use streaming endpoints.')}
+                  {tr('Non-streaming models use bundled Silero VAD to split long recordings; streaming models use their own endpoints.')}
                 </p>
                 <div class="mt-4 grid gap-5 rounded-md border bg-muted/20 p-4">
                   <div class="grid grid-cols-[minmax(0,1fr)_280px] items-center gap-6">

--- a/apps/desktop/src/lib/capabilities/browser/browserCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/browser/browserCapabilities.ts
@@ -7,6 +7,10 @@ import {
 } from '../workbenchCapabilities'
 import { createUnavailableWorkbenchCapabilities } from '../unavailableCapabilities'
 import { createBrowserImagePasteCapability } from './imagePasteCapability'
+import {
+  createBrowserSpeechCapability,
+  detectBrowserSpeechSupport,
+} from './speech/browserSpeechCapability'
 
 export type BrowserWindowOpen = (
   url?: string | URL,
@@ -44,18 +48,20 @@ export function createBrowserExternalLinkCapability(
 
 /**
  * Browser registry. Ordinary external links and DOM-scoped image paste are
- * available; native paths, native capture, speech, and Desktop administration
- * remain explicitly unavailable.
+ * available. Browser speech is registered only when its hard platform APIs are
+ * present; model installation remains an honest runtime readiness state.
  */
 export function createBrowserWorkbenchCapabilities(
   environment: BrowserCapabilityEnvironment = browserEnvironment(),
 ): WorkbenchCapabilities {
   const unavailable = createUnavailableWorkbenchCapabilities()
   const { manifest: _manifest, ...slots } = unavailable
+  const speech = detectBrowserSpeechSupport()
   return createWorkbenchCapabilities({
     ...slots,
     externalLinks: browserSlot(createBrowserExternalLinkCapability(environment)),
     imagePaste: browserSlot(createBrowserImagePasteCapability()),
+    ...(speech.supported ? { speech: browserSlot(createBrowserSpeechCapability()) } : {}),
   })
 }
 

--- a/apps/desktop/src/lib/capabilities/browser/speech/browserModelStore.test.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/browserModelStore.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BrowserModelStore } from './browserModelStore'
+import {
+  BROWSER_SPEECH_CACHE_NAME,
+  BROWSER_SPEECH_MODEL_DIGEST,
+  BROWSER_SPEECH_MODEL_FILES,
+  BROWSER_SPEECH_MODEL_ID,
+  BROWSER_SPEECH_MARKER_URL,
+} from './browserSpeechManifest'
+
+class MemoryCache {
+  readonly entries = new Map<string, Response>()
+  putCount = 0
+  async match(input: RequestInfo | URL) {
+    return this.entries.get(String(input))?.clone()
+  }
+  async put(input: RequestInfo | URL, response: Response) {
+    this.putCount += 1
+    this.entries.set(String(input), response.clone())
+  }
+  async delete(input: RequestInfo | URL) {
+    return this.entries.delete(String(input))
+  }
+}
+
+class MemoryCaches {
+  readonly cache = new MemoryCache()
+  async open(_name: string) { return this.cache as unknown as Cache }
+  async delete(name: string) {
+    if (name !== BROWSER_SPEECH_CACHE_NAME) return false
+    this.cache.entries.clear()
+    return true
+  }
+}
+
+function storedFile(bytes: number, sha256: string) {
+  return new Response(new Uint8Array(), { headers: {
+    'x-rambledesk-bytes': String(bytes),
+    'x-rambledesk-sha256': sha256,
+  } })
+}
+
+function store(caches = new MemoryCaches(), fetch = vi.fn<typeof globalThis.fetch>()) {
+  return {
+    caches,
+    fetch,
+    value: new BrowserModelStore({
+      caches: caches as unknown as CacheStorage,
+      fetch,
+      storage: {
+        estimate: async () => ({ quota: 2_000_000_000, usage: 0 }),
+        persist: async () => true,
+      },
+    }),
+  }
+}
+
+describe('BrowserModelStore', () => {
+  it('advertises installed only after the versioned marker and every verified entry exist', async () => {
+    const base = store()
+    for (const file of BROWSER_SPEECH_MODEL_FILES) {
+      base.caches.cache.entries.set(file.url, storedFile(file.bytes, file.sha256))
+    }
+    expect((await base.value.listModels())[0].installed).toBe(false)
+
+    base.caches.cache.entries.set(BROWSER_SPEECH_MARKER_URL, new Response(JSON.stringify({
+      modelId: BROWSER_SPEECH_MODEL_ID,
+      manifestSha256: BROWSER_SPEECH_MODEL_DIGEST,
+    })))
+    expect((await base.value.listModels())[0].installed).toBe(true)
+
+    const missing = BROWSER_SPEECH_MODEL_FILES.at(-1)!
+    base.caches.cache.entries.delete(missing.url)
+    const degraded = (await base.value.listModels())[0]
+    expect(degraded.installed).toBe(false)
+    expect(degraded.missing_files).toContain(missing.name)
+  })
+
+  it('recovers a verified partial cache without fetching it again and never writes a marker on failure', async () => {
+    const base = store(new MemoryCaches(), vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), {
+      headers: { 'content-length': '3' },
+    })))
+    const first = BROWSER_SPEECH_MODEL_FILES[0]
+    base.caches.cache.entries.set(first.url, storedFile(first.bytes, first.sha256))
+
+    await expect(base.value.downloadModel(BROWSER_SPEECH_MODEL_ID)).rejects.toMatchObject({
+      code: 'model_size_mismatch',
+    })
+
+    expect(base.fetch).toHaveBeenCalledOnce()
+    expect(base.fetch).toHaveBeenCalledWith(BROWSER_SPEECH_MODEL_FILES[1].url, expect.any(Object))
+    expect(base.caches.cache.entries.has(first.url)).toBe(true)
+    expect(base.caches.cache.entries.has(BROWSER_SPEECH_MARKER_URL)).toBe(false)
+    expect((await base.value.listModels())[0].installed).toBe(false)
+  })
+
+  it('streams a chunked response when Content-Length is not exposed', async () => {
+    const base = store(new MemoryCaches(), vi.fn(async () => new Response(new Uint8Array([1, 2, 3]))))
+    await expect(base.value.downloadModel(BROWSER_SPEECH_MODEL_ID)).rejects.toMatchObject({
+      code: 'model_size_mismatch',
+    })
+    expect(base.caches.cache.putCount).toBe(1)
+    expect(base.caches.cache.entries.has(BROWSER_SPEECH_MARKER_URL)).toBe(false)
+  })
+
+  it('deletes only the versioned browser model cache', async () => {
+    const base = store()
+    base.caches.cache.entries.set(BROWSER_SPEECH_MARKER_URL, new Response('{}'))
+    const result = await base.value.deleteModel(BROWSER_SPEECH_MODEL_ID)
+    expect(result.installed).toBe(false)
+    expect(base.caches.cache.entries.size).toBe(0)
+  })
+})

--- a/apps/desktop/src/lib/capabilities/browser/speech/browserModelStore.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/browserModelStore.ts
@@ -1,0 +1,239 @@
+import type {
+  CapabilityErrorHandler,
+  CapabilityUnsubscribe,
+  SpeechModelInfo,
+  SpeechModelProgress,
+} from '../../workbenchCapabilities'
+import {
+  BROWSER_SPEECH_CACHE_NAME,
+  BROWSER_SPEECH_MODEL_DIGEST,
+  BROWSER_SPEECH_MODEL_FILES,
+  BROWSER_SPEECH_MODEL_ID,
+  BROWSER_SPEECH_MARKER_URL,
+  BROWSER_SPEECH_TOTAL_BYTES,
+  browserSpeechModelInfo,
+} from './browserSpeechManifest'
+import { Sha256 } from './sha256'
+
+export class BrowserSpeechError extends Error {
+  constructor(readonly code: string, message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'BrowserSpeechError'
+  }
+}
+
+type CacheEnvironment = Readonly<{
+  caches: CacheStorage
+  fetch: typeof fetch
+  storage?: Pick<StorageManager, 'estimate' | 'persist'>
+}>
+
+export class BrowserModelStore {
+  readonly #environment: CacheEnvironment
+  readonly #progressListeners = new Set<(progress: SpeechModelProgress) => void>()
+  #download: AbortController | null = null
+
+  constructor(environment: CacheEnvironment = browserCacheEnvironment()) {
+    this.#environment = environment
+  }
+
+  async listModels(): Promise<readonly SpeechModelInfo[]> {
+    const cache = await this.#environment.caches.open(BROWSER_SPEECH_CACHE_NAME)
+    const missing = await missingModelFiles(cache)
+    const marker = await cache.match(BROWSER_SPEECH_MARKER_URL)
+    const installed = marker !== undefined && missing.length === 0 && await validMarker(marker)
+    return [browserSpeechModelInfo(installed, installed ? [] : missing)]
+  }
+
+  async downloadModel(modelId: string): Promise<SpeechModelInfo> {
+    requireSupportedModel(modelId)
+    if (this.#download !== null) {
+      throw new BrowserSpeechError('model_download_active', 'The browser speech model is already downloading.')
+    }
+    await this.#assertQuota()
+    const abort = new AbortController()
+    this.#download = abort
+    let downloaded = 0
+    const cache = await this.#environment.caches.open(BROWSER_SPEECH_CACHE_NAME)
+    await cache.delete(BROWSER_SPEECH_MARKER_URL)
+    this.#emitProgress(downloaded)
+    try {
+      for (const file of BROWSER_SPEECH_MODEL_FILES) {
+        const existing = await cache.match(file.url)
+        if (existing && responseMatchesManifest(existing, file.bytes, file.sha256)) {
+          downloaded += file.bytes
+          this.#emitProgress(downloaded)
+          continue
+        }
+        if (existing) await cache.delete(file.url)
+        const response = await this.#environment.fetch(file.url, {
+          cache: 'no-store',
+          credentials: 'omit',
+          mode: 'cors',
+          signal: abort.signal,
+        })
+        if (!response.ok || response.body === null) {
+          throw new BrowserSpeechError(
+            'model_download_blocked',
+            `Could not download ${file.name} from the pinned ModelScope mirror (HTTP ${response.status}).`,
+          )
+        }
+        const contentLengthHeader = response.headers.get('content-length')
+        const contentLength = contentLengthHeader === null ? null : Number(contentLengthHeader)
+        if (contentLength !== null && Number.isFinite(contentLength) && contentLength !== file.bytes) {
+          throw new BrowserSpeechError(
+            'model_size_mismatch',
+            `${file.name} size mismatch: expected ${file.bytes}, received ${contentLength}.`,
+          )
+        }
+        const [verifyBody, cacheBody] = response.body.tee()
+        const headers = new Headers(response.headers)
+        headers.set('x-rambledesk-bytes', String(file.bytes))
+        headers.set('x-rambledesk-sha256', file.sha256)
+        const cacheWrite = cache.put(
+          file.url,
+          new Response(cacheBody, { status: 200, headers }),
+        )
+        const reader = verifyBody.getReader()
+        const hash = new Sha256()
+        let fileBytes = 0
+        try {
+          while (true) {
+            const { value, done } = await reader.read()
+            if (done) break
+            if (abort.signal.aborted) throw abort.signal.reason
+            hash.update(value)
+            fileBytes += value.byteLength
+            this.#emitProgress(downloaded + Math.min(fileBytes, file.bytes))
+          }
+          await cacheWrite
+        } catch (cause) {
+          // A tee branch may still be writing after verification fails. Settle
+          // it before delete so no write-after-delete can create a partial file.
+          await cacheWrite.catch(() => undefined)
+          await cache.delete(file.url)
+          throw cause
+        }
+        if (fileBytes !== file.bytes) {
+          await cache.delete(file.url)
+          throw new BrowserSpeechError(
+            'model_size_mismatch',
+            `${file.name} size mismatch: expected ${file.bytes}, received ${fileBytes}.`,
+          )
+        }
+        const actual = hash.digestHex()
+        if (actual !== file.sha256) {
+          await cache.delete(file.url)
+          throw new BrowserSpeechError(
+            'model_sha256_mismatch',
+            `${file.name} SHA-256 mismatch: expected ${file.sha256}, received ${actual}.`,
+          )
+        }
+        downloaded += file.bytes
+        this.#emitProgress(downloaded)
+      }
+      await cache.put(BROWSER_SPEECH_MARKER_URL, new Response(JSON.stringify({
+        schemaVersion: 1,
+        modelId: BROWSER_SPEECH_MODEL_ID,
+        manifestSha256: BROWSER_SPEECH_MODEL_DIGEST,
+      }), { headers: { 'content-type': 'application/json' } }))
+      this.#emitProgress(BROWSER_SPEECH_TOTAL_BYTES)
+      return (await this.listModels())[0]
+    } catch (cause) {
+      if (abort.signal.aborted) {
+        throw new BrowserSpeechError('model_download_cancelled', 'Browser speech model download was cancelled.', { cause })
+      }
+      if (cause instanceof BrowserSpeechError) throw cause
+      throw new BrowserSpeechError('model_download_blocked', `Browser speech model download failed: ${messageFrom(cause)}`, { cause })
+    } finally {
+      if (this.#download === abort) this.#download = null
+    }
+  }
+
+  cancelDownload(): void {
+    this.#download?.abort(new Error('cancelled'))
+  }
+
+  async deleteModel(modelId: string): Promise<SpeechModelInfo> {
+    requireSupportedModel(modelId)
+    this.cancelDownload()
+    await this.#environment.caches.delete(BROWSER_SPEECH_CACHE_NAME)
+    return browserSpeechModelInfo(false, BROWSER_SPEECH_MODEL_FILES.map((file) => file.name))
+  }
+
+  onProgress(
+    handler: (progress: SpeechModelProgress) => void,
+    _onError: CapabilityErrorHandler,
+  ): CapabilityUnsubscribe {
+    this.#progressListeners.add(handler)
+    return () => this.#progressListeners.delete(handler)
+  }
+
+  async #assertQuota() {
+    if (!this.#environment.storage) return
+    const estimate = await this.#environment.storage.estimate()
+    if (estimate.quota === undefined || estimate.usage === undefined) return
+    const remaining = estimate.quota - estimate.usage
+    if (remaining < BROWSER_SPEECH_TOTAL_BYTES * 1.1) {
+      throw new BrowserSpeechError(
+        'storage_quota_insufficient',
+        `Browser storage is too small for the speech model (${Math.floor(remaining / 1024 / 1024)} MB free).`,
+      )
+    }
+    void this.#environment.storage.persist().catch(() => false)
+  }
+
+  #emitProgress(downloaded: number) {
+    const progress = Object.freeze({
+      model_id: BROWSER_SPEECH_MODEL_ID,
+      downloaded,
+      total: BROWSER_SPEECH_TOTAL_BYTES,
+    })
+    for (const listener of this.#progressListeners) listener(progress)
+  }
+}
+
+function browserCacheEnvironment(): CacheEnvironment {
+  if (!('caches' in globalThis)) {
+    throw new BrowserSpeechError('cache_storage_unavailable', 'Cache Storage is unavailable in this browser.')
+  }
+  return {
+    caches: globalThis.caches,
+    fetch: globalThis.fetch.bind(globalThis),
+    storage: navigator.storage,
+  }
+}
+
+async function missingModelFiles(cache: Cache): Promise<string[]> {
+  const missing: string[] = []
+  for (const file of BROWSER_SPEECH_MODEL_FILES) {
+    const response = await cache.match(file.url)
+    if (!response || !responseMatchesManifest(response, file.bytes, file.sha256)) missing.push(file.name)
+  }
+  return missing
+}
+
+function responseMatchesManifest(response: Response, bytes: number, sha256: string): boolean {
+  return response.headers.get('x-rambledesk-bytes') === String(bytes) &&
+    response.headers.get('x-rambledesk-sha256') === sha256
+}
+
+async function validMarker(response: Response): Promise<boolean> {
+  try {
+    const marker = await response.json() as Record<string, unknown>
+    return marker.modelId === BROWSER_SPEECH_MODEL_ID &&
+      marker.manifestSha256 === BROWSER_SPEECH_MODEL_DIGEST
+  } catch {
+    return false
+  }
+}
+
+function requireSupportedModel(modelId: string) {
+  if (modelId !== BROWSER_SPEECH_MODEL_ID) {
+    throw new BrowserSpeechError('model_unsupported', `Browser speech supports only ${BROWSER_SPEECH_MODEL_ID}; received ${modelId}.`)
+  }
+}
+
+function messageFrom(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}

--- a/apps/desktop/src/lib/capabilities/browser/speech/browserSpeechArchitecture.test.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/browserSpeechArchitecture.test.ts
@@ -1,0 +1,23 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+describe('browser speech architecture boundary', () => {
+  it('keeps capture in the worklet, recognition/resampling in the Worker, and has no audio upload route', async () => {
+    const publicRoot = fileURLToPath(new URL('../../../../../public/browser-speech/', import.meta.url))
+    const [worklet, worker] = await Promise.all([
+      readFile(`${publicRoot}/pcm-capture.worklet.js`, 'utf8'),
+      readFile(`${publicRoot}/sherpa.worker.js`, 'utf8'),
+    ])
+    expect(worklet).toContain("registerProcessor('rambledesk-pcm-capture'")
+    expect(worklet).not.toMatch(/createOnlineRecognizer|fetch\(/u)
+    expect(worker).toMatch(/class StreamingResampler/u)
+    expect(worker).toMatch(/createOnlineRecognizer\(Module/u)
+    expect(worker).toMatch(/zipformer2Ctc/u)
+    expect(worker).toMatch(/printErr: captureEngineDiagnostic/u)
+    expect(worker).toMatch(/actual\.length >= 8 && expected\.startsWith\(actual\)/u)
+    expect(worker).toMatch(/cache\.delete\(file\.url\)/u)
+    expect(worker).toMatch(/cache\.delete\(markerUrl\)/u)
+    expect(worker).not.toMatch(/\/api\/speech|FormData|audio\/wav/u)
+  })
+})

--- a/apps/desktop/src/lib/capabilities/browser/speech/browserSpeechCapability.test.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/browserSpeechCapability.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { SpeechRecognitionEvent } from '$lib/speech'
+import { BROWSER_SPEECH_MODEL_ID, browserSpeechModelInfo } from './browserSpeechManifest'
+import {
+  createBrowserSpeechCapability,
+  type BrowserSpeechEnvironment,
+} from './browserSpeechCapability'
+
+class FakeWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: OnErrorEventHandler = null
+  terminated = false
+  readonly commands: string[] = []
+  postMessage(message: { type: string; sessionId: string }) {
+    this.commands.push(message.type)
+    if (message.type === 'init') queueMicrotask(() => this.emit({ type: 'ready', runtimeVersion: '1.13.7', runtimeGitSha: '917bed95c8e5c7c18aa4d69fea42e9ef8ef0a60e', ortVersion: 'test' }, message.sessionId))
+    if (message.type === 'stop') queueMicrotask(() => {
+      this.emit({ type: 'stable', segmentIndex: 0, text: '尾帧' }, message.sessionId)
+      this.emit({ type: 'disposed', reason: 'stopped' }, message.sessionId)
+    })
+    if (message.type === 'cancel') queueMicrotask(() => {
+      this.emit({ type: 'stable', segmentIndex: 0, text: '不应出现' }, message.sessionId)
+      this.emit({ type: 'disposed', reason: 'cancelled' }, message.sessionId)
+    })
+  }
+  terminate() { this.terminated = true }
+  emit(message: Record<string, unknown>, sessionId = 'session-a') {
+    if (!this.terminated) this.onmessage?.({ data: { v: 1, sessionId, ...message } } as MessageEvent)
+  }
+}
+
+class FakeWorkletPort {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  postMessage(message: { type: string }) {
+    if (message.type === 'flush') queueMicrotask(() => this.onmessage?.({ data: { type: 'flushed', lastSeq: 4, droppedFrames: 0 } } as MessageEvent))
+  }
+}
+
+function speechHarness(mediaPromise?: Promise<MediaStream>) {
+  const worker = new FakeWorker()
+  const track = { label: 'Test microphone', stop: vi.fn(), onended: null } as unknown as MediaStreamTrack
+  const stream = { getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream
+  const port = new FakeWorkletPort()
+  const worklet = { port, connect: vi.fn((_node) => _node), disconnect: vi.fn(), onprocessorerror: null } as unknown as AudioWorkletNode
+  const source = { connect: vi.fn((_node) => _node), disconnect: vi.fn() } as unknown as MediaStreamAudioSourceNode
+  const gain = { gain: { value: 1 }, connect: vi.fn((_node) => _node) } as unknown as GainNode
+  const context = {
+    state: 'running',
+    audioWorklet: { addModule: vi.fn(async () => undefined) },
+    createMediaStreamSource: vi.fn(() => source),
+    createGain: vi.fn(() => gain),
+    destination: {},
+    resume: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+  } as unknown as AudioContext
+  const documentTarget = new EventTarget() as Document
+  Object.defineProperty(documentTarget, 'visibilityState', { value: 'visible', configurable: true })
+  const environment: BrowserSpeechEnvironment = {
+    mediaDevices: {
+      getUserMedia: vi.fn(() => mediaPromise ?? Promise.resolve(stream)),
+      enumerateDevices: vi.fn(async () => []),
+    } as unknown as MediaDevices,
+    document: documentTarget,
+    createWorker: () => worker as unknown as Worker,
+    createAudioContext: () => context,
+    createAudioWorkletNode: () => worklet,
+    createMessageChannel: () => ({ port1: {}, port2: {} }) as MessageChannel,
+    createSessionId: () => 'session-a',
+    setTimeout,
+    clearTimeout,
+  }
+  const modelStore = {
+    listModels: async () => [browserSpeechModelInfo(true, [])],
+    downloadModel: vi.fn(), deleteModel: vi.fn(), onProgress: vi.fn(() => () => {}),
+  }
+  const events: SpeechRecognitionEvent[] = []
+  const onError = vi.fn()
+  const capability = createBrowserSpeechCapability(modelStore as never, environment)
+  return { capability, worker, track, stream, events, onError, listener: { onEvent: (event: SpeechRecognitionEvent) => events.push(event), onError } }
+}
+
+const OPTIONS = {
+  inputDevice: null,
+  modelId: BROWSER_SPEECH_MODEL_ID,
+  vadThreshold: 0.5,
+  vadSilenceMs: 700,
+  hotwords: [],
+} as const
+
+describe('Browser SpeechRecognitionPlugin lifecycle', () => {
+  it('flushes tail once, ignores stale events, and makes the first terminal intent idempotent', async () => {
+    const base = speechHarness()
+    const session = base.capability.start(OPTIONS, base.listener)
+    await session.ready
+    base.worker.emit({ type: 'stable', segmentIndex: 9, text: 'stale' }, 'old-session')
+    await Promise.all([session.stop(), session.stop(), session.cancel()])
+    base.worker.emit({ type: 'stable', segmentIndex: 10, text: 'late' })
+
+    expect(base.worker.commands.filter((type) => type === 'stop')).toHaveLength(1)
+    expect(base.worker.commands).not.toContain('cancel')
+    expect(base.events.filter((event) => event.type === 'stable')).toEqual([
+      { type: 'stable', sessionId: 'session-a', segmentIndex: 0, text: '尾帧' },
+    ])
+    expect(base.events.at(-1)).toEqual({ type: 'stopped', sessionId: 'session-a', reason: 'stopped' })
+  })
+
+  it('cancels abortively and suppresses queued worker tail', async () => {
+    const base = speechHarness()
+    const session = base.capability.start(OPTIONS, base.listener)
+    await session.ready
+    await session.cancel()
+    await Promise.resolve()
+    expect(base.events.some((event) => event.type === 'stable')).toBe(false)
+    expect(base.events.at(-1)).toEqual({ type: 'stopped', sessionId: 'session-a', reason: 'cancelled' })
+  })
+
+  it('stops a getUserMedia result that resolves after cancellation', async () => {
+    let resolveMedia: (stream: MediaStream) => void = () => {}
+    const pending = new Promise<MediaStream>((resolve) => (resolveMedia = resolve))
+    const base = speechHarness(pending)
+    const session = base.capability.start(OPTIONS, base.listener)
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve()
+    await session.cancel()
+    resolveMedia(base.stream)
+    await Promise.resolve(); await Promise.resolve()
+    await expect(session.ready).rejects.toThrow('stopped before it became ready')
+    expect(base.track.stop).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/capabilities/browser/speech/browserSpeechCapability.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/browserSpeechCapability.ts
@@ -1,0 +1,369 @@
+import type {
+  SpeechAdministrationCapability,
+  SpeechRecognitionOptions,
+  SpeechRecognitionPlugin,
+} from '../../workbenchCapabilities'
+import type {
+  SpeechRecognitionListener,
+  SpeechRecognitionSession,
+  SpeechRecognitionStopReason,
+} from '$lib/speech'
+import { BrowserModelStore, BrowserSpeechError } from './browserModelStore'
+import {
+  BROWSER_SPEECH_CACHE_NAME,
+  BROWSER_SPEECH_MODEL_FILES,
+  BROWSER_SPEECH_MODEL_ID,
+  BROWSER_SPEECH_MARKER_URL,
+  BROWSER_SPEECH_RUNTIME,
+} from './browserSpeechManifest'
+import { BROWSER_SPEECH_PROTOCOL_VERSION, isWorkerEvent } from './protocol'
+
+export type BrowserSpeechSupport = Readonly<{
+  supported: boolean
+  code?: string
+  message?: string
+}>
+
+export type BrowserSpeechEnvironment = Readonly<{
+  mediaDevices: MediaDevices
+  document: Document
+  createWorker(url: string): Worker
+  createAudioContext(): AudioContext
+  createAudioWorkletNode(context: AudioContext): AudioWorkletNode
+  createMessageChannel(): MessageChannel
+  createSessionId(): string
+  setTimeout: typeof globalThis.setTimeout
+  clearTimeout: typeof globalThis.clearTimeout
+}>
+
+export function detectBrowserSpeechSupport(scope: typeof globalThis = globalThis): BrowserSpeechSupport {
+  if (!scope.isSecureContext) return unsupported('browser_insecure_context', 'Browser speech requires a secure context.')
+  if (!scope.navigator?.mediaDevices?.getUserMedia) return unsupported('media_devices_unavailable', 'getUserMedia is unavailable.')
+  if (!('AudioContext' in scope) || !('AudioWorkletNode' in scope)) return unsupported('audio_worklet_unavailable', 'AudioWorklet is unavailable.')
+  if (!('Worker' in scope)) return unsupported('worker_unavailable', 'Dedicated Worker is unavailable.')
+  if (!('WebAssembly' in scope)) return unsupported('webassembly_unavailable', 'WebAssembly is unavailable.')
+  if (!('caches' in scope)) return unsupported('cache_storage_unavailable', 'Cache Storage is unavailable.')
+  return Object.freeze({ supported: true })
+}
+
+export function createBrowserSpeechCapability(
+  modelStore: Pick<BrowserModelStore, 'listModels' | 'downloadModel' | 'deleteModel' | 'onProgress'> = new BrowserModelStore(),
+  environment: BrowserSpeechEnvironment = browserSpeechEnvironment(),
+): SpeechRecognitionPlugin & SpeechAdministrationCapability {
+  let activeSessionId: string | null = null
+  return {
+    start(options, listener) {
+      const id = environment.createSessionId()
+      if (activeSessionId !== null) return failedSession(id, new BrowserSpeechError('session_active', 'A browser speech session is already active.'))
+      activeSessionId = id
+      return createSession(environment, modelStore, id, options, listener, () => {
+        if (activeSessionId === id) activeSessionId = null
+      })
+    },
+    listModels: () => modelStore.listModels(),
+    downloadModel: (modelId) => modelStore.downloadModel(modelId),
+    deleteModel: (modelId) => modelStore.deleteModel(modelId),
+    listInputDevices: async () => {
+      const devices = await environment.mediaDevices.enumerateDevices()
+      return devices.filter((device) => device.kind === 'audioinput').map((device) => device.deviceId)
+    },
+    onModelProgress: (handler, onError) => modelStore.onProgress(handler, onError),
+  }
+}
+
+function createSession(
+  environment: BrowserSpeechEnvironment,
+  modelStore: Pick<BrowserModelStore, 'listModels'>,
+  sessionId: string,
+  requestedOptions: SpeechRecognitionOptions,
+  listener: SpeechRecognitionListener,
+  release: () => void,
+): SpeechRecognitionSession {
+  let worker: Worker | null = null
+  let audioContext: AudioContext | null = null
+  let source: MediaStreamAudioSourceNode | null = null
+  let worklet: AudioWorkletNode | null = null
+  let mediaStream: MediaStream | null = null
+  let active = true
+  let readySettled = false
+  let terminalIntent: 'stop' | 'cancel' | null = null
+  let terminalPromise: Promise<void> | null = null
+  let resolveReady: () => void = () => {}
+  let rejectReady: (cause: unknown) => void = () => {}
+  let resolveTerminal: () => void = () => {}
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve
+    rejectReady = reject
+  })
+  const terminal = new Promise<void>((resolve) => (resolveTerminal = resolve))
+  let resolveFlushed: ((lastSeq: number) => void) | null = null
+  const visibilityHandler = () => {
+    if (environment.document.visibilityState === 'hidden' && active) {
+      fail(new BrowserSpeechError('background_suspended', 'Browser speech stopped because the page became hidden.'))
+    }
+  }
+  environment.document.addEventListener('visibilitychange', visibilityHandler)
+
+  void initialize().catch(fail)
+
+  async function initialize() {
+    const models = await modelStore.listModels()
+    if (!models[0]?.installed) {
+      throw new BrowserSpeechError('model_not_installed', 'The browser speech model is not installed. Open Voice settings to download it.')
+    }
+    const options = requestedOptions.modelId === BROWSER_SPEECH_MODEL_ID
+      ? requestedOptions
+      : { ...requestedOptions, modelId: BROWSER_SPEECH_MODEL_ID }
+    if (requestedOptions.modelId !== BROWSER_SPEECH_MODEL_ID) {
+      listener.onEvent({
+        type: 'warning', sessionId, code: 'browser_model_selection_migrated',
+        message: `Browser speech selected its local streaming model ${BROWSER_SPEECH_MODEL_ID} instead of ${requestedOptions.modelId}.`,
+      })
+    }
+    if (options.hotwords.length > 0) {
+      listener.onEvent({
+        type: 'warning', sessionId, code: 'hotwords_unsupported',
+        message: 'Browser speech does not currently apply hotwords.',
+      })
+    }
+
+    worker = environment.createWorker(BROWSER_SPEECH_RUNTIME.worker)
+    worker.onerror = () => fail(new BrowserSpeechError('worker_crashed', 'The browser speech Worker crashed.'))
+    const workerReady = new Promise<void>((resolve, reject) => {
+      if (!worker) return reject(new Error('Worker was not created.'))
+      worker.onmessage = ({ data }) => {
+        if (!isWorkerEvent(data, sessionId) || !active) return
+        switch (data.type) {
+          case 'ready': resolve(); break
+          case 'partial': listener.onEvent({ type: 'partial', sessionId, text: data.text }); break
+          case 'processing': listener.onEvent({ type: 'processing', sessionId, segmentIndex: data.segmentIndex }); break
+          case 'stable': listener.onEvent({ type: 'stable', sessionId, segmentIndex: data.segmentIndex, text: data.text }); break
+          case 'warning': listener.onEvent({ type: 'warning', sessionId, code: data.code, message: data.message }); break
+          case 'disposed': finish(data.reason); break
+          case 'fatal': reject(new BrowserSpeechError(data.code, data.message)); fail(new BrowserSpeechError(data.code, data.message)); break
+        }
+      }
+    })
+    worker.postMessage({
+      v: BROWSER_SPEECH_PROTOCOL_VERSION,
+      type: 'init',
+      sessionId,
+      cacheName: BROWSER_SPEECH_CACHE_NAME,
+      markerUrl: BROWSER_SPEECH_MARKER_URL,
+      runtime: {
+        glue: BROWSER_SPEECH_RUNTIME.glue,
+        wrapper: BROWSER_SPEECH_RUNTIME.wrapper,
+        wasm: BROWSER_SPEECH_RUNTIME.wasm,
+        wasmBytes: BROWSER_SPEECH_RUNTIME.wasmBytes,
+        wasmSha256: BROWSER_SPEECH_RUNTIME.wasmSha256,
+        version: BROWSER_SPEECH_RUNTIME.version,
+        gitSha: BROWSER_SPEECH_RUNTIME.gitSha,
+      },
+      files: BROWSER_SPEECH_MODEL_FILES,
+      options: { vadSilenceMs: options.vadSilenceMs },
+    })
+
+    // Load and verify the runtime/model before opening the microphone. This
+    // keeps the 8-credit PCM window for recognition, not cold-start warmup.
+    await withTimeout(
+      workerReady,
+      environment,
+      60_000,
+      'worker_initialization_timeout',
+      'The browser speech engine did not initialize within 60 seconds.',
+    )
+
+    const mediaPromise = environment.mediaDevices.getUserMedia({
+      audio: options.inputDevice
+        ? { deviceId: { exact: options.inputDevice }, channelCount: { ideal: 1 }, echoCancellation: false, noiseSuppression: false, autoGainControl: false }
+        : { channelCount: { ideal: 1 }, echoCancellation: false, noiseSuppression: false, autoGainControl: false },
+      video: false,
+    })
+    mediaStream = await withPermissionTimeout(mediaPromise, environment, 15_000, () => !active)
+    if (!active) {
+      stopTracks(mediaStream)
+      throw new BrowserSpeechError('session_cancelled', 'Browser speech was cancelled before microphone setup completed.')
+    }
+    for (const track of mediaStream.getAudioTracks()) {
+      track.onended = () => fail(new BrowserSpeechError('input_device_ended', 'The browser microphone input ended.'))
+    }
+    audioContext = environment.createAudioContext()
+    await audioContext.audioWorklet.addModule(BROWSER_SPEECH_RUNTIME.worklet)
+    if (audioContext.state === 'suspended') await audioContext.resume()
+    source = audioContext.createMediaStreamSource(mediaStream)
+    worklet = environment.createAudioWorkletNode(audioContext)
+    worklet.onprocessorerror = () => fail(new BrowserSpeechError('audio_worklet_failed', 'The browser audio capture worklet failed.'))
+    const silent = audioContext.createGain()
+    silent.gain.value = 0
+    source.connect(worklet).connect(silent).connect(audioContext.destination)
+    worklet.port.onmessage = ({ data }) => {
+      if (data?.type === 'level') listener.onEvent({ type: 'level', sessionId, rms: Number(data.rms) || 0 })
+      if (data?.type === 'flushed') {
+        if (data.droppedFrames > 0) {
+          listener.onEvent({ type: 'warning', sessionId, code: 'pcm_backpressure', message: `Browser audio dropped ${data.droppedFrames} frames because recognition could not keep up.` })
+        }
+        resolveFlushed?.(Number(data.lastSeq) || 0)
+        resolveFlushed = null
+      }
+    }
+    const channel = environment.createMessageChannel()
+    worker.postMessage({ v: 1, type: 'bindPcm', sessionId, port: channel.port1 }, [channel.port1])
+    worklet.port.postMessage({ type: 'bind', sessionId, credits: 8, port: channel.port2 }, [channel.port2])
+    if (!active || terminalIntent !== null) throw new BrowserSpeechError('session_cancelled', 'Browser speech stopped before it became ready.')
+    readySettled = true
+    listener.onEvent({
+      type: 'started', sessionId,
+      inputDevice: options.inputDevice || mediaStream.getAudioTracks()[0]?.label || 'System default microphone',
+      provider: 'sherpa-onnx-web-1.13.7/zipformer-small-ctc',
+    })
+    resolveReady()
+  }
+
+  function terminate(intent: 'stop' | 'cancel'): Promise<void> {
+    if (!active) return terminal
+    if (terminalIntent !== null) return terminalPromise ?? terminal
+    terminalIntent = intent
+    terminalPromise = intent === 'stop' ? gracefulStop() : abortiveCancel()
+    return terminalPromise
+  }
+
+  async function gracefulStop() {
+    if (!readySettled || !worklet || !worker) return abortiveCancel()
+    try {
+      const lastSeq = await withTimeout(new Promise<number>((resolve) => {
+        resolveFlushed = resolve
+        worklet?.port.postMessage({ type: 'flush' })
+      }), environment, 2_000, 'audio_worklet_flush_timeout', 'The audio worklet did not flush within 2 seconds.')
+      stopAudio()
+      worker.postMessage({ v: 1, type: 'stop', sessionId, lastSeq })
+      return await withTimeout(terminal, environment, 10_000, 'shutdown_timeout', 'The speech Worker did not finish the final segment within 10 seconds.')
+    } catch (cause) {
+      fail(cause)
+      return terminal
+    }
+  }
+
+  async function abortiveCancel() {
+    stopAudio()
+    worker?.postMessage({ v: 1, type: 'cancel', sessionId })
+    finish('cancelled')
+    return terminal
+  }
+
+  function fail(cause: unknown) {
+    if (!active) return
+    const error = cause instanceof BrowserSpeechError
+      ? cause
+      : new BrowserSpeechError('browser_speech_failed', cause instanceof Error ? cause.message : String(cause), { cause })
+    listener.onEvent({ type: 'error', sessionId, code: error.code, message: error.message })
+    listener.onError(error)
+    if (!readySettled) rejectReady(error)
+    stopAudio()
+    worker?.postMessage({ v: 1, type: 'cancel', sessionId })
+    finish('unexpected')
+  }
+
+  function finish(reason: SpeechRecognitionStopReason) {
+    if (!active) return
+    active = false
+    environment.document.removeEventListener('visibilitychange', visibilityHandler)
+    stopAudio()
+    worker?.terminate()
+    worker = null
+    release()
+    if (!readySettled && reason !== 'unexpected') rejectReady(new BrowserSpeechError('session_cancelled', 'Browser speech stopped before it became ready.'))
+    listener.onEvent({ type: 'stopped', sessionId, reason })
+    resolveTerminal()
+  }
+
+  function stopAudio() {
+    source?.disconnect()
+    worklet?.disconnect()
+    stopTracks(mediaStream)
+    mediaStream = null
+    void audioContext?.close().catch(() => undefined)
+    audioContext = null
+    source = null
+    worklet = null
+  }
+
+  return Object.freeze({ id: sessionId, ready, stop: () => terminate('stop'), cancel: () => terminate('cancel') })
+}
+
+async function withPermissionTimeout(
+  promise: Promise<MediaStream>,
+  environment: Pick<BrowserSpeechEnvironment, 'setTimeout' | 'clearTimeout'>,
+  milliseconds: number,
+  stale: () => boolean,
+): Promise<MediaStream> {
+  let timeout: ReturnType<typeof globalThis.setTimeout> | undefined
+  const lateGuard = promise.then((stream) => {
+    if (stale()) stopTracks(stream)
+    return stream
+  })
+  try {
+    return await Promise.race([
+      lateGuard,
+      new Promise<never>((_, reject) => {
+        timeout = environment.setTimeout(() => reject(new BrowserSpeechError('microphone_permission_timeout', 'The browser did not finish the microphone permission request within 15 seconds.')), milliseconds)
+      }),
+    ])
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === 'NotAllowedError') {
+      throw new BrowserSpeechError('microphone_permission_denied', 'Microphone permission was denied.', { cause })
+    }
+    throw cause
+  } finally {
+    if (timeout !== undefined) environment.clearTimeout(timeout)
+  }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  environment: Pick<BrowserSpeechEnvironment, 'setTimeout' | 'clearTimeout'>,
+  milliseconds: number,
+  code: string,
+  message: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof globalThis.setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = environment.setTimeout(() => reject(new BrowserSpeechError(code, message)), milliseconds)
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) environment.clearTimeout(timeout)
+  }
+}
+
+function stopTracks(stream: MediaStream | null) {
+  for (const track of stream?.getTracks() ?? []) track.stop()
+}
+
+function failedSession(id: string, cause: unknown): SpeechRecognitionSession {
+  return Object.freeze({ id, ready: Promise.reject(cause), stop: async () => undefined, cancel: async () => undefined })
+}
+
+function browserSpeechEnvironment(): BrowserSpeechEnvironment {
+  return {
+    mediaDevices: navigator.mediaDevices,
+    document,
+    createWorker: (url) => new Worker(url, { name: 'rambledesk-browser-speech' }),
+    createAudioContext: () => new AudioContext({ latencyHint: 'interactive' }),
+    createAudioWorkletNode: (context) => new AudioWorkletNode(context, 'rambledesk-pcm-capture', {
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      outputChannelCount: [1],
+    }),
+    createMessageChannel: () => new MessageChannel(),
+    createSessionId: () => crypto.randomUUID(),
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+  }
+}
+
+function unsupported(code: string, message: string): BrowserSpeechSupport {
+  return Object.freeze({ supported: false, code, message })
+}

--- a/apps/desktop/src/lib/capabilities/browser/speech/browserSpeechManifest.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/browserSpeechManifest.ts
@@ -1,0 +1,68 @@
+import type { SpeechModelInfo } from '../../workbenchCapabilities'
+
+export const BROWSER_SPEECH_MODEL_ID =
+  'zipformer-small-streaming-zh-en-ctc-int8-2026-06-18' as const
+export const BROWSER_SPEECH_MODEL_DIGEST =
+  'bb1b0ec05bd728f0732c8c0d313ce801ea8afa77453c091f841901dd242b1f44'
+export const BROWSER_SPEECH_CACHE_NAME =
+  `rambledesk-browser-speech-${BROWSER_SPEECH_MODEL_ID}-${BROWSER_SPEECH_MODEL_DIGEST}`
+export const BROWSER_SPEECH_MARKER_URL =
+  'https://rambledesk.invalid/browser-speech/installed.json'
+export const BROWSER_SPEECH_TOTAL_BYTES = 29_258_848
+
+const MODELSCOPE_BASE =
+  'https://www.modelscope.cn/models/pkufool/zipformer-small-streaming'
+const MODELSCOPE_REVISION = '8de27eb36a6f767eea91f2ff1f5660ad499ed688'
+
+export type BrowserSpeechModelFile = Readonly<{
+  name: string
+  bytes: number
+  sha256: string
+  url: string
+}>
+
+export const BROWSER_SPEECH_MODEL_FILES: readonly BrowserSpeechModelFile[] = Object.freeze([
+  modelFile('ctc-chunk-32-left-128.int8.onnx', 29_144_714, 'c82f67125c87e06b2cdb11e7ac3d5a7d3d81539634e384b4b60ccfb8cc1f3c82'),
+  modelFile('tokens.txt', 114_134, '5beaddf82e078ef5644dcad130f3c4817a04016bfb0f31c0df28c6b4fa8df3af', 'data/tokens.txt'),
+])
+
+export const BROWSER_SPEECH_RUNTIME = Object.freeze({
+  version: '1.13.7',
+  gitSha: '917bed95c8e5c7c18aa4d69fea42e9ef8ef0a60e',
+  root: '/browser-speech/runtime',
+  glue: '/browser-speech/runtime/sherpa-onnx-wasm-web.js',
+  wasm: '/browser-speech/runtime/sherpa-onnx-wasm-web.wasm',
+  wrapper: '/browser-speech/runtime/sherpa-onnx-asr.js',
+  worker: '/browser-speech/sherpa.worker.js',
+  worklet: '/browser-speech/pcm-capture.worklet.js',
+  wasmBytes: 14_869_666,
+  wasmSha256: 'f0bd7239906d96a5aff87b523879b898c0522d58c2c7ac2f8795b74186dc9c99',
+})
+
+export function browserSpeechModelInfo(installed: boolean, missingFiles: readonly string[]): SpeechModelInfo {
+  return Object.freeze({
+    id: BROWSER_SPEECH_MODEL_ID,
+    engine_id: 'sherpa_online',
+    display_name: 'Zipformer Small 流式中英（Browser experimental）',
+    description: '浏览器本地识别；模型下载到此浏览器的 Cache Storage，音频不会上传。',
+    size_bytes: BROWSER_SPEECH_TOTAL_BYTES,
+    installed,
+    path: installed
+      ? `Cache Storage: ${BROWSER_SPEECH_CACHE_NAME}`
+      : 'Browser Cache Storage (not installed)',
+    missing_files: missingFiles,
+    streaming: true,
+    hotwords_supported: false,
+    languages: ['中文', 'English'],
+    license: 'Apache-2.0 (ModelScope repository metadata)',
+  })
+}
+
+function modelFile(name: string, bytes: number, sha256: string, remotePath = name): BrowserSpeechModelFile {
+  return Object.freeze({
+    name,
+    bytes,
+    sha256,
+    url: `${MODELSCOPE_BASE}/resolve/${MODELSCOPE_REVISION}/${remotePath}`,
+  })
+}

--- a/apps/desktop/src/lib/capabilities/browser/speech/protocol.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/protocol.ts
@@ -1,0 +1,42 @@
+import type { BrowserSpeechModelFile } from './browserSpeechManifest'
+
+export const BROWSER_SPEECH_PROTOCOL_VERSION = 1 as const
+
+export type BrowserSpeechWorkerCommand =
+  | Readonly<{
+      v: 1
+      type: 'init'
+      sessionId: string
+      cacheName: string
+      runtime: Readonly<{ glue: string; wrapper: string; wasm: string; wasmBytes: number; wasmSha256: string; version: string; gitSha: string }>
+      files: readonly BrowserSpeechModelFile[]
+      options: Readonly<{ vadSilenceMs: number }>
+    }>
+  | Readonly<{ v: 1; type: 'bindPcm'; sessionId: string; port: MessagePort }>
+  | Readonly<{ v: 1; type: 'stop'; sessionId: string; lastSeq: number }>
+  | Readonly<{ v: 1; type: 'cancel'; sessionId: string }>
+
+export type BrowserSpeechWorkerEvent =
+  | Readonly<{ v: 1; type: 'ready'; sessionId: string; runtimeVersion: string; runtimeGitSha: string; ortVersion: string }>
+  | Readonly<{ v: 1; type: 'partial'; sessionId: string; text: string }>
+  | Readonly<{ v: 1; type: 'processing'; sessionId: string; segmentIndex: number }>
+  | Readonly<{ v: 1; type: 'stable'; sessionId: string; segmentIndex: number; text: string }>
+  | Readonly<{ v: 1; type: 'warning'; sessionId: string; code: string; message: string }>
+  | Readonly<{ v: 1; type: 'disposed'; sessionId: string; reason: 'stopped' | 'cancelled' }>
+  | Readonly<{ v: 1; type: 'fatal'; sessionId: string; code: string; message: string }>
+
+export type BrowserSpeechPcmMessage = Readonly<{
+  v: 1
+  type: 'pcm'
+  sessionId: string
+  seq: number
+  sampleRate: number
+  samples: ArrayBuffer
+}>
+
+export function isWorkerEvent(value: unknown, sessionId: string): value is BrowserSpeechWorkerEvent {
+  if (value === null || typeof value !== 'object') return false
+  const message = value as Record<string, unknown>
+  return message.v === BROWSER_SPEECH_PROTOCOL_VERSION &&
+    message.sessionId === sessionId && typeof message.type === 'string'
+}

--- a/apps/desktop/src/lib/capabilities/browser/speech/sha256.test.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/sha256.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { Sha256 } from './sha256'
+
+describe('incremental SHA-256', () => {
+  it.each([
+    ['', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+    ['abc', 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'],
+  ])('matches the standard vector for %j', (input, expected) => {
+    expect(new Sha256().update(new TextEncoder().encode(input)).digestHex()).toBe(expected)
+  })
+
+  it('is invariant to response chunk boundaries', () => {
+    const input = new TextEncoder().encode('RambleDesk browser speech '.repeat(200))
+    const whole = new Sha256().update(input).digestHex()
+    const chunked = new Sha256()
+    for (let offset = 0; offset < input.length; offset += 37) {
+      chunked.update(input.subarray(offset, offset + 37))
+    }
+    expect(chunked.digestHex()).toBe(whole)
+  })
+})

--- a/apps/desktop/src/lib/capabilities/browser/speech/sha256.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/sha256.ts
@@ -1,0 +1,98 @@
+/** Incremental SHA-256 used for large model responses without materializing a 155 MB ArrayBuffer. */
+export class Sha256 {
+  readonly #state = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ])
+  readonly #block = new Uint8Array(64)
+  readonly #words = new Uint32Array(64)
+  #blockLength = 0
+  #bytes = 0
+  #finished = false
+
+  update(input: Uint8Array): this {
+    if (this.#finished) throw new Error('SHA-256 digest is already finalized.')
+    this.#bytes += input.byteLength
+    let offset = 0
+    while (offset < input.byteLength) {
+      const count = Math.min(64 - this.#blockLength, input.byteLength - offset)
+      this.#block.set(input.subarray(offset, offset + count), this.#blockLength)
+      this.#blockLength += count
+      offset += count
+      if (this.#blockLength === 64) {
+        this.#compress()
+        this.#blockLength = 0
+      }
+    }
+    return this
+  }
+
+  digestHex(): string {
+    if (!this.#finished) {
+      const bitLength = BigInt(this.#bytes) * 8n
+      this.#block[this.#blockLength++] = 0x80
+      if (this.#blockLength > 56) {
+        this.#block.fill(0, this.#blockLength)
+        this.#compress()
+        this.#blockLength = 0
+      }
+      this.#block.fill(0, this.#blockLength, 56)
+      for (let index = 0; index < 8; index += 1) {
+        this.#block[63 - index] = Number((bitLength >> BigInt(index * 8)) & 0xffn)
+      }
+      this.#compress()
+      this.#finished = true
+    }
+    return [...this.#state].map((word) => word.toString(16).padStart(8, '0')).join('')
+  }
+
+  #compress() {
+    const words = this.#words
+    for (let index = 0; index < 16; index += 1) {
+      const offset = index * 4
+      words[index] = (
+        (this.#block[offset] << 24) |
+        (this.#block[offset + 1] << 16) |
+        (this.#block[offset + 2] << 8) |
+        this.#block[offset + 3]
+      ) >>> 0
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const x = words[index - 15]
+      const y = words[index - 2]
+      const s0 = rotate(x, 7) ^ rotate(x, 18) ^ (x >>> 3)
+      const s1 = rotate(y, 17) ^ rotate(y, 19) ^ (y >>> 10)
+      words[index] = (words[index - 16] + s0 + words[index - 7] + s1) >>> 0
+    }
+    let [a, b, c, d, e, f, g, h] = this.#state
+    for (let index = 0; index < 64; index += 1) {
+      const s1 = rotate(e, 6) ^ rotate(e, 11) ^ rotate(e, 25)
+      const choose = (e & f) ^ (~e & g)
+      const first = (h + s1 + choose + K[index] + words[index]) >>> 0
+      const s0 = rotate(a, 2) ^ rotate(a, 13) ^ rotate(a, 22)
+      const majority = (a & b) ^ (a & c) ^ (b & c)
+      const second = (s0 + majority) >>> 0
+      h = g; g = f; f = e; e = (d + first) >>> 0
+      d = c; c = b; b = a; a = (first + second) >>> 0
+    }
+    const next = [a, b, c, d, e, f, g, h]
+    for (let index = 0; index < 8; index += 1) {
+      this.#state[index] = (this.#state[index] + next[index]) >>> 0
+    }
+  }
+}
+
+function rotate(value: number, count: number): number {
+  return (value >>> count) | (value << (32 - count))
+}
+
+const K = new Uint32Array([
+  0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+  0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+  0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+  0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+  0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+  0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+  0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+  0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2,
+])

--- a/apps/desktop/src/lib/capabilities/browser/speech/streamingResampler.test.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/streamingResampler.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { downmixToMono, StreamingResampler } from './streamingResampler'
+
+describe('browser speech audio transforms', () => {
+  it.each([44_100, 48_000, 96_000])('resamples %i Hz to 16 kHz independently of chunks', (rate) => {
+    const input = Float32Array.from({ length: rate }, (_, index) => Math.sin(index / 31))
+    const whole = new StreamingResampler(rate)
+    const expected = [...whole.push(input), ...whole.flush()]
+    const chunked = new StreamingResampler(rate)
+    const actual: number[] = []
+    for (let offset = 0; offset < input.length; offset += 997) {
+      actual.push(...chunked.push(input.subarray(offset, offset + 997)))
+    }
+    actual.push(...chunked.flush())
+    expect(actual).toHaveLength(expected.length)
+    expect(actual).toEqual(expected)
+    expect(actual.every(Number.isFinite)).toBe(true)
+    expect(actual.length).toBeGreaterThanOrEqual(15_999)
+    expect(actual.length).toBeLessThanOrEqual(16_001)
+  })
+
+  it('downmixes every input channel instead of selecting the first', () => {
+    expect([...downmixToMono([new Float32Array([1, -1]), new Float32Array([-1, 1])])]).toEqual([0, 0])
+  })
+})

--- a/apps/desktop/src/lib/capabilities/browser/speech/streamingResampler.ts
+++ b/apps/desktop/src/lib/capabilities/browser/speech/streamingResampler.ts
@@ -1,0 +1,67 @@
+export class StreamingResampler {
+  #buffer = new Float32Array(0)
+  #bufferStart = 0
+  #totalInput = 0
+  #nextOutput = 0
+
+  constructor(readonly inputRate: number, readonly outputRate = 16_000) {
+    if (!(inputRate > 0) || !(outputRate > 0)) throw new RangeError('Sample rates must be positive.')
+  }
+
+  push(input: Float32Array): Float32Array {
+    if (input.length === 0) return new Float32Array(0)
+    const data = new Float32Array(this.#buffer.length + input.length)
+    data.set(this.#buffer)
+    data.set(input, this.#buffer.length)
+    this.#totalInput += input.length
+    const output: number[] = []
+    let position = this.#sourcePosition()
+    while (position + 1 < this.#totalInput) {
+      const absoluteIndex = Math.floor(position)
+      const index = absoluteIndex - this.#bufferStart
+      const fraction = position - absoluteIndex
+      output.push(data[index] + (data[index + 1] - data[index]) * fraction)
+      this.#nextOutput += 1
+      position = this.#sourcePosition()
+    }
+    const nextRequired = Math.min(Math.floor(position), this.#totalInput - 1)
+    const consumed = Math.max(0, nextRequired - this.#bufferStart)
+    this.#buffer = data.slice(consumed)
+    this.#bufferStart += consumed
+    return Float32Array.from(output)
+  }
+
+  flush(): Float32Array {
+    if (this.#buffer.length === 0) return new Float32Array(0)
+    const output: number[] = []
+    let position = this.#sourcePosition()
+    while (position < this.#totalInput) {
+      const index = Math.floor(position) - this.#bufferStart
+      const next = Math.min(index + 1, this.#buffer.length - 1)
+      const fraction = position - Math.floor(position)
+      output.push(this.#buffer[index] + (this.#buffer[next] - this.#buffer[index]) * fraction)
+      this.#nextOutput += 1
+      position = this.#sourcePosition()
+    }
+    this.#buffer = new Float32Array(0)
+    this.#bufferStart = 0
+    this.#totalInput = 0
+    this.#nextOutput = 0
+    return Float32Array.from(output)
+  }
+
+  #sourcePosition(): number {
+    return this.#nextOutput * this.inputRate / this.outputRate
+  }
+}
+
+export function downmixToMono(channels: readonly Float32Array[]): Float32Array {
+  if (channels.length === 0) return new Float32Array(0)
+  if (channels.length === 1) return channels[0].slice()
+  const length = Math.min(...channels.map((channel) => channel.length))
+  const mono = new Float32Array(length)
+  for (const channel of channels) {
+    for (let index = 0; index < length; index += 1) mono[index] += channel[index] / channels.length
+  }
+  return mono
+}

--- a/apps/desktop/src/lib/capabilities/capabilities.test.ts
+++ b/apps/desktop/src/lib/capabilities/capabilities.test.ts
@@ -41,7 +41,10 @@ describe('capability contracts', () => {
   it('reports subscription failure asynchronously and respects early unsubscribe', async () => {
     const capabilities = createUnavailableWorkbenchCapabilities()
     const onError = vi.fn()
-    const unsubscribe = capabilities.speech.implementation.onEvent(vi.fn(), onError)
+    const unsubscribe = capabilities.dataStorageAdministration.implementation.onProgress(
+      vi.fn(),
+      onError,
+    )
     unsubscribe()
     await Promise.resolve()
     expect(onError).not.toHaveBeenCalled()

--- a/apps/desktop/src/lib/capabilities/capabilityArchitecture.test.ts
+++ b/apps/desktop/src/lib/capabilities/capabilityArchitecture.test.ts
@@ -78,4 +78,50 @@ describe('capability architecture', () => {
 
     expect(actual.sort()).toEqual(expected.sort())
   })
+
+  it('keeps platform capability implementations outside Draft and Application Transport', async () => {
+    const sourceRoot = fileURLToPath(new URL('../../', import.meta.url))
+    const capabilityRoot = path.join(sourceRoot, 'lib', 'capabilities')
+    const platformFiles = [
+      ...(await sourceFiles(path.join(capabilityRoot, 'browser'))),
+      ...(await sourceFiles(path.join(capabilityRoot, 'tauri'))),
+    ]
+    const forbidden = [
+      'ApplicationTransport',
+      'RichFeedbackEditor',
+      'draftOperations',
+      '@tiptap/',
+      'FeedbackWorkspace',
+    ]
+    const violations: string[] = []
+
+    for (const file of platformFiles) {
+      const source = await readFile(file, 'utf8')
+      if (forbidden.some((marker) => source.includes(marker))) {
+        violations.push(portableRelativePath(sourceRoot, file))
+      }
+    }
+
+    expect(violations).toEqual([])
+  })
+
+  it('keeps the native Speech Plugin independent from Feedback Requests', async () => {
+    const sourceRoot = fileURLToPath(new URL('../../', import.meta.url))
+    const plugin = await readFile(
+      path.join(sourceRoot, 'lib', 'capabilities', 'tauri', 'speechCapability.ts'),
+      'utf8',
+    )
+    const commands = await readFile(
+      path.join(sourceRoot, '..', 'src-tauri', 'src', 'commands.rs'),
+      'utf8',
+    )
+    const start = commands.slice(
+      commands.indexOf('pub(super) async fn start_voice_ramble'),
+      commands.indexOf('pub(super) async fn stop_voice_ramble'),
+    )
+
+    expect(plugin).not.toMatch(/requestId|request_id|ApplicationTransport|FeedbackWorkspace/u)
+    expect(start).not.toContain(['get', 'feedback', 'workspace'].join('_'))
+    expect(start).not.toContain(['Feedback', 'Status'].join(''))
+  })
 })

--- a/apps/desktop/src/lib/capabilities/speechModelSelection.test.ts
+++ b/apps/desktop/src/lib/capabilities/speechModelSelection.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import type { SpeechModelInfo } from './workbenchCapabilities'
+import { resolveSupportedSpeechModelId } from './speechModelSelection'
+
+const xAsr = 'x-asr-480ms-streaming-zh-en-punct-int8-2026-06-05' as const
+const senseVoice = 'sense-voice-zh-en-ja-ko-yue-2024-07-17' as const
+const model = (id: SpeechModelInfo['id']) => ({ id }) as SpeechModelInfo
+
+describe('platform speech model selection', () => {
+  it('migrates a stale Desktop default only when the platform has one explicit model', () => {
+    expect(resolveSupportedSpeechModelId(senseVoice, [model(xAsr)])).toBe(xAsr)
+  })
+
+  it('never guesses when several platform models remain possible', () => {
+    expect(resolveSupportedSpeechModelId(senseVoice, [model(xAsr), model(senseVoice)])).toBe(senseVoice)
+    expect(resolveSupportedSpeechModelId(senseVoice, [model(xAsr), model('funasr-nano-int8-2025-12-30')])).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/capabilities/speechModelSelection.ts
+++ b/apps/desktop/src/lib/capabilities/speechModelSelection.ts
@@ -1,0 +1,10 @@
+import type { SpeechModelId } from '$lib/preferences'
+
+/** Resolve a platform's saved choice without pretending an unsupported model is installed. */
+export function resolveSupportedSpeechModelId(
+  selected: SpeechModelId,
+  models: readonly Readonly<{ id: SpeechModelId }>[],
+): SpeechModelId | null {
+  if (models.some((model) => model.id === selected)) return selected
+  return models.length === 1 ? models[0].id : null
+}

--- a/apps/desktop/src/lib/capabilities/tauri/speechCapability.test.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/speechCapability.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SpeechRecognitionEvent } from '$lib/speech'
+import { createTauriSpeechCapability } from './speechCapability'
+import type {
+  TauriCapabilityApi,
+  TauriEvent,
+  TauriUnlisten,
+} from './tauriCapabilityApi'
+
+type NativeEvent = Readonly<Record<string, unknown> & {
+  type: string
+  recognition_session_id: string
+}>
+
+type SpeechHarness = Readonly<{
+  api: TauriCapabilityApi
+  invoke: ReturnType<typeof vi.fn>
+  listen: ReturnType<typeof vi.fn>
+  unlisten: ReturnType<typeof vi.fn>
+  emit(event: NativeEvent): void
+}>
+
+const OPTIONS = Object.freeze({
+  inputDevice: null,
+  modelId: 'sense-voice-small',
+  vadThreshold: 0.4,
+  vadSilenceMs: 650,
+  hotwords: ['RambleDesk'],
+})
+
+function harness(
+  onStop: (emit: (event: NativeEvent) => void) => void = (emit) => {
+    emit({ type: 'stopped', recognition_session_id: 'session-a' })
+  },
+): SpeechHarness {
+  let handler: ((event: TauriEvent<NativeEvent>) => void) | undefined
+  const unlisten = vi.fn()
+  const emit = (event: NativeEvent) => handler?.({ payload: event })
+  const listen = vi.fn(async (_event: string, next: typeof handler): Promise<TauriUnlisten> => {
+    handler = next
+    return unlisten
+  })
+  const invoke = vi.fn(async (command: string, args?: Record<string, unknown>) => {
+    if (command === 'start_voice_ramble') {
+      const input = args?.input as { recognition_session_id: string }
+      return {
+        recognition_session_id: input.recognition_session_id,
+        provider: 'sense_voice',
+        model_path: '/models/sense-voice',
+      }
+    }
+    if (command === 'stop_voice_ramble') onStop(emit)
+    return undefined
+  })
+  return {
+    api: { invoke, listen } as unknown as TauriCapabilityApi,
+    invoke,
+    listen,
+    unlisten,
+    emit,
+  }
+}
+
+function listener() {
+  const events: SpeechRecognitionEvent[] = []
+  const onError = vi.fn()
+  return {
+    events,
+    onError,
+    value: {
+      onEvent: (event: SpeechRecognitionEvent) => events.push(event),
+      onError,
+    },
+  }
+}
+
+describe('Tauri SpeechRecognitionPlugin contract', () => {
+  it('registers the event listener before it invokes native start', async () => {
+    let resolveListen: ((unlisten: TauriUnlisten) => void) | undefined
+    const base = harness()
+    base.listen.mockImplementationOnce(
+      () => new Promise<TauriUnlisten>((resolve) => (resolveListen = resolve)),
+    )
+    const speech = createTauriSpeechCapability(base.api, () => 'session-a')
+    const observed = listener()
+
+    const session = speech.start(OPTIONS, observed.value)
+    expect(session.id).toBe('session-a')
+    expect(base.listen).toHaveBeenCalledWith('voice-ramble-event', expect.any(Function))
+    expect(base.invoke).not.toHaveBeenCalled()
+
+    resolveListen?.(base.unlisten as unknown as TauriUnlisten)
+    await session.ready
+
+    expect(base.invoke.mock.invocationCallOrder[0]).toBeGreaterThan(
+      base.listen.mock.invocationCallOrder[0] ?? 0,
+    )
+    expect(base.invoke).toHaveBeenCalledWith('start_voice_ramble', {
+      input: {
+        recognition_session_id: 'session-a',
+        input_device: null,
+        model_id: 'sense-voice-small',
+        vad_threshold: 0.4,
+        vad_silence_ms: 650,
+        hotwords: ['RambleDesk'],
+      },
+    })
+  })
+
+  it('maps only events belonging to its own session', async () => {
+    const base = harness()
+    const observed = listener()
+    const session = createTauriSpeechCapability(base.api, () => 'session-a')
+      .start(OPTIONS, observed.value)
+    await session.ready
+
+    base.emit({
+      type: 'stable',
+      recognition_session_id: 'old-session',
+      chunk_index: 0,
+      text: '旧内容',
+    })
+    base.emit({
+      type: 'stable',
+      recognition_session_id: 'session-a',
+      chunk_index: 2,
+      text: '新内容',
+    })
+
+    expect(observed.events).toEqual([
+      { type: 'stable', sessionId: 'session-a', segmentIndex: 2, text: '新内容' },
+    ])
+  })
+
+  it('gracefully stops once and preserves native tail events before stopped', async () => {
+    const base = harness((emit) => {
+      emit({
+        type: 'stable',
+        recognition_session_id: 'session-a',
+        chunk_index: 3,
+        text: '尾帧',
+      })
+      emit({ type: 'stopped', recognition_session_id: 'session-a' })
+    })
+    const observed = listener()
+    const session = createTauriSpeechCapability(base.api, () => 'session-a')
+      .start(OPTIONS, observed.value)
+    await session.ready
+
+    await Promise.all([session.stop(), session.stop()])
+
+    expect(base.invoke.mock.calls.filter(([command]) => command === 'stop_voice_ramble')).toHaveLength(1)
+    expect(observed.events).toEqual([
+      { type: 'stable', sessionId: 'session-a', segmentIndex: 3, text: '尾帧' },
+      { type: 'stopped', sessionId: 'session-a', reason: 'stopped' },
+    ])
+    expect(base.unlisten).toHaveBeenCalledOnce()
+  })
+
+  it('cancels once and suppresses native tail recognition output', async () => {
+    const base = harness((emit) => {
+      emit({
+        type: 'stable',
+        recognition_session_id: 'session-a',
+        chunk_index: 4,
+        text: '不应写入',
+      })
+      emit({ type: 'stopped', recognition_session_id: 'session-a' })
+    })
+    const observed = listener()
+    const session = createTauriSpeechCapability(base.api, () => 'session-a')
+      .start(OPTIONS, observed.value)
+    await session.ready
+
+    await Promise.all([session.cancel(), session.stop(), session.cancel()])
+
+    expect(base.invoke.mock.calls.filter(([command]) => command === 'stop_voice_ramble')).toHaveLength(1)
+    expect(observed.events).toEqual([
+      { type: 'stopped', sessionId: 'session-a', reason: 'cancelled' },
+    ])
+  })
+
+  it('can cancel while listener registration is still pending without starting native audio', async () => {
+    let resolveListen: ((unlisten: TauriUnlisten) => void) | undefined
+    const base = harness()
+    base.listen.mockImplementationOnce(
+      () => new Promise<TauriUnlisten>((resolve) => (resolveListen = resolve)),
+    )
+    const observed = listener()
+    const session = createTauriSpeechCapability(base.api, () => 'session-a')
+      .start(OPTIONS, observed.value)
+
+    const cancelled = session.cancel()
+    resolveListen?.(base.unlisten as unknown as TauriUnlisten)
+
+    await cancelled
+    await expect(session.ready).rejects.toThrow('stopped before it became ready')
+    expect(base.invoke).not.toHaveBeenCalledWith('start_voice_ramble', expect.anything())
+    expect(observed.events).toEqual([
+      { type: 'stopped', sessionId: 'session-a', reason: 'cancelled' },
+    ])
+  })
+})

--- a/apps/desktop/src/lib/capabilities/tauri/speechCapability.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/speechCapability.ts
@@ -1,33 +1,298 @@
 import type {
   SpeechAdministrationCapability,
-  SpeechCapability,
+  SpeechRecognitionOptions,
+  SpeechRecognitionPlugin,
 } from '../workbenchCapabilities'
+import type {
+  SpeechRecognitionEvent,
+  SpeechRecognitionListener,
+  SpeechRecognitionSession,
+  SpeechRecognitionStopReason,
+} from '$lib/speech'
 import { subscribeToTauriEvent } from './subscription'
-import type { TauriCapabilityApi } from './tauriCapabilityApi'
+import type { TauriCapabilityApi, TauriUnlisten } from './tauriCapabilityApi'
+
+type NativeSpeechEvent =
+  | Readonly<{
+      type: 'started'
+      recognition_session_id: string
+      input_device: string
+      provider: string
+    }>
+  | Readonly<{
+      type: 'partial'
+      recognition_session_id: string
+      text: string
+    }>
+  | Readonly<{
+      type: 'level'
+      recognition_session_id: string
+      rms: number
+    }>
+  | Readonly<{
+      type: 'processing'
+      recognition_session_id: string
+      chunk_index: number
+    }>
+  | Readonly<{
+      type: 'stable'
+      recognition_session_id: string
+      chunk_index: number
+      text: string
+    }>
+  | Readonly<{
+      type: 'warning'
+      recognition_session_id: string
+      code: string
+      message: string
+    }>
+  | Readonly<{
+      type: 'stopped'
+      recognition_session_id: string
+    }>
+  | Readonly<{
+      type: 'error'
+      recognition_session_id: string
+      code: string
+      message: string
+    }>
+
+type NativeSpeechSessionView = Readonly<{
+  recognition_session_id: string
+  provider: string
+  model_path: string
+}>
+
+type TerminalIntent = 'stop' | 'cancel'
+
+class SpeechSessionTerminatedBeforeReadyError extends Error {
+  constructor() {
+    super('Speech recognition stopped before it became ready.')
+    this.name = 'SpeechSessionTerminatedBeforeReadyError'
+  }
+}
 
 export function createTauriSpeechCapability(
   api: TauriCapabilityApi,
-): SpeechCapability & SpeechAdministrationCapability {
+  createSessionId: () => string = () => crypto.randomUUID(),
+): SpeechRecognitionPlugin & SpeechAdministrationCapability {
+  let activeSessionId: string | null = null
+
   return {
-    start: (input) =>
-      api.invoke('start_voice_ramble', {
-        input: {
-          request_id: input.requestId,
-          input_device: input.inputDevice,
-          model_id: input.modelId,
-          vad_threshold: input.vadThreshold,
-          vad_silence_ms: input.vadSilenceMs,
-          hotwords: [...input.hotwords],
-        },
-      }),
-    stop: () => api.invoke<void>('stop_voice_ramble'),
-    onEvent: (handler, onError) =>
-      subscribeToTauriEvent(api, 'voice-ramble-event', handler, onError),
+    start: (options, listener) => {
+      const sessionId = createSessionId()
+      if (activeSessionId !== null) {
+        return failedSession(
+          sessionId,
+          new Error('A speech recognition session is already active.'),
+        )
+      }
+      activeSessionId = sessionId
+      return createSession(api, sessionId, options, listener, () => {
+        if (activeSessionId === sessionId) activeSessionId = null
+      })
+    },
     listModels: () => api.invoke('list_speech_models'),
     downloadModel: (modelId) => api.invoke('download_speech_model', { modelId }),
     deleteModel: (modelId) => api.invoke('delete_speech_model', { modelId }),
     listInputDevices: () => api.invoke('list_speech_input_devices'),
     onModelProgress: (handler, onError) =>
       subscribeToTauriEvent(api, 'speech-model-progress', handler, onError),
+  }
+}
+
+function createSession(
+  api: TauriCapabilityApi,
+  sessionId: string,
+  options: SpeechRecognitionOptions,
+  listener: SpeechRecognitionListener,
+  releaseSlot: () => void,
+): SpeechRecognitionSession {
+  let active = true
+  let unlisten: TauriUnlisten | undefined
+  let terminalIntent: TerminalIntent | null = null
+  let termination: Promise<void> | null = null
+  let startIssued = false
+  let startCommand: Promise<NativeSpeechSessionView> | null = null
+  let resolveStartDecision: () => void = () => {}
+  const startDecision = new Promise<void>((resolve) => {
+    resolveStartDecision = resolve
+  })
+  let resolveTerminal: () => void = () => {}
+  let rejectTerminal: (cause: unknown) => void = () => {}
+  const terminal = new Promise<void>((resolve, reject) => {
+    resolveTerminal = resolve
+    rejectTerminal = reject
+  })
+
+  const finish = (reason: SpeechRecognitionStopReason) => {
+    if (!active) return
+    active = false
+    unlisten?.()
+    unlisten = undefined
+    releaseSlot()
+    listener.onEvent({ type: 'stopped', sessionId, reason })
+    resolveTerminal()
+  }
+
+  const fail = (cause: unknown) => {
+    if (!active) return
+    active = false
+    unlisten?.()
+    unlisten = undefined
+    releaseSlot()
+    listener.onError(cause)
+    resolveTerminal()
+  }
+
+  const handleNativeEvent = (wire: NativeSpeechEvent) => {
+    if (!active || wire.recognition_session_id !== sessionId) return
+    if (wire.type === 'stopped') {
+      const reason = terminalIntent === 'cancel'
+        ? 'cancelled'
+        : terminalIntent === 'stop'
+          ? 'stopped'
+          : 'unexpected'
+      finish(reason)
+      return
+    }
+    // The native compatibility facade currently uses graceful shutdown for
+    // both paths. Cancellation still has abortive public semantics because no
+    // tail or queued recognition event escapes after the caller cancels.
+    if (terminalIntent === 'cancel') return
+    listener.onEvent(mapNativeSpeechEvent(wire))
+  }
+
+  const ready = (async () => {
+    try {
+      unlisten = await api.listen<NativeSpeechEvent>(
+        'voice-ramble-event',
+        ({ payload }) => handleNativeEvent(payload),
+      )
+      if (terminalIntent !== null) {
+        resolveStartDecision()
+        finish('cancelled')
+        throw new SpeechSessionTerminatedBeforeReadyError()
+      }
+      startIssued = true
+      startCommand = api.invoke<NativeSpeechSessionView>('start_voice_ramble', {
+        input: {
+          recognition_session_id: sessionId,
+          input_device: options.inputDevice,
+          model_id: options.modelId,
+          vad_threshold: options.vadThreshold,
+          vad_silence_ms: options.vadSilenceMs,
+          hotwords: [...options.hotwords],
+        },
+      })
+      resolveStartDecision()
+      const started = await startCommand
+      if (started.recognition_session_id !== sessionId) {
+        throw new Error('Native speech recognition returned a different session id.')
+      }
+      if (terminalIntent !== null) {
+        throw new SpeechSessionTerminatedBeforeReadyError()
+      }
+    } catch (cause) {
+      resolveStartDecision()
+      if (terminalIntent === null) fail(cause)
+      throw cause
+    }
+  })()
+
+  function terminate(intent: TerminalIntent): Promise<void> {
+    if (!active) return terminal
+    if (terminalIntent !== null) return termination ?? terminal
+    terminalIntent = intent
+    termination = runTermination()
+    return termination
+  }
+
+  async function runTermination(): Promise<void> {
+    await startDecision
+    if (!active) return terminal
+    if (!startIssued || startCommand === null) {
+      finish('cancelled')
+      return terminal
+    }
+    try {
+      await startCommand
+      if (!active) return terminal
+      await api.invoke<void>('stop_voice_ramble')
+      return terminal
+    } catch (cause) {
+      if (active) {
+        listener.onError(cause)
+        listener.onEvent({ type: 'stopped', sessionId, reason: 'unexpected' })
+        active = false
+        unlisten?.()
+        unlisten = undefined
+        releaseSlot()
+        rejectTerminal(cause)
+      }
+      return terminal
+    }
+  }
+
+  return Object.freeze({
+    id: sessionId,
+    ready,
+    stop: () => terminate('stop'),
+    cancel: () => terminate('cancel'),
+  })
+}
+
+function failedSession(sessionId: string, cause: unknown): SpeechRecognitionSession {
+  const ready = Promise.reject(cause)
+  return Object.freeze({
+    id: sessionId,
+    ready,
+    stop: async () => undefined,
+    cancel: async () => undefined,
+  })
+}
+
+function mapNativeSpeechEvent(
+  wire: Exclude<NativeSpeechEvent, { type: 'stopped' }>,
+): SpeechRecognitionEvent {
+  switch (wire.type) {
+    case 'started':
+      return {
+        type: 'started',
+        sessionId: wire.recognition_session_id,
+        inputDevice: wire.input_device,
+        provider: wire.provider,
+      }
+    case 'partial':
+      return { type: 'partial', sessionId: wire.recognition_session_id, text: wire.text }
+    case 'level':
+      return { type: 'level', sessionId: wire.recognition_session_id, rms: wire.rms }
+    case 'processing':
+      return {
+        type: 'processing',
+        sessionId: wire.recognition_session_id,
+        segmentIndex: wire.chunk_index,
+      }
+    case 'stable':
+      return {
+        type: 'stable',
+        sessionId: wire.recognition_session_id,
+        segmentIndex: wire.chunk_index,
+        text: wire.text,
+      }
+    case 'warning':
+      return {
+        type: 'warning',
+        sessionId: wire.recognition_session_id,
+        code: wire.code,
+        message: wire.message,
+      }
+    case 'error':
+      return {
+        type: 'error',
+        sessionId: wire.recognition_session_id,
+        code: wire.code,
+        message: wire.message,
+      }
   }
 }

--- a/apps/desktop/src/lib/capabilities/tauri/tauriCapabilities.test.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/tauriCapabilities.test.ts
@@ -44,7 +44,17 @@ function createFakeApi(responses: Record<string, unknown> = {}): FakeApi {
   const window = fakeWindow()
   const webview = fakeWebview()
   const invokeMock = vi.fn(
-    async (command: string) => responses[command],
+    async (command: string, args?: Record<string, unknown>) => {
+      if (command === 'start_voice_ramble' && responses[command] === undefined) {
+        const input = args?.input as { recognition_session_id?: string } | undefined
+        return {
+          recognition_session_id: input?.recognition_session_id,
+          provider: 'sense_voice',
+          model_path: '/models/sense-voice',
+        }
+      }
+      return responses[command]
+    },
   )
   const listenMock = vi.fn(async () => vi.fn())
   const emitMock = vi.fn(async () => undefined)
@@ -205,14 +215,17 @@ describe('Tauri Workbench capabilities', () => {
       fileName: 'clipboard.png',
       expectedRevision: 9,
     })
-    await capabilities.speech.implementation.start({
-      requestId: 'request-1',
-      inputDevice: null,
-      modelId: 'sense-voice-small',
-      vadThreshold: 0.4,
-      vadSilenceMs: 650,
-      hotwords: ['RambleDesk'],
-    })
+    const speechSession = capabilities.speech.implementation.start(
+      {
+        inputDevice: null,
+        modelId: 'sense-voice-small',
+        vadThreshold: 0.4,
+        vadSilenceMs: 650,
+        hotwords: ['RambleDesk'],
+      },
+      { onEvent: vi.fn(), onError: vi.fn() },
+    )
+    await speechSession.ready
 
     expect(api.invokeMock).toHaveBeenCalledWith('import_feedback_attachment_path', {
       requestId: 'request-1', path: '/tmp/example.png', expectedRevision: 7,
@@ -232,7 +245,7 @@ describe('Tauri Workbench capabilities', () => {
     })
     expect(api.invokeMock).toHaveBeenCalledWith('start_voice_ramble', {
       input: {
-        request_id: 'request-1',
+        recognition_session_id: speechSession.id,
         input_device: null,
         model_id: 'sense-voice-small',
         vad_threshold: 0.4,
@@ -334,7 +347,6 @@ describe('Tauri Workbench capabilities', () => {
     await capabilities.globalShortcuts.implementation.read()
     await capabilities.globalShortcuts.implementation.reset()
     await capabilities.globalShortcuts.implementation.setCaptureActive(true)
-    await capabilities.speech.implementation.stop()
     await capabilities.speech.implementation.listModels()
     await capabilities.speech.implementation.downloadModel('sense-voice-small')
     await capabilities.speech.implementation.deleteModel('sense-voice-small')
@@ -354,7 +366,6 @@ describe('Tauri Workbench capabilities', () => {
     capabilities.screenCapture.implementation.onFinished(handler, onError)
     capabilities.screenCapture.implementation.onShortcut(handler, onError)
     capabilities.globalShortcuts.implementation.onRambleToggle(handler, onError)
-    capabilities.speech.implementation.onEvent(handler, onError)
     capabilities.speech.implementation.onModelProgress(handler, onError)
     capabilities.rambleConsole.implementation.onCommand(handler, onError)
     capabilities.rambleConsole.implementation.onReady(handler, onError)
@@ -392,7 +403,6 @@ describe('Tauri Workbench capabilities', () => {
       'screen-capture-finished',
       'screen-capture-shortcut',
       'ramble-toggle-shortcut',
-      'voice-ramble-event',
       'speech-model-progress',
       'ramble-console-command',
       'ramble-console-ready',

--- a/apps/desktop/src/lib/capabilities/unavailableCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/unavailableCapabilities.ts
@@ -94,9 +94,12 @@ const UNAVAILABLE_WORKBENCH_CAPABILITIES = createWorkbenchCapabilities({
     onRambleToggle: (_handler, onError) => unavailableSubscription('globalShortcuts', onError),
   }),
   speech: slot({
-    start: () => rejected('speech'),
-    stop: () => rejected('speech'),
-    onEvent: (_handler, onError) => unavailableSubscription('speech', onError),
+    start: () => ({
+      id: 'unavailable-speech',
+      ready: rejected('speech'),
+      stop: () => rejected('speech'),
+      cancel: () => rejected('speech'),
+    }),
     listModels: () => rejected('speech'),
     downloadModel: () => rejected('speech'),
     deleteModel: () => rejected('speech'),

--- a/apps/desktop/src/lib/capabilities/workbenchCapabilities.ts
+++ b/apps/desktop/src/lib/capabilities/workbenchCapabilities.ts
@@ -5,7 +5,10 @@ import type { SpeechModelId } from '$lib/preferences'
 import type { RambleConsoleCommand, RambleConsoleState } from '$lib/rambleConsole'
 import type { ScreenCaptureReady } from '$lib/screenCapture'
 import type { ShortcutAction, ShortcutConfig } from '$lib/shortcutSettings'
-import type { SpeechEvent, VoiceRambleSessionView } from '$lib/speech'
+import type {
+  SpeechRecognitionListener,
+  SpeechRecognitionSession,
+} from '$lib/speech'
 import type { ClientAttachmentFile } from './clientAttachmentFile'
 
 import {
@@ -155,18 +158,18 @@ export interface ShortcutCapability {
   onRambleToggle(handler: () => void, onError: CapabilityErrorHandler): CapabilityUnsubscribe
 }
 
-export type StartSpeechInput = Readonly<{
-  requestId: string
+export type SpeechRecognitionOptions = Readonly<{
   inputDevice: string | null
   modelId: string
   vadThreshold: number
   vadSilenceMs: number
   hotwords: readonly string[]
 }>
-export interface SpeechCapability {
-  start(input: StartSpeechInput): Promise<VoiceRambleSessionView>
-  stop(): Promise<void>
-  onEvent(handler: (event: SpeechEvent) => void, onError: CapabilityErrorHandler): CapabilityUnsubscribe
+export interface SpeechRecognitionPlugin {
+  start(
+    options: SpeechRecognitionOptions,
+    listener: SpeechRecognitionListener,
+  ): SpeechRecognitionSession
 }
 
 export interface RambleConsoleCapability {
@@ -312,7 +315,7 @@ export type WorkbenchCapabilitySlots = Readonly<{
   imagePaste: CapabilitySlot<ImagePasteCapability>
   serverPaths: CapabilitySlot<ServerPathCapability>
   globalShortcuts: CapabilitySlot<ShortcutCapability>
-  speech: CapabilitySlot<SpeechCapability & SpeechAdministrationCapability>
+  speech: CapabilitySlot<SpeechRecognitionPlugin & SpeechAdministrationCapability>
   rambleConsole: CapabilitySlot<RambleConsoleCapability>
   softwareUpdates: CapabilitySlot<UpdaterCapability>
   systemPermissions: CapabilitySlot<SystemPermissionCapability>

--- a/apps/desktop/src/lib/i18n.ts
+++ b/apps/desktop/src/lib/i18n.ts
@@ -533,7 +533,7 @@ const chinese: Record<string, string> = {
   'VAD segmented · Non-streaming': 'VAD 分段 · 非流式',
   'Model license': '模型许可',
   'Voice activity detection (VAD)': '语音活动检测（VAD）',
-  'SenseVoice and FunASR-Nano use bundled Silero VAD to split long recordings; X-ASR continues to use streaming endpoints.': 'SenseVoice 和 FunASR-Nano 使用内置 Silero VAD 自动切分长录音；X-ASR 仍按流式端点分段。',
+  'Non-streaming models use bundled Silero VAD to split long recordings; streaming models use their own endpoints.': '非流式模型使用内置 Silero VAD 自动切分长录音；流式模型使用各自的端点分段。',
   'Speech threshold': '声音阈值',
   'Raise it in noisy environments; lower it when quiet speech is often missed.': '环境嘈杂时调高；轻声讲话经常漏检时调低。',
   'VAD speech threshold': 'VAD 声音阈值',

--- a/apps/desktop/src/lib/preferences.ts
+++ b/apps/desktop/src/lib/preferences.ts
@@ -23,6 +23,7 @@ export type SpeechModelId =
   | 'x-asr-480ms-streaming-zh-en-punct-int8-2026-06-05'
   | 'sense-voice-zh-en-ja-ko-yue-2024-07-17'
   | 'funasr-nano-int8-2025-12-30'
+  | 'zipformer-small-streaming-zh-en-ctc-int8-2026-06-18'
 
 export const DEFAULT_SPEECH_MODEL_ID: SpeechModelId =
   'sense-voice-zh-en-ja-ko-yue-2024-07-17'
@@ -135,7 +136,8 @@ function isSpeechModelId(value: string | null): value is SpeechModelId {
   return (
     value === 'x-asr-480ms-streaming-zh-en-punct-int8-2026-06-05' ||
     value === 'sense-voice-zh-en-ja-ko-yue-2024-07-17' ||
-    value === 'funasr-nano-int8-2025-12-30'
+    value === 'funasr-nano-int8-2025-12-30' ||
+    value === 'zipformer-small-streaming-zh-en-ctc-int8-2026-06-18'
   )
 }
 

--- a/apps/desktop/src/lib/speech.test.ts
+++ b/apps/desktop/src/lib/speech.test.ts
@@ -1,29 +1,28 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  eventBelongsToVoiceSession,
+  eventBelongsToSpeechSession,
   stableSpeechSegmentId,
   stableTranscript,
   voiceStartStillLive,
-  type SpeechEvent,
+  type SpeechRecognitionEvent,
 } from './speech'
 
 describe('voice ramble events', () => {
-  const stable: SpeechEvent = {
+  const stable: SpeechRecognitionEvent = {
     type: 'stable',
-    request_id: 'request-a',
-    voice_session_id: 'session-a',
-    chunk_index: 0,
+    sessionId: 'session-a',
+    segmentIndex: 0,
     text: '  中文片段  ',
   }
 
-  it('accepts the first event before the start command has returned its session id', () => {
-    expect(eventBelongsToVoiceSession(stable, 'request-a', '')).toBe(true)
+  it('accepts events only for the active client-local recognition session', () => {
+    expect(eventBelongsToSpeechSession(stable, 'session-a')).toBe(true)
   })
 
-  it('rejects events from another request or an old session', () => {
-    expect(eventBelongsToVoiceSession(stable, 'request-b', '')).toBe(false)
-    expect(eventBelongsToVoiceSession(stable, 'request-a', 'session-b')).toBe(false)
+  it('rejects events from an old or not-yet-bound session', () => {
+    expect(eventBelongsToSpeechSession(stable, 'session-b')).toBe(false)
+    expect(eventBelongsToSpeechSession(stable, '')).toBe(false)
   })
 
   it('treats a start as failed if error or stop arrived before the command returned', () => {
@@ -40,15 +39,14 @@ describe('voice ramble events', () => {
     expect(
       stableTranscript({
         type: 'processing',
-        request_id: 'request-a',
-        voice_session_id: 'session-a',
-        chunk_index: 0,
+        sessionId: 'session-a',
+        segmentIndex: 0,
       }),
     ).toBeNull()
   })
 
   it('derives a stable segment id so duplicate native delivery is idempotent', () => {
-    const event = stable as Extract<SpeechEvent, { type: 'stable' }>
+    const event = stable as Extract<SpeechRecognitionEvent, { type: 'stable' }>
     expect(stableSpeechSegmentId(event)).toBe('asr-session-a-0')
     expect(stableSpeechSegmentId(event)).toBe('asr-session-a-0')
   })

--- a/apps/desktop/src/lib/speech.ts
+++ b/apps/desktop/src/lib/speech.ts
@@ -1,71 +1,73 @@
-export type SpeechEvent =
+export type SpeechRecognitionStopReason = 'stopped' | 'cancelled' | 'unexpected'
+
+export type SpeechRecognitionEvent =
   | {
       type: 'started'
-      request_id: string
-      voice_session_id: string
-      input_device: string
+      sessionId: string
+      inputDevice: string
       provider: string
     }
   | {
       type: 'partial'
-      request_id: string
-      voice_session_id: string
+      sessionId: string
       text: string
     }
   | {
       type: 'level'
-      request_id: string
-      voice_session_id: string
+      sessionId: string
       rms: number
     }
   | {
       type: 'processing'
-      request_id: string
-      voice_session_id: string
-      chunk_index: number
+      sessionId: string
+      segmentIndex: number
     }
   | {
       type: 'stable'
-      request_id: string
-      voice_session_id: string
-      chunk_index: number
+      sessionId: string
+      segmentIndex: number
       text: string
     }
   | {
       type: 'warning'
-      request_id: string
-      voice_session_id: string
+      sessionId: string
       code: string
       message: string
     }
   | {
       type: 'stopped'
-      request_id: string
-      voice_session_id: string
+      sessionId: string
+      reason: SpeechRecognitionStopReason
     }
   | {
       type: 'error'
-      request_id: string
-      voice_session_id: string
+      sessionId: string
       code: string
       message: string
     }
 
-export type VoiceRambleSessionView = {
-  voice_session_id: string
-  provider: string
-  model_path: string
+export type SpeechRecognitionListener = Readonly<{
+  onEvent: (event: SpeechRecognitionEvent) => void
+  onError: (cause: unknown) => void
+}>
+
+/**
+ * A client-local recognition session. The Platform Plugin owns devices,
+ * models, workers, and resource cleanup; callers only observe normalized
+ * events and choose graceful stop or abortive cancellation.
+ */
+export interface SpeechRecognitionSession {
+  readonly id: string
+  readonly ready: Promise<void>
+  stop(): Promise<void>
+  cancel(): Promise<void>
 }
 
-export function eventBelongsToVoiceSession(
-  event: SpeechEvent,
-  requestId: string,
-  voiceSessionId: string,
+export function eventBelongsToSpeechSession(
+  event: SpeechRecognitionEvent,
+  sessionId: string,
 ): boolean {
-  return (
-    event.request_id === requestId &&
-    (voiceSessionId.length === 0 || event.voice_session_id === voiceSessionId)
-  )
+  return sessionId.length > 0 && event.sessionId === sessionId
 }
 
 export function voiceStartStillLive(
@@ -74,14 +76,14 @@ export function voiceStartStillLive(
   return phase === 'starting' || phase === 'listening' || phase === 'processing'
 }
 
-export function stableTranscript(event: SpeechEvent): string | null {
+export function stableTranscript(event: SpeechRecognitionEvent): string | null {
   if (event.type !== 'stable') return null
   const text = event.text.trim()
   return text.length > 0 ? text : null
 }
 
 export function stableSpeechSegmentId(
-  event: Extract<SpeechEvent, { type: 'stable' }>,
+  event: Extract<SpeechRecognitionEvent, { type: 'stable' }>,
 ): string {
-  return `asr-${event.voice_session_id}-${event.chunk_index}`
+  return `asr-${event.sessionId}-${event.segmentIndex}`
 }

--- a/apps/desktop/src/lib/speechModelLabels.ts
+++ b/apps/desktop/src/lib/speechModelLabels.ts
@@ -28,6 +28,11 @@ const englishCopy: Partial<Record<SpeechModelId, EnglishModelCopy>> = {
     description: 'High-quality non-streaming transcription with VAD splitting; it needs a larger download and more memory.',
     languages: { '中文': 'Chinese', English: 'English', '日本語': 'Japanese' },
   },
+  'zipformer-small-streaming-zh-en-ctc-int8-2026-06-18': {
+    displayName: 'Zipformer Small streaming Chinese/English (Browser experimental)',
+    description: 'Browser-local streaming transcription. The model stays in this browser and audio is never uploaded.',
+    languages: { '中文': 'Chinese', English: 'English' },
+  },
 }
 
 export function speechModelDisplayName(locale: Locale, id: SpeechModelId, fallback: string) {

--- a/apps/desktop/src/lib/workbench/CommandRail.svelte
+++ b/apps/desktop/src/lib/workbench/CommandRail.svelte
@@ -62,10 +62,7 @@
   $: readOnly =
     workspace.request.status === 'completed' || workspace.request.status === 'cancelled'
   $: interactionLocked = cooking || submitting || cancelling || approving
-  $: ramblePanelAvailable = voiceRambleAvailable({
-    speech: capabilities.speech.status,
-    rambleConsole: capabilities.rambleConsole.status,
-  })
+  $: ramblePanelAvailable = voiceRambleAvailable(capabilities.speech.status)
   $: nativeCaptureAvailable = canShowNativeCapture({
     screenCapture: capabilities.screenCapture.status,
     clipboardCapture: capabilities.clipboardCapture.status,

--- a/apps/desktop/src/lib/workbench/RambleSessionController.svelte
+++ b/apps/desktop/src/lib/workbench/RambleSessionController.svelte
@@ -104,31 +104,41 @@
   }
 
   onMount(() => {
-    if (capabilities.speech.status.availability === 'unavailable') return
-    void capabilities.globalShortcuts.implementation.read()
-      .then((settings) => shortcutSettings.set(settings))
-      .catch(() => {})
-    const captureShortcutUnlisten = capabilities.screenCapture.implementation.onShortcut(() => {
-      if (workspace && !interactionLocked) void onStartScreenCapture()
-    }, (cause) => {
-        attachmentMessage = t($locale, 'Cannot listen for the capture shortcut: {error}', { error: messageFrom(cause) })
-      })
-    const rambleShortcutUnlisten = capabilities.globalShortcuts.implementation.onRambleToggle(() => {
-      void toggleRamble()
-    }, (cause) => {
-        ramblePhase = 'error'
-        rambleMessage = t($locale, 'Cannot listen for the Ramble shortcut: {error}', { error: messageFrom(cause) })
-      })
-    const consoleCommandUnlisten = capabilities.rambleConsole.implementation.onCommand(
-      (command) => void handleRambleConsoleCommand(command),
-      () => {},
-    )
-    const consoleReadyUnlisten = capabilities.rambleConsole.implementation.onReady(() => {
-      if (rambleEngaged) {
-        void capabilities.rambleConsole.implementation.restoreVisibility().catch(() => {})
-      }
-      broadcastRambleConsoleState()
-    }, () => {})
+    let captureShortcutUnlisten = () => {}
+    let rambleShortcutUnlisten = () => {}
+    let consoleCommandUnlisten = () => {}
+    let consoleReadyUnlisten = () => {}
+
+    if (capabilities.globalShortcuts.status.availability !== 'unavailable') {
+      void capabilities.globalShortcuts.implementation.read()
+        .then((settings) => shortcutSettings.set(settings))
+        .catch(() => {})
+      rambleShortcutUnlisten = capabilities.globalShortcuts.implementation.onRambleToggle(() => {
+        void toggleRamble()
+      }, (cause) => {
+          ramblePhase = 'error'
+          rambleMessage = t($locale, 'Cannot listen for the Ramble shortcut: {error}', { error: messageFrom(cause) })
+        })
+    }
+    if (capabilities.screenCapture.status.availability !== 'unavailable') {
+      captureShortcutUnlisten = capabilities.screenCapture.implementation.onShortcut(() => {
+        if (workspace && !interactionLocked) void onStartScreenCapture()
+      }, (cause) => {
+          attachmentMessage = t($locale, 'Cannot listen for the capture shortcut: {error}', { error: messageFrom(cause) })
+        })
+    }
+    if (capabilities.rambleConsole.status.availability !== 'unavailable') {
+      consoleCommandUnlisten = capabilities.rambleConsole.implementation.onCommand(
+        (command) => void handleRambleConsoleCommand(command),
+        () => {},
+      )
+      consoleReadyUnlisten = capabilities.rambleConsole.implementation.onReady(() => {
+        if (rambleEngaged) {
+          void capabilities.rambleConsole.implementation.restoreVisibility().catch(() => {})
+        }
+        broadcastRambleConsoleState()
+      }, () => {})
+    }
 
     return () => {
       rambleShortcutUnlisten()
@@ -228,10 +238,12 @@
     void capabilities.rambleConsole.implementation
       .recordDiagnostic('ramble_started', rambleRequestId)
       .catch(() => {})
-    try {
-      await capabilities.rambleConsole.implementation.show()
-    } catch (cause) {
-      onPageError(t($locale, 'Could not open the Ramble console: {error}', { error: messageFrom(cause) }))
+    if (capabilities.rambleConsole.status.availability !== 'unavailable') {
+      try {
+        await capabilities.rambleConsole.implementation.show()
+      } catch (cause) {
+        onPageError(t($locale, 'Could not open the Ramble console: {error}', { error: messageFrom(cause) }))
+      }
     }
     await beginVoiceRamble()
   }

--- a/apps/desktop/src/lib/workbench/RambleSessionController.svelte
+++ b/apps/desktop/src/lib/workbench/RambleSessionController.svelte
@@ -28,11 +28,12 @@
     type RambleConsoleState,
   } from '../rambleConsole'
   import {
-    eventBelongsToVoiceSession,
+    eventBelongsToSpeechSession,
     stableSpeechSegmentId,
     stableTranscript,
     voiceStartStillLive,
-    type SpeechEvent,
+    type SpeechRecognitionEvent,
+    type SpeechRecognitionSession,
   } from '../speech'
   import { createSingleFlight } from '../singleFlight'
   import { resolvedRamblePhase } from './rambleSessionState'
@@ -70,6 +71,7 @@
 
   let voiceRequestId = ''
   let voiceSessionId = ''
+  let speechSession: SpeechRecognitionSession | null = null
   let rambleContextId = ''
   let rambleSourceLabel = ''
   let clipboardCaptureCount = 0
@@ -106,13 +108,6 @@
     void capabilities.globalShortcuts.implementation.read()
       .then((settings) => shortcutSettings.set(settings))
       .catch(() => {})
-    const voiceUnlisten = capabilities.speech.implementation.onEvent(
-      handleVoiceEvent,
-      (cause) => {
-        voicePhase = 'error'
-        voiceMessage = t($locale, 'Cannot listen for speech events: {error}', { error: messageFrom(cause) })
-      },
-    )
     const captureShortcutUnlisten = capabilities.screenCapture.implementation.onShortcut(() => {
       if (workspace && !interactionLocked) void onStartScreenCapture()
     }, (cause) => {
@@ -136,12 +131,11 @@
     }, () => {})
 
     return () => {
-      voiceUnlisten()
       rambleShortcutUnlisten()
       captureShortcutUnlisten()
       consoleCommandUnlisten()
       consoleReadyUnlisten()
-      if (voiceCanStop) void capabilities.speech.implementation.stop()
+      void speechSession?.cancel().catch(() => {})
     }
   })
 
@@ -193,6 +187,7 @@
     voicePhase = 'idle'
     voiceRequestId = ''
     voiceSessionId = ''
+    speechSession = null
     voiceDevice = ''
     voicePartial = ''
     voiceLevel = 0
@@ -279,7 +274,7 @@
   }
 
   async function startVoiceRamble(): Promise<boolean> {
-    if (!rambleRequestId || voiceActive) return false
+    if (!rambleRequestId || voiceActive || speechSession) return false
     voicePhase = 'starting'
     voiceRequestId = rambleRequestId
     voiceSessionId = ''
@@ -290,25 +285,38 @@
     voiceModelMissing = false
     void playRecordArmSound(get(notificationVolume))
     try {
-      const session = await capabilities.speech.implementation.start({
-        requestId: rambleRequestId,
-        inputDevice: $speechInputDevice || null,
-        modelId: $speechModelId,
-        vadThreshold: $speechVadThreshold,
-        vadSilenceMs: $speechVadSilenceMs,
-        hotwords: $speechHotwords,
-      })
+      const session = capabilities.speech.implementation.start(
+        {
+          inputDevice: $speechInputDevice || null,
+          modelId: $speechModelId,
+          vadThreshold: $speechVadThreshold,
+          vadSilenceMs: $speechVadSilenceMs,
+          hotwords: $speechHotwords,
+        },
+        {
+          onEvent: handleVoiceEvent,
+          onError: (cause) => {
+            voicePhase = 'error'
+            voiceMessage = t($locale, 'Cannot listen for speech events: {error}', { error: messageFrom(cause) })
+          },
+        },
+      )
+      speechSession = session
+      voiceSessionId = session.id
+      await session.ready
       if (!voiceStartStillLive(voicePhase)) {
+        await session.cancel().catch(() => {})
+        if (speechSession === session) speechSession = null
         voiceSessionId = ''
-        await capabilities.speech.implementation.stop().catch(() => {})
         return false
       }
-      voiceSessionId = session.voice_session_id
       if (voicePhase === 'starting') {
         voicePhase = 'listening'
         voiceMessage = t($locale, 'VAD is listening · Transcribes automatically after each spoken segment')
       }
     } catch (cause) {
+      speechSession = null
+      voiceSessionId = ''
       const message = messageFrom(cause)
       voicePhase = 'error'
       voiceMessage = message
@@ -320,10 +328,15 @@
 
   async function stopVoiceRamble(): Promise<boolean> {
     if (!voiceCanStop) return true
+    const session = speechSession
+    if (!session) {
+      resetVoiceUi()
+      return true
+    }
     voicePhase = 'stopping'
     voiceMessage = t($locale, 'Finishing the final transcription segment…')
     try {
-      await capabilities.speech.implementation.stop()
+      await session.stop()
       for (let attempt = 0; attempt < 5 && voicePhase === 'stopping'; attempt += 1) {
         await new Promise((resolve) => setTimeout(resolve, 20))
       }
@@ -442,25 +455,20 @@
     }
   }
 
-  function handleVoiceEvent(event: SpeechEvent) {
+  function handleVoiceEvent(event: SpeechRecognitionEvent) {
     const currentRequestId = voiceRequestId
     if (
-      !eventBelongsToVoiceSession(
-        event,
-        currentRequestId,
-        voiceSessionId,
-      )
+      !currentRequestId ||
+      !eventBelongsToSpeechSession(event, voiceSessionId)
     ) {
       return
     }
-    voiceRequestId = event.request_id
-    voiceSessionId = event.voice_session_id
     switch (event.type) {
       case 'started':
         voicePhase = 'listening'
         markRambleRecording()
-        voiceDevice = event.input_device
-        voiceMessage = t($locale, 'Recording · {device}', { device: event.input_device })
+        voiceDevice = event.inputDevice
+        voiceMessage = t($locale, 'Recording · {device}', { device: event.inputDevice })
         break
       case 'partial':
         voicePartial = event.text
@@ -473,10 +481,10 @@
         markRambleRecording()
         break
       case 'processing':
-        voiceChunkIndex = event.chunk_index + 1
+        voiceChunkIndex = event.segmentIndex + 1
         if (voicePhase !== 'stopping') voicePhase = 'processing'
         markRambleRecording()
-        voiceMessage = t($locale, 'Transcribing segment {count}…', { count: event.chunk_index + 1 })
+        voiceMessage = t($locale, 'Transcribing segment {count}…', { count: event.segmentIndex + 1 })
         break
       case 'stable': {
         const transcript = stableTranscript(event)
@@ -491,10 +499,10 @@
           )
         }
         voicePartial = ''
-        voiceChunkIndex = event.chunk_index + 1
+        voiceChunkIndex = event.segmentIndex + 1
         if (voicePhase !== 'stopping') voicePhase = 'listening'
         markRambleRecording()
-        voiceMessage = t($locale, 'Segment {count} written to the document', { count: event.chunk_index + 1 })
+        voiceMessage = t($locale, 'Segment {count} written to the document', { count: event.segmentIndex + 1 })
         break
       }
       case 'warning':
@@ -502,6 +510,7 @@
         break
       case 'stopped':
         voicePhase = 'idle'
+        speechSession = null
         voiceSessionId = ''
         voiceLevel = 0
         voicePartial = ''

--- a/apps/desktop/src/lib/workbench/TaskBriefView.svelte
+++ b/apps/desktop/src/lib/workbench/TaskBriefView.svelte
@@ -56,10 +56,7 @@
     workspace.request.status === 'completed' ||
     workspace.request.status === 'cancelled'
   $: actionGroupContent = collectActionGroupContent(editorDocument)
-  $: voiceRambleAvailable = canStartVoiceRamble({
-    speech: capabilities.speech.status,
-    rambleConsole: capabilities.rambleConsole.status,
-  })
+  $: voiceRambleAvailable = canStartVoiceRamble(capabilities.speech.status)
 
   function tr(source: string, values: Record<string, string | number> = {}) {
     return t($locale, source, values)

--- a/apps/desktop/src/lib/workbench/workbenchCapabilityUi.test.ts
+++ b/apps/desktop/src/lib/workbench/workbenchCapabilityUi.test.ts
@@ -16,11 +16,10 @@ const unavailable = {
 } satisfies CapabilityStatus
 
 describe('workbench capability presentation', () => {
-  it('shows voice Ramble only when speech and console capabilities are usable', () => {
-    expect(voiceRambleAvailable({ speech: available, rambleConsole: available })).toBe(true)
-    expect(voiceRambleAvailable({ speech: degraded, rambleConsole: available })).toBe(true)
-    expect(voiceRambleAvailable({ speech: unavailable, rambleConsole: available })).toBe(false)
-    expect(voiceRambleAvailable({ speech: available, rambleConsole: unavailable })).toBe(false)
+  it('shows voice Ramble whenever the platform speech plugin is usable', () => {
+    expect(voiceRambleAvailable(available)).toBe(true)
+    expect(voiceRambleAvailable(degraded)).toBe(true)
+    expect(voiceRambleAvailable(unavailable)).toBe(false)
   })
 
   it('shows native capture actions only when screen and clipboard capture are usable', () => {

--- a/apps/desktop/src/lib/workbench/workbenchCapabilityUi.ts
+++ b/apps/desktop/src/lib/workbench/workbenchCapabilityUi.ts
@@ -1,10 +1,5 @@
 import type { CapabilityStatus } from '$lib/capabilities/capabilityManifest'
 
-type VoiceRambleCapabilityStatuses = Readonly<{
-  speech: CapabilityStatus
-  rambleConsole: CapabilityStatus
-}>
-
 type NativeCaptureCapabilityStatuses = Readonly<{
   screenCapture: CapabilityStatus
   clipboardCapture: CapabilityStatus
@@ -14,8 +9,8 @@ function usable(status: CapabilityStatus): boolean {
   return status.availability !== 'unavailable'
 }
 
-export function voiceRambleAvailable(statuses: VoiceRambleCapabilityStatuses): boolean {
-  return usable(statuses.speech) && usable(statuses.rambleConsole)
+export function voiceRambleAvailable(speech: CapabilityStatus): boolean {
+  return usable(speech)
 }
 
 export function nativeCaptureAvailable(statuses: NativeCaptureCapabilityStatuses): boolean {

--- a/crates/rambledesk-local-server/src/web_access_server.rs
+++ b/crates/rambledesk-local-server/src/web_access_server.rs
@@ -187,7 +187,7 @@ pub async fn start_web_access_server(
     let spa_state = SpaState {
         allowed_host: authority.clone(),
         content_security_policy: format!(
-            "default-src 'self'; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://{address}; frame-ancestors 'none'"
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://{address} https://www.modelscope.cn https://cdn-lfs-cn-1.modelscope.cn; frame-ancestors 'none'"
         ),
         assets,
     };

--- a/crates/rambledesk-local-server/tests/web_access_server.rs
+++ b/crates/rambledesk-local-server/tests/web_access_server.rs
@@ -80,6 +80,10 @@ async fn independent_server_serves_spa_history_and_fingerprinted_assets() -> any
                     SpaAssetCachePolicy::Immutable,
                 ),
             ),
+            (
+                "browser-speech/runtime/sherpa-onnx-wasm-web.wasm".into(),
+                asset("wasm", "application/wasm", SpaAssetCachePolicy::NoCache),
+            ),
         ]),
     });
     let sessions = Arc::new(WebSessionManager::with_policy(
@@ -184,6 +188,14 @@ async fn independent_server_serves_spa_history_and_fingerprinted_assets() -> any
             response.headers()[reqwest::header::CACHE_CONTROL],
             "no-store"
         );
+        let csp = response.headers()[reqwest::header::CONTENT_SECURITY_POLICY].to_str()?;
+        assert!(csp.contains("script-src 'self' 'wasm-unsafe-eval'"));
+        assert!(csp.contains("worker-src 'self'"));
+        assert!(csp.contains("connect-src 'self' ws://"));
+        assert!(csp.contains("https://www.modelscope.cn"));
+        assert!(csp.contains("https://cdn-lfs-cn-1.modelscope.cn"));
+        assert!(!csp.contains("*.modelscope.cn"));
+        assert!(!csp.contains("'unsafe-eval'"));
         assert_eq!(response.text().await?, "<main>Workbench</main>");
     }
 
@@ -198,6 +210,20 @@ async fn independent_server_serves_spa_history_and_fingerprinted_assets() -> any
     );
     assert_eq!(asset.headers()["x-content-type-options"], "nosniff");
     assert_eq!(asset.headers()["x-frame-options"], "DENY");
+
+    let wasm = client
+        .head(format!(
+            "{}/browser-speech/runtime/sherpa-onnx-wasm-web.wasm",
+            server.origin()
+        ))
+        .send()
+        .await?;
+    assert_eq!(wasm.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        wasm.headers()[reqwest::header::CONTENT_TYPE],
+        "application/wasm"
+    );
+    assert_eq!(wasm.headers()["x-content-type-options"], "nosniff");
 
     for path in ["/assets/missing", "/missing.js", "/a%2Fb"] {
         let response = client

--- a/crates/rambledesk-speech/src/lib.rs
+++ b/crates/rambledesk-speech/src/lib.rs
@@ -3,8 +3,56 @@ use std::{path::PathBuf, sync::Arc};
 use thiserror::Error;
 
 pub const SPEECH_SAMPLE_RATE: u32 = 16_000;
+const MIN_PCM_SAMPLE_RATE_HZ: u32 = 8_000;
+const MAX_PCM_SAMPLE_RATE_HZ: u32 = 192_000;
+const MAX_PCM_CHUNK_SECONDS: usize = 10;
 
 pub type SpeechEventSink = Arc<dyn Fn(SpeechEvent) + Send + Sync + 'static>;
+
+/// A normalized mono PCM buffer produced by an Audio Source.
+///
+/// Audio Sources retain their native sample rate. The Speech Engine owns
+/// resampling so browser and native producers share the same recognition path.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PcmAudioChunk {
+    samples: Vec<f32>,
+    sample_rate_hz: u32,
+}
+
+impl PcmAudioChunk {
+    pub fn try_new(samples: Vec<f32>, sample_rate_hz: u32) -> Result<Self, SpeechError> {
+        if !(MIN_PCM_SAMPLE_RATE_HZ..=MAX_PCM_SAMPLE_RATE_HZ).contains(&sample_rate_hz) {
+            return Err(SpeechError::InvalidConfiguration(format!(
+                "PCM 采样率必须在 {MIN_PCM_SAMPLE_RATE_HZ} 到 {MAX_PCM_SAMPLE_RATE_HZ} Hz 之间"
+            )));
+        }
+        if samples.is_empty() {
+            return Err(SpeechError::InvalidConfiguration(
+                "PCM 音频块不能为空".to_owned(),
+            ));
+        }
+        let max_samples = sample_rate_hz as usize * MAX_PCM_CHUNK_SECONDS;
+        if samples.len() > max_samples {
+            return Err(SpeechError::InvalidConfiguration(format!(
+                "PCM 音频块不能超过 {MAX_PCM_CHUNK_SECONDS} 秒"
+            )));
+        }
+        if samples.iter().any(|sample| !sample.is_finite()) {
+            return Err(SpeechError::InvalidConfiguration(
+                "PCM 音频块包含非有限采样值".to_owned(),
+            ));
+        }
+        Ok(Self {
+            samples,
+            sample_rate_hz,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeAudioSourceConfig {
+    pub input_device: Option<String>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -50,6 +98,41 @@ pub struct SpeechSessionConfig {
     pub vad_silence_ms: u32,
     pub input_device: Option<String>,
     pub hotwords: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpeechEngineConfig {
+    pub request_id: String,
+    pub voice_session_id: String,
+    pub provider: SpeechProvider,
+    pub model_path: PathBuf,
+    pub vad_model_path: PathBuf,
+    pub vad_threshold: f32,
+    pub vad_silence_ms: u32,
+    pub hotwords: Vec<String>,
+}
+
+impl From<&SpeechSessionConfig> for SpeechEngineConfig {
+    fn from(config: &SpeechSessionConfig) -> Self {
+        Self {
+            request_id: config.request_id.clone(),
+            voice_session_id: config.voice_session_id.clone(),
+            provider: config.provider,
+            model_path: config.model_path.clone(),
+            vad_model_path: config.vad_model_path.clone(),
+            vad_threshold: config.vad_threshold,
+            vad_silence_ms: config.vad_silence_ms,
+            hotwords: config.hotwords.clone(),
+        }
+    }
+}
+
+impl From<&SpeechSessionConfig> for NativeAudioSourceConfig {
+    fn from(config: &SpeechSessionConfig) -> Self {
+        Self {
+            input_device: config.input_device.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -130,8 +213,8 @@ struct EventIdentity {
 }
 
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-impl From<&SpeechSessionConfig> for EventIdentity {
-    fn from(config: &SpeechSessionConfig) -> Self {
+impl From<&SpeechEngineConfig> for EventIdentity {
+    fn from(config: &SpeechEngineConfig) -> Self {
         Self {
             request_id: config.request_id.clone(),
             voice_session_id: config.voice_session_id.clone(),
@@ -170,23 +253,22 @@ pub fn rms(samples: &[f32]) -> f32 {
     (samples.iter().map(|sample| sample * sample).sum::<f32>() / samples.len() as f32).sqrt()
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos", test))]
-fn downmix<T>(input: &[T], channels: usize, normalize: impl Fn(&T) -> f32) -> Vec<f32> {
-    if channels == 0 {
-        return Vec::new();
-    }
-    input
-        .chunks(channels)
-        .map(|frame| frame.iter().map(&normalize).sum::<f32>() / frame.len() as f32)
-        .collect()
-}
-
 pub mod model;
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-mod native;
+mod native_audio_source;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+mod session;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+mod speech_engine;
 
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-pub use native::{SpeechSession, ensure_vad_model, list_input_devices};
+pub use native_audio_source::list_input_devices;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+pub use session::SpeechSession;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+pub use speech_engine::{
+    SpeechEngineHandle, SpeechEngineInputResult, SpeechEngineSession, ensure_vad_model,
+};
 
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub struct SpeechSession;
@@ -229,12 +311,6 @@ mod tests {
     }
 
     #[test]
-    fn downmixes_stereo_frames() {
-        let input = [1.0_f32, -1.0, 0.5, 0.25];
-        assert_eq!(downmix(&input, 2, |value| *value), vec![0.0, 0.375]);
-    }
-
-    #[test]
     fn rms_handles_empty_and_constant_audio() {
         assert_eq!(rms(&[]), 0.0);
         assert!((rms(&[0.5, -0.5]) - 0.5).abs() < f32::EPSILON);
@@ -251,5 +327,43 @@ mod tests {
         let value = serde_json::to_value(event).expect("serialize event");
         assert_eq!(value["type"], "stable");
         assert_eq!(value["text"], "你好");
+    }
+
+    #[test]
+    fn legacy_session_config_projects_independent_source_and_engine_configs() {
+        let config = SpeechSessionConfig {
+            request_id: "request".to_owned(),
+            voice_session_id: "voice".to_owned(),
+            provider: SpeechProvider::XAsr,
+            model_path: PathBuf::from("model"),
+            vad_model_path: PathBuf::from("vad"),
+            vad_threshold: 0.5,
+            vad_silence_ms: 800,
+            input_device: Some("Microphone".to_owned()),
+            hotwords: vec!["RambleDesk".to_owned()],
+        };
+
+        let source = NativeAudioSourceConfig::from(&config);
+        let engine = SpeechEngineConfig::from(&config);
+        assert_eq!(source.input_device.as_deref(), Some("Microphone"));
+        assert_eq!(engine.request_id, "request");
+        assert_eq!(engine.voice_session_id, "voice");
+        assert_eq!(engine.provider, SpeechProvider::XAsr);
+        assert_eq!(engine.hotwords, vec!["RambleDesk"]);
+    }
+
+    #[test]
+    fn pcm_audio_chunk_rejects_unbounded_or_invalid_input() {
+        assert!(PcmAudioChunk::try_new(vec![0.0], 0).is_err());
+        assert!(PcmAudioChunk::try_new(vec![0.0], 7_999).is_err());
+        assert!(PcmAudioChunk::try_new(Vec::new(), SPEECH_SAMPLE_RATE).is_err());
+        assert!(PcmAudioChunk::try_new(vec![f32::NAN], SPEECH_SAMPLE_RATE).is_err());
+        assert!(
+            PcmAudioChunk::try_new(
+                vec![0.0; SPEECH_SAMPLE_RATE as usize * MAX_PCM_CHUNK_SECONDS + 1],
+                SPEECH_SAMPLE_RATE,
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/rambledesk-speech/src/lib.rs
+++ b/crates/rambledesk-speech/src/lib.rs
@@ -11,8 +11,8 @@ pub type SpeechEventSink = Arc<dyn Fn(SpeechEvent) + Send + Sync + 'static>;
 
 /// A normalized mono PCM buffer produced by an Audio Source.
 ///
-/// Audio Sources retain their native sample rate. The Speech Engine owns
-/// resampling so browser and native producers share the same recognition path.
+/// Audio Sources retain their native sample rate. Inside the Desktop Speech
+/// Recognition Plugin, the local Speech Engine owns model-rate resampling.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PcmAudioChunk {
     samples: Vec<f32>,

--- a/crates/rambledesk-speech/src/lib.rs
+++ b/crates/rambledesk-speech/src/lib.rs
@@ -50,6 +50,7 @@ impl PcmAudioChunk {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(any(target_os = "windows", target_os = "macos", test))]
 pub(crate) struct NativeAudioSourceConfig {
     pub input_device: Option<String>,
 }
@@ -127,6 +128,7 @@ impl From<&SpeechSessionConfig> for SpeechEngineConfig {
     }
 }
 
+#[cfg(any(target_os = "windows", target_os = "macos", test))]
 impl From<&SpeechSessionConfig> for NativeAudioSourceConfig {
     fn from(config: &SpeechSessionConfig) -> Self {
         Self {

--- a/crates/rambledesk-speech/src/native_audio_source.rs
+++ b/crates/rambledesk-speech/src/native_audio_source.rs
@@ -1,0 +1,207 @@
+use crate::{NativeAudioSourceConfig, PcmAudioChunk, SpeechError};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use std::sync::Arc;
+
+pub(crate) type PcmAudioSink = Arc<dyn Fn(PcmAudioChunk) + Send + Sync + 'static>;
+pub(crate) type NativeAudioSourceFaultSink =
+    Arc<dyn Fn(NativeAudioSourceFault) + Send + Sync + 'static>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeAudioSourceFault {
+    pub message: String,
+}
+
+pub fn list_input_devices() -> Result<Vec<String>, SpeechError> {
+    let host = cpal::default_host();
+    let devices = host
+        .input_devices()
+        .map_err(|error| SpeechError::InputConfiguration(error.to_string()))?;
+    let mut names = devices
+        .filter_map(|device| device.name().ok())
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
+/// An active native Audio Source.
+///
+/// The cpal stream stays on the thread that creates this value. It only emits
+/// normalized mono PCM and source faults; request and recognition semantics
+/// belong to the facade and Speech Engine respectively.
+pub(crate) struct NativeAudioSourceSession {
+    input_device: String,
+    stream: Option<cpal::Stream>,
+}
+
+impl NativeAudioSourceSession {
+    pub(crate) fn input_device(&self) -> &str {
+        &self.input_device
+    }
+
+    pub(crate) fn stop(mut self) {
+        self.stream.take();
+    }
+}
+
+impl Drop for NativeAudioSourceSession {
+    fn drop(&mut self) {
+        self.stream.take();
+    }
+}
+
+pub(crate) struct PreparedNativeAudioSource {
+    device: cpal::Device,
+    input_device: String,
+    stream_config: cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+}
+
+impl PreparedNativeAudioSource {
+    pub(crate) fn open(config: NativeAudioSourceConfig) -> Result<Self, SpeechError> {
+        let host = cpal::default_host();
+        let device = if let Some(selected) = config.input_device.as_deref() {
+            host.input_devices()
+                .map_err(|error| SpeechError::InputConfiguration(error.to_string()))?
+                .find(|device| device.name().is_ok_and(|name| name == selected))
+                .ok_or_else(|| {
+                    SpeechError::InputConfiguration(format!("找不到麦克风：{selected}"))
+                })?
+        } else {
+            host.default_input_device()
+                .ok_or(SpeechError::NoInputDevice)?
+        };
+        let input_device = device
+            .name()
+            .unwrap_or_else(|_| "系统默认麦克风".to_owned());
+        let supported_config = device
+            .default_input_config()
+            .map_err(|error| SpeechError::InputConfiguration(error.to_string()))?;
+        let sample_format = supported_config.sample_format();
+        if !matches!(
+            sample_format,
+            cpal::SampleFormat::F32 | cpal::SampleFormat::I16 | cpal::SampleFormat::U16
+        ) {
+            return Err(SpeechError::UnsupportedSampleFormat(format!(
+                "{sample_format:?}"
+            )));
+        }
+        Ok(Self {
+            device,
+            input_device,
+            stream_config: supported_config.into(),
+            sample_format,
+        })
+    }
+
+    pub(crate) fn start(
+        self,
+        pcm_sink: PcmAudioSink,
+        fault_sink: NativeAudioSourceFaultSink,
+    ) -> Result<NativeAudioSourceSession, SpeechError> {
+        let source_rate = self.stream_config.sample_rate.0;
+        let channels = self.stream_config.channels as usize;
+        let stream = match self.sample_format {
+            cpal::SampleFormat::F32 => build_stream(
+                &self.device,
+                &self.stream_config,
+                channels,
+                source_rate,
+                pcm_sink,
+                fault_sink,
+                |value: &f32| *value,
+            ),
+            cpal::SampleFormat::I16 => build_stream(
+                &self.device,
+                &self.stream_config,
+                channels,
+                source_rate,
+                pcm_sink,
+                fault_sink,
+                |value: &i16| *value as f32 / i16::MAX as f32,
+            ),
+            cpal::SampleFormat::U16 => build_stream(
+                &self.device,
+                &self.stream_config,
+                channels,
+                source_rate,
+                pcm_sink,
+                fault_sink,
+                |value: &u16| (*value as f32 - 32_768.0) / 32_768.0,
+            ),
+            other => Err(SpeechError::UnsupportedSampleFormat(format!("{other:?}"))),
+        }?;
+        stream
+            .play()
+            .map_err(|error| SpeechError::InputStream(error.to_string()))?;
+        Ok(NativeAudioSourceSession {
+            input_device: self.input_device,
+            stream: Some(stream),
+        })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_stream<T>(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    channels: usize,
+    sample_rate_hz: u32,
+    pcm_sink: PcmAudioSink,
+    fault_sink: NativeAudioSourceFaultSink,
+    normalize: impl Fn(&T) -> f32 + Send + Sync + 'static,
+) -> Result<cpal::Stream, SpeechError>
+where
+    T: cpal::SizedSample + Send + 'static,
+{
+    let data_fault_sink = Arc::clone(&fault_sink);
+    device
+        .build_input_stream(
+            config,
+            move |data: &[T], _| {
+                let samples = downmix(data, channels, &normalize);
+                if samples.is_empty() {
+                    return;
+                }
+                match PcmAudioChunk::try_new(samples, sample_rate_hz) {
+                    Ok(chunk) => pcm_sink(chunk),
+                    Err(error) => data_fault_sink(NativeAudioSourceFault {
+                        message: error.to_string(),
+                    }),
+                }
+            },
+            move |error| {
+                fault_sink(NativeAudioSourceFault {
+                    message: error.to_string(),
+                });
+            },
+            None,
+        )
+        .map_err(|error| SpeechError::InputStream(error.to_string()))
+}
+
+fn downmix<T>(input: &[T], channels: usize, normalize: impl Fn(&T) -> f32) -> Vec<f32> {
+    if channels == 0 {
+        return Vec::new();
+    }
+    input
+        .chunks(channels)
+        .map(|frame| frame.iter().map(&normalize).sum::<f32>() / frame.len() as f32)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn downmixes_and_normalizes_stereo_frames() {
+        let input = [1.0_f32, -1.0, 0.5, 0.25];
+        assert_eq!(downmix(&input, 2, |value| *value), vec![0.0, 0.375]);
+    }
+
+    #[test]
+    fn downmix_rejects_zero_channels_without_panicking() {
+        assert!(downmix(&[1.0_f32], 0, |value| *value).is_empty());
+    }
+}

--- a/crates/rambledesk-speech/src/session.rs
+++ b/crates/rambledesk-speech/src/session.rs
@@ -1,0 +1,277 @@
+use crate::{
+    EventIdentity, NativeAudioSourceConfig, PcmAudioChunk, SpeechEngineConfig, SpeechEngineSession,
+    SpeechError, SpeechEvent, SpeechEventSink,
+    native_audio_source::{
+        NativeAudioSourceFault, NativeAudioSourceFaultSink, NativeAudioSourceSession, PcmAudioSink,
+        PreparedNativeAudioSource,
+    },
+};
+use std::{
+    sync::{Arc, mpsc::SyncSender, mpsc::sync_channel},
+    thread::{self, JoinHandle},
+};
+
+/// Compatibility facade that composes the native Audio Source with the Speech
+/// Engine while preserving the existing Tauri-facing start/stop interface.
+///
+/// CoreAudio remains owned by the dedicated session thread. Shutdown always
+/// stops the producer before draining and finalizing the Speech Engine.
+pub struct SpeechSession {
+    stop_tx: Option<SyncSender<()>>,
+    owner: Option<JoinHandle<Result<(), SpeechError>>>,
+}
+
+impl SpeechSession {
+    pub fn start(
+        config: crate::SpeechSessionConfig,
+        sink: SpeechEventSink,
+    ) -> Result<Self, SpeechError> {
+        let (startup_tx, startup_rx) = sync_channel(1);
+        let (stop_tx, stop_rx) = sync_channel(1);
+        let owner_stop_tx = stop_tx.clone();
+        let owner = thread::Builder::new()
+            .name("rambledesk-speech-session".to_owned())
+            .spawn(move || run_owned_session(config, sink, owner_stop_tx, stop_rx, startup_tx))
+            .map_err(|error| SpeechError::InputStream(error.to_string()))?;
+
+        match startup_rx.recv() {
+            Ok(Ok(())) => Ok(Self {
+                stop_tx: Some(stop_tx),
+                owner: Some(owner),
+            }),
+            Ok(Err(error)) => {
+                let _ = owner.join();
+                Err(error)
+            }
+            Err(_) => {
+                let _ = owner.join();
+                Err(SpeechError::WorkerPanicked)
+            }
+        }
+    }
+
+    pub fn stop(mut self) -> Result<(), SpeechError> {
+        self.signal_stop();
+        self.join_owner()
+    }
+
+    fn signal_stop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+    }
+
+    fn join_owner(&mut self) -> Result<(), SpeechError> {
+        match self.owner.take() {
+            Some(owner) => owner.join().map_err(|_| SpeechError::WorkerPanicked)?,
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for SpeechSession {
+    fn drop(&mut self) {
+        self.signal_stop();
+        let _ = self.join_owner();
+    }
+}
+
+fn run_owned_session(
+    config: crate::SpeechSessionConfig,
+    sink: SpeechEventSink,
+    model_abort_tx: SyncSender<()>,
+    stop_rx: std::sync::mpsc::Receiver<()>,
+    startup_tx: SyncSender<Result<(), SpeechError>>,
+) -> Result<(), SpeechError> {
+    let source_config = NativeAudioSourceConfig::from(&config);
+    let engine_config = SpeechEngineConfig::from(&config);
+    let identity = EventIdentity::from(&engine_config);
+    let provider = engine_config.provider;
+
+    // Resolve the native device before starting the recognizer so invalid
+    // device configuration has the same synchronous failure semantics as the
+    // previous facade.
+    let prepared_source = match PreparedNativeAudioSource::open(source_config) {
+        Ok(source) => source,
+        Err(error) => {
+            let _ = startup_tx.send(Err(error));
+            return Ok(());
+        }
+    };
+    let (engine_handle, engine_session) = match SpeechEngineSession::start_with_abort(
+        engine_config,
+        Arc::clone(&sink),
+        Some(model_abort_tx),
+    ) {
+        Ok(engine) => engine,
+        Err(error) => {
+            let _ = startup_tx.send(Err(error));
+            return Ok(());
+        }
+    };
+
+    let pcm_sink: PcmAudioSink = Arc::new(move |chunk: PcmAudioChunk| {
+        let _ = engine_handle.try_push(chunk);
+    });
+    let fault_identity = identity.clone();
+    let fault_event_sink = Arc::clone(&sink);
+    let fault_sink: NativeAudioSourceFaultSink = Arc::new(move |fault: NativeAudioSourceFault| {
+        fault_event_sink(source_fault_event(&fault_identity, fault));
+    });
+
+    let source_session = match prepared_source.start(pcm_sink, fault_sink) {
+        Ok(source) => source,
+        Err(error) => {
+            let _ = engine_session.stop();
+            let _ = startup_tx.send(Err(error));
+            return Ok(());
+        }
+    };
+
+    sink(SpeechEvent::Started {
+        request_id: identity.request_id.clone(),
+        voice_session_id: identity.voice_session_id.clone(),
+        input_device: source_session.input_device().to_owned(),
+        provider: provider.id().to_owned(),
+    });
+
+    if startup_tx.send(Ok(())).is_err() {
+        return stop_owned_session(source_session, engine_session, identity, sink);
+    }
+    let _ = stop_rx.recv();
+    stop_owned_session(source_session, engine_session, identity, sink)
+}
+
+fn stop_owned_session(
+    source_session: NativeAudioSourceSession,
+    engine_session: SpeechEngineSession,
+    identity: EventIdentity,
+    sink: SpeechEventSink,
+) -> Result<(), SpeechError> {
+    stop_components(
+        || source_session.stop(),
+        || engine_session.stop(),
+        identity,
+        sink,
+    )
+}
+
+fn stop_components(
+    stop_source: impl FnOnce(),
+    stop_engine: impl FnOnce() -> Result<(), SpeechError>,
+    identity: EventIdentity,
+    sink: SpeechEventSink,
+) -> Result<(), SpeechError> {
+    stop_source();
+    let engine_result = stop_engine();
+    sink(SpeechEvent::Stopped {
+        request_id: identity.request_id,
+        voice_session_id: identity.voice_session_id,
+    });
+    engine_result
+}
+
+fn source_fault_event(identity: &EventIdentity, fault: NativeAudioSourceFault) -> SpeechEvent {
+    SpeechEvent::Error {
+        request_id: identity.request_id.clone(),
+        voice_session_id: identity.voice_session_id.clone(),
+        code: "microphone_stream".to_owned(),
+        message: format!("麦克风输入中断：{}", fault.message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    fn test_identity() -> EventIdentity {
+        EventIdentity {
+            request_id: "request".to_owned(),
+            voice_session_id: "voice".to_owned(),
+        }
+    }
+
+    #[test]
+    fn source_fault_keeps_the_existing_tauri_event_contract() {
+        let event = source_fault_event(
+            &test_identity(),
+            NativeAudioSourceFault {
+                message: "device lost".to_owned(),
+            },
+        );
+        assert_eq!(
+            event,
+            SpeechEvent::Error {
+                request_id: "request".to_owned(),
+                voice_session_id: "voice".to_owned(),
+                code: "microphone_stream".to_owned(),
+                message: "麦克风输入中断：device lost".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn shutdown_stops_source_before_engine_tail_and_stopped_event() {
+        let sequence = Arc::new(Mutex::new(Vec::new()));
+        let source_sequence = Arc::clone(&sequence);
+        let engine_sequence = Arc::clone(&sequence);
+        let event_sequence = Arc::clone(&sequence);
+        let sink: SpeechEventSink = Arc::new(move |event| {
+            let label = match event {
+                SpeechEvent::Stable { .. } => "stable",
+                SpeechEvent::Stopped { .. } => "stopped",
+                _ => "other",
+            };
+            event_sequence.lock().unwrap().push(label);
+        });
+
+        let engine_sink = Arc::clone(&sink);
+        stop_components(
+            move || source_sequence.lock().unwrap().push("source"),
+            move || {
+                engine_sequence.lock().unwrap().push("engine");
+                engine_sink(SpeechEvent::Stable {
+                    request_id: "request".to_owned(),
+                    voice_session_id: "voice".to_owned(),
+                    chunk_index: 0,
+                    text: "tail".to_owned(),
+                });
+                Ok(())
+            },
+            test_identity(),
+            sink,
+        )
+        .unwrap();
+
+        assert_eq!(
+            *sequence.lock().unwrap(),
+            vec!["source", "engine", "stable", "stopped"]
+        );
+    }
+
+    #[test]
+    fn shutdown_emits_stopped_once_when_engine_reports_failure() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let recorded_events = Arc::clone(&events);
+        let sink: SpeechEventSink = Arc::new(move |event| {
+            recorded_events.lock().unwrap().push(event);
+        });
+
+        let result = stop_components(
+            || {},
+            || Err(SpeechError::WorkerPanicked),
+            test_identity(),
+            sink,
+        );
+
+        assert!(matches!(result, Err(SpeechError::WorkerPanicked)));
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![SpeechEvent::Stopped {
+                request_id: "request".to_owned(),
+                voice_session_id: "voice".to_owned(),
+            }]
+        );
+    }
+}

--- a/crates/rambledesk-speech/src/speech_engine.rs
+++ b/crates/rambledesk-speech/src/speech_engine.rs
@@ -1,7 +1,6 @@
 mod worker;
 
 use super::*;
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use sherpa_onnx::{
     OfflineFunASRNanoModelConfig, OfflineRecognizer, OfflineRecognizerConfig,
     OfflineSenseVoiceModelConfig, OnlineRecognizer, OnlineRecognizerConfig, OnlineStream,
@@ -12,11 +11,11 @@ use std::{
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
-        mpsc::{SyncSender, sync_channel},
+        mpsc::{SyncSender, TrySendError, sync_channel},
     },
     thread::{self, JoinHandle},
 };
-use worker::{WorkerContext, run_sherpa_worker_after_load};
+use worker::{SpeechEngineWorkerContext, run_speech_engine_after_load};
 
 // Large enough to hold ~30–40s of typical input callbacks while the ASR
 // model loads. Recording starts before recognizer creation; dropping that
@@ -32,19 +31,6 @@ const SHERPA_FINALIZE_ROUNDS: u32 = 256;
 const VAD_MODEL_BYTES: u64 = 643_854;
 const VAD_MODEL_FILE: &str = "silero_vad.onnx";
 const VAD_BUNDLED_BYTES: &[u8] = include_bytes!("../assets/silero_vad.onnx");
-
-pub fn list_input_devices() -> Result<Vec<String>, SpeechError> {
-    let host = cpal::default_host();
-    let devices = host
-        .input_devices()
-        .map_err(|error| SpeechError::InputConfiguration(error.to_string()))?;
-    let mut names = devices
-        .filter_map(|device| device.name().ok())
-        .collect::<Vec<_>>();
-    names.sort();
-    names.dedup();
-    Ok(names)
-}
 
 pub fn ensure_vad_model(library_root: &Path) -> Result<PathBuf, SpeechError> {
     let directory = library_root
@@ -199,7 +185,7 @@ struct SherpaOffline {
 }
 
 impl SherpaOffline {
-    fn create(config: &SpeechSessionConfig) -> Result<Self, SpeechError> {
+    fn create(config: &SpeechEngineConfig) -> Result<Self, SpeechError> {
         if !(0.05..=0.95).contains(&config.vad_threshold) {
             return Err(SpeechError::InvalidConfiguration(
                 "VAD 声音阈值必须在 0.05 到 0.95 之间".to_owned(),
@@ -414,7 +400,7 @@ enum RecognitionEngine {
 }
 
 impl RecognitionEngine {
-    fn create(config: &SpeechSessionConfig) -> Result<Self, SpeechError> {
+    fn create(config: &SpeechEngineConfig) -> Result<Self, SpeechError> {
         if config.provider.streaming() {
             Ok(Self::Online(SherpaOnline::create(
                 &config.model_path,
@@ -440,282 +426,167 @@ impl RecognitionEngine {
     }
 }
 
-struct NativeSpeechSession {
-    identity: EventIdentity,
+/// Non-blocking PCM input for a Speech Engine session.
+///
+/// A full queue drops the new chunk and records one backpressure incident.
+/// Once the session begins stopping, submissions are rejected.
+#[derive(Clone)]
+pub struct SpeechEngineHandle {
+    audio_tx: SyncSender<PcmAudioChunk>,
     running: Arc<AtomicBool>,
-    stream: Option<cpal::Stream>,
-    worker: Option<JoinHandle<()>>,
-    sink: SpeechEventSink,
+    dropped_buffers: Arc<AtomicU64>,
 }
 
-impl NativeSpeechSession {
-    fn start(
-        config: SpeechSessionConfig,
-        sink: SpeechEventSink,
-        abort_tx: SyncSender<()>,
-    ) -> Result<Self, SpeechError> {
-        let provider = config.provider;
-        let host = cpal::default_host();
-        let device = if let Some(selected) = config.input_device.as_deref() {
-            host.input_devices()
-                .map_err(|error| SpeechError::InputConfiguration(error.to_string()))?
-                .find(|device| device.name().is_ok_and(|name| name == selected))
-                .ok_or_else(|| {
-                    SpeechError::InputConfiguration(format!("找不到麦克风：{selected}"))
-                })?
-        } else {
-            host.default_input_device()
-                .ok_or(SpeechError::NoInputDevice)?
-        };
-        let device_name = device
-            .name()
-            .unwrap_or_else(|_| "系统默认麦克风".to_owned());
-        let supported_config = device
-            .default_input_config()
-            .map_err(|error| SpeechError::InputConfiguration(error.to_string()))?;
-        let sample_format = supported_config.sample_format();
-        if !matches!(
-            sample_format,
-            cpal::SampleFormat::F32 | cpal::SampleFormat::I16 | cpal::SampleFormat::U16
-        ) {
-            return Err(SpeechError::UnsupportedSampleFormat(format!(
-                "{sample_format:?}"
-            )));
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpeechEngineInputResult {
+    Accepted,
+    Backpressured,
+    Closed,
+}
+
+impl SpeechEngineHandle {
+    pub fn try_push(&self, chunk: PcmAudioChunk) -> SpeechEngineInputResult {
+        if !self.running.load(Ordering::Acquire) {
+            return SpeechEngineInputResult::Closed;
         }
-        let stream_config: cpal::StreamConfig = supported_config.into();
-        let source_rate = stream_config.sample_rate.0;
-        let channels = stream_config.channels as usize;
+        match self.audio_tx.try_send(chunk) {
+            Ok(()) => SpeechEngineInputResult::Accepted,
+            Err(TrySendError::Full(_)) => {
+                self.dropped_buffers.fetch_add(1, Ordering::Relaxed);
+                SpeechEngineInputResult::Backpressured
+            }
+            Err(TrySendError::Disconnected(_)) => SpeechEngineInputResult::Closed,
+        }
+    }
+}
+
+/// An active Speech Engine worker and its bounded PCM input queue.
+pub struct SpeechEngineSession {
+    running: Arc<AtomicBool>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl SpeechEngineSession {
+    pub fn start(
+        config: SpeechEngineConfig,
+        sink: SpeechEventSink,
+    ) -> Result<(SpeechEngineHandle, Self), SpeechError> {
+        Self::start_with_abort(config, sink, None)
+    }
+
+    pub(crate) fn start_with_abort(
+        config: SpeechEngineConfig,
+        sink: SpeechEventSink,
+        abort_tx: Option<SyncSender<()>>,
+    ) -> Result<(SpeechEngineHandle, Self), SpeechError> {
         let identity = EventIdentity::from(&config);
         let running = Arc::new(AtomicBool::new(true));
         let (audio_tx, audio_rx) = sync_channel(AUDIO_QUEUE_CAPACITY);
         let dropped_buffers = Arc::new(AtomicU64::new(0));
-
-        let worker_identity = identity.clone();
-        let worker_sink = sink.clone();
-        let worker_running = running.clone();
-        let worker_dropped = dropped_buffers.clone();
+        let worker_running = Arc::clone(&running);
+        let worker_dropped = Arc::clone(&dropped_buffers);
         let worker = thread::Builder::new()
             .name("rambledesk-speech".to_owned())
             .spawn(move || {
-                run_sherpa_worker_after_load(
+                run_speech_engine_after_load(
                     config,
                     audio_rx,
-                    WorkerContext {
-                        source_rate,
-                        identity: worker_identity,
+                    SpeechEngineWorkerContext {
+                        identity,
                         running: worker_running,
-                        sink: worker_sink,
+                        sink,
                         dropped_buffers: worker_dropped,
                     },
                     abort_tx,
                 );
             })
             .map_err(|error| SpeechError::InputStream(error.to_string()))?;
-
-        let stream_sink = sink.clone();
-        let stream_identity = identity.clone();
-        let dropped_for_callback = dropped_buffers.clone();
-        let stream = match sample_format {
-            cpal::SampleFormat::F32 => build_stream(
-                &device,
-                &stream_config,
+        Ok((
+            SpeechEngineHandle {
                 audio_tx,
-                channels,
-                |value: &f32| *value,
-                dropped_for_callback,
-                stream_identity,
-                stream_sink,
-            ),
-            cpal::SampleFormat::I16 => build_stream(
-                &device,
-                &stream_config,
-                audio_tx,
-                channels,
-                |value: &i16| *value as f32 / i16::MAX as f32,
-                dropped_for_callback,
-                stream_identity,
-                stream_sink,
-            ),
-            cpal::SampleFormat::U16 => build_stream(
-                &device,
-                &stream_config,
-                audio_tx,
-                channels,
-                |value: &u16| (*value as f32 - 32_768.0) / 32_768.0,
-                dropped_for_callback,
-                stream_identity,
-                stream_sink,
-            ),
-            other => Err(SpeechError::UnsupportedSampleFormat(format!("{other:?}"))),
-        };
-        let stream = match stream {
-            Ok(stream) => stream,
-            Err(error) => {
-                running.store(false, Ordering::Release);
-                let _ = worker.join();
-                return Err(error);
-            }
-        };
-        if let Err(error) = stream.play() {
-            running.store(false, Ordering::Release);
-            drop(stream);
-            let _ = worker.join();
-            return Err(SpeechError::InputStream(error.to_string()));
-        }
-
-        sink(SpeechEvent::Started {
-            request_id: identity.request_id.clone(),
-            voice_session_id: identity.voice_session_id.clone(),
-            input_device: device_name,
-            provider: provider.id().to_owned(),
-        });
-
-        Ok(Self {
-            identity,
-            running,
-            stream: Some(stream),
-            worker: Some(worker),
-            sink,
-        })
-    }
-
-    fn stop(mut self) -> Result<(), SpeechError> {
-        self.running.store(false, Ordering::Release);
-        self.stream.take();
-        if let Some(worker) = self.worker.take() {
-            worker.join().map_err(|_| SpeechError::WorkerPanicked)?;
-        }
-        (self.sink)(SpeechEvent::Stopped {
-            request_id: self.identity.request_id.clone(),
-            voice_session_id: self.identity.voice_session_id.clone(),
-        });
-        Ok(())
-    }
-}
-
-impl Drop for NativeSpeechSession {
-    fn drop(&mut self) {
-        self.running.store(false, Ordering::Release);
-        self.stream.take();
-    }
-}
-
-/// Sendable control handle for a native audio session.
-///
-/// CoreAudio streams are thread-affine on macOS, so the native stream stays
-/// on a dedicated owner thread. Tauri state stores only this control handle.
-pub struct SpeechSession {
-    stop_tx: Option<SyncSender<()>>,
-    owner: Option<JoinHandle<Result<(), SpeechError>>>,
-}
-
-impl SpeechSession {
-    pub fn start(config: SpeechSessionConfig, sink: SpeechEventSink) -> Result<Self, SpeechError> {
-        let (startup_tx, startup_rx) = sync_channel(1);
-        let (stop_tx, stop_rx) = sync_channel(1);
-        let abort_tx = stop_tx.clone();
-        let owner = thread::Builder::new()
-            .name("rambledesk-speech-session".to_owned())
-            .spawn(
-                move || match NativeSpeechSession::start(config, sink, abort_tx) {
-                    Ok(session) => {
-                        if startup_tx.send(Ok(())).is_err() {
-                            return session.stop();
-                        }
-                        let _ = stop_rx.recv();
-                        session.stop()
-                    }
-                    Err(error) => {
-                        let _ = startup_tx.send(Err(error));
-                        Ok(())
-                    }
-                },
-            )
-            .map_err(|error| SpeechError::InputStream(error.to_string()))?;
-
-        match startup_rx.recv() {
-            Ok(Ok(())) => Ok(Self {
-                stop_tx: Some(stop_tx),
-                owner: Some(owner),
-            }),
-            Ok(Err(error)) => {
-                let _ = owner.join();
-                Err(error)
-            }
-            Err(_) => {
-                let _ = owner.join();
-                Err(SpeechError::WorkerPanicked)
-            }
-        }
+                running: Arc::clone(&running),
+                dropped_buffers,
+            },
+            Self {
+                running,
+                worker: Some(worker),
+            },
+        ))
     }
 
     pub fn stop(mut self) -> Result<(), SpeechError> {
-        self.signal_stop();
-        self.join_owner()
+        self.stop_worker()
     }
 
-    fn signal_stop(&mut self) {
-        if let Some(stop_tx) = self.stop_tx.take() {
-            let _ = stop_tx.send(());
-        }
-    }
-
-    fn join_owner(&mut self) -> Result<(), SpeechError> {
-        match self.owner.take() {
-            Some(owner) => owner.join().map_err(|_| SpeechError::WorkerPanicked)?,
+    fn stop_worker(&mut self) -> Result<(), SpeechError> {
+        self.running.store(false, Ordering::Release);
+        match self.worker.take() {
+            Some(worker) => worker.join().map_err(|_| SpeechError::WorkerPanicked),
             None => Ok(()),
         }
     }
 }
 
-impl Drop for SpeechSession {
+impl Drop for SpeechEngineSession {
     fn drop(&mut self) {
-        self.signal_stop();
-        let _ = self.join_owner();
+        let _ = self.stop_worker();
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn build_stream<T>(
-    device: &cpal::Device,
-    config: &cpal::StreamConfig,
-    audio_tx: SyncSender<Vec<f32>>,
-    channels: usize,
-    normalize: impl Fn(&T) -> f32 + Send + Sync + 'static,
-    dropped_buffers: Arc<AtomicU64>,
-    identity: EventIdentity,
-    sink: SpeechEventSink,
-) -> Result<cpal::Stream, SpeechError>
-where
-    T: cpal::SizedSample + Send + 'static,
-{
-    let error_identity = identity.clone();
-    let error_sink = sink.clone();
-    device
-        .build_input_stream(
-            config,
-            move |data: &[T], _| {
-                let mono = downmix(data, channels, &normalize);
-                if audio_tx.try_send(mono).is_err() {
-                    dropped_buffers.fetch_add(1, Ordering::Relaxed);
-                }
-            },
-            move |error| {
-                error_sink(SpeechEvent::Error {
-                    request_id: error_identity.request_id.clone(),
-                    voice_session_id: error_identity.voice_session_id.clone(),
-                    code: "microphone_stream".to_owned(),
-                    message: format!("麦克风输入中断：{error}"),
-                });
-            },
-            None,
-        )
-        .map_err(|error| SpeechError::InputStream(error.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc::sync_channel;
+
+    fn test_handle(
+        capacity: usize,
+    ) -> (
+        SpeechEngineHandle,
+        std::sync::mpsc::Receiver<PcmAudioChunk>,
+        Arc<AtomicBool>,
+        Arc<AtomicU64>,
+    ) {
+        let (audio_tx, audio_rx) = sync_channel(capacity);
+        let running = Arc::new(AtomicBool::new(true));
+        let dropped_buffers = Arc::new(AtomicU64::new(0));
+        (
+            SpeechEngineHandle {
+                audio_tx,
+                running: Arc::clone(&running),
+                dropped_buffers: Arc::clone(&dropped_buffers),
+            },
+            audio_rx,
+            running,
+            dropped_buffers,
+        )
+    }
+
+    fn chunk() -> PcmAudioChunk {
+        PcmAudioChunk::try_new(vec![0.25, -0.25], 48_000).unwrap()
+    }
+
+    #[test]
+    fn pcm_input_reports_acceptance_backpressure_and_closed_state() {
+        let (handle, audio_rx, running, dropped_buffers) = test_handle(1);
+        assert_eq!(handle.try_push(chunk()), SpeechEngineInputResult::Accepted);
+        assert_eq!(
+            handle.try_push(chunk()),
+            SpeechEngineInputResult::Backpressured
+        );
+        assert_eq!(dropped_buffers.load(Ordering::Relaxed), 1);
+        assert_eq!(audio_rx.recv().unwrap(), chunk());
+
+        running.store(false, Ordering::Release);
+        assert_eq!(handle.try_push(chunk()), SpeechEngineInputResult::Closed);
+    }
+
+    #[test]
+    fn pcm_input_reports_closed_when_worker_is_gone() {
+        let (handle, audio_rx, _, dropped_buffers) = test_handle(1);
+        drop(audio_rx);
+        assert_eq!(handle.try_push(chunk()), SpeechEngineInputResult::Closed);
+        assert_eq!(dropped_buffers.load(Ordering::Relaxed), 0);
+    }
 
     #[test]
     fn join_hotwords_trims_and_skips_empty() {

--- a/crates/rambledesk-speech/src/speech_engine/worker.rs
+++ b/crates/rambledesk-speech/src/speech_engine/worker.rs
@@ -1,12 +1,13 @@
 //! The transcription worker thread: it owns the recognizer, drains the audio
 //! channel, and emits speech events until the session stops.
 //!
-//! Split out of `native.rs` to keep that module within the repository's Rust
+//! Split out of `speech_engine.rs` to keep that module within the repository's Rust
 //! module size budget.
 
-use super::{RecognitionEngine, SpeechSessionConfig};
+use super::RecognitionEngine;
 use crate::{
-    EventIdentity, SPEECH_SAMPLE_RATE, SpeechEvent, SpeechEventSink, resample_linear, rms,
+    EventIdentity, PcmAudioChunk, SPEECH_SAMPLE_RATE, SpeechEngineConfig, SpeechEvent,
+    SpeechEventSink, resample_linear, rms,
 };
 use std::{
     sync::{
@@ -20,21 +21,20 @@ use std::{
 /// Everything the worker needs besides the recognizer and its audio feed.
 /// Grouped rather than passed one by one: the two entry points otherwise take
 /// eight and seven positional arguments of largely interchangeable types.
-pub(super) struct WorkerContext {
-    pub source_rate: u32,
+pub(super) struct SpeechEngineWorkerContext {
     pub identity: EventIdentity,
     pub running: Arc<AtomicBool>,
     pub sink: SpeechEventSink,
     pub dropped_buffers: Arc<AtomicU64>,
 }
 
-/// Load the recognizer, then transcribe. Recording has already started by the
-/// time this runs, so the load happens here rather than blocking the caller.
-pub(super) fn run_sherpa_worker_after_load(
-    config: SpeechSessionConfig,
-    audio_rx: Receiver<Vec<f32>>,
-    context: WorkerContext,
-    abort_tx: SyncSender<()>,
+/// Load the recognizer, then transcribe. Loading runs concurrently with native
+/// source startup; the bounded input queue preserves warmup audio meanwhile.
+pub(super) fn run_speech_engine_after_load(
+    config: SpeechEngineConfig,
+    audio_rx: Receiver<PcmAudioChunk>,
+    context: SpeechEngineWorkerContext,
+    abort_tx: Option<SyncSender<()>>,
 ) {
     (context.sink)(SpeechEvent::Warning {
         request_id: context.identity.request_id.clone(),
@@ -52,18 +52,19 @@ pub(super) fn run_sherpa_worker_after_load(
                 code: "model_load".to_owned(),
                 message: error.to_string(),
             });
-            let _ = abort_tx.try_send(());
+            if let Some(abort_tx) = abort_tx {
+                let _ = abort_tx.try_send(());
+            }
         }
     }
 }
 
 fn run_sherpa_worker(
     mut engine: RecognitionEngine,
-    audio_rx: Receiver<Vec<f32>>,
-    context: WorkerContext,
+    audio_rx: Receiver<PcmAudioChunk>,
+    context: SpeechEngineWorkerContext,
 ) {
-    let WorkerContext {
-        source_rate,
+    let SpeechEngineWorkerContext {
         identity,
         running,
         sink,
@@ -71,13 +72,14 @@ fn run_sherpa_worker(
     } = context;
     loop {
         match audio_rx.recv_timeout(Duration::from_millis(80)) {
-            Ok(samples) => {
+            Ok(chunk) => {
                 sink(SpeechEvent::Level {
                     request_id: identity.request_id.clone(),
                     voice_session_id: identity.voice_session_id.clone(),
-                    rms: rms(&samples).clamp(0.0, 1.0),
+                    rms: rms(&chunk.samples).clamp(0.0, 1.0),
                 });
-                let audio = resample_linear(&samples, source_rate, SPEECH_SAMPLE_RATE);
+                let audio =
+                    resample_linear(&chunk.samples, chunk.sample_rate_hz, SPEECH_SAMPLE_RATE);
                 engine.accept(&audio, &identity, &sink);
             }
             Err(RecvTimeoutError::Timeout) if !running.load(Ordering::Acquire) => break,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,6 +61,9 @@ application facade，由 Tauri state、该进程的 Local Integration Server 与
 Desktop Shell ─── Native Capability Implementation ───┐
                                                       ├─ outside Application Transport
 Web browser  ─── Browser Capability Implementation ───┘
+
+Desktop / Browser / Mobile Platform Plugin
+  └─ local speech or capture ──→ SpeechEvent / Attachment Candidate ──→ TipTap Ramble Core
 ```
 
 Desktop Client 与 Web Client 复用同一 Workbench Client 和 Application Transport
@@ -112,6 +115,10 @@ Client 只能根据 capability manifest 呈现可用操作：
 - Browser Capability 受 secure context、浏览器权限、用户手势和当前设备限制；
 - Browser file picker 选择客户端文件，不代表 Backend Runtime 所在机器的 working directory；
 - 缺失或降级的 Browser Capability 必须明确不可用，不能伪装成 Native Capability 等价实现。
+
+语音和截图等设备流程由当前客户端的 Platform Plugin 组合。Platform Plugin 是第一方、typed 的
+Capability Module，不是 Host Adapter，也不隐含动态第三方插件加载器。它不经 Application Transport
+代理设备操作，只向共享 TipTap Ramble Core 返回 `SpeechEvent` 或 `AttachmentCandidate`。
 
 ## Feedback Draft 所有权
 
@@ -280,17 +287,21 @@ TARGET Web Client 复用该 UI，但不复用 Desktop Shell 或 Native Capabilit
   `unload` 不可靠，因此不能把唯一一次保存或任何终态 mutation 放在 `unload` handler 中；
 - 重连或重新打开 view 时，从 Backend Runtime 重新读取 Request、Draft revision 与运行状态。
 
-### Audio Source 与 Speech Engine
+### TipTap Ramble Core 与 Platform Plugin
 
-Audio Source 是 device Capability，speech recognition 是 Backend Runtime 使用的 Speech Engine：
+Ramble 是以 TipTap Feedback Draft 为中心的编辑流程，不是录音 session。共享 Ramble Core 持有
+SpeechEvent 到 TipTap transaction 的映射、stable segment identity、附件 node、autosave 与 CAS；
+它不持有麦克风/屏幕权限、PCM、重采样、VAD、模型、WASM Worker 或系统截图 overlay。
 
-- Desktop 的 Native Audio Source 可以把本机音频流直接交给既有 Speech Engine；
-- Browser Audio Source 通过浏览器权限和用户手势取得媒体，首期把 MediaRecorder Blob 或有界分段
-  经 authenticated HTTP 上传到 server-side recognition session；
-- Desktop 与 Web 必须投影同一 SpeechEvent contract，断线、停止、权限拒绝或设备丢失都要显式
-  终结 recognition session；
-- 只有实时 partial transcript 成为明确验收需求时，才新增独立 binary WebSocket；不得复用首期
-  invalidation WebSocket 传 PCM。
+- Desktop Speech Recognition Plugin 在本机组合 Native Audio Source、Rust sherpa-onnx Speech Engine
+  与模型资料库；`rambledesk-speech` 的 source/engine seam 是其内部实现；
+- Browser Speech Recognition Plugin 在浏览器所在设备组合 `getUserMedia`、AudioWorklet、流式重采样、
+  dedicated Worker、sherpa-onnx WebAssembly 与 origin-local Model Store；
+- Mobile Client 未来通过各自平台的原生音频 API 与 sherpa-onnx binding 实现同一插件合同；
+- Capture Plugin 在当前设备取得图像并返回 Attachment Candidate；共享 Draft 流程负责验证、上传或
+  持久化，成功后再插入 TipTap attachment node；
+- 平台共享 SpeechEvent 与 Attachment Candidate 合同，不共享引擎进程、模型或权限；实时音频、
+  recognition session 与设备权限不进入 Application Transport。
 
 ## 事实来源
 
@@ -305,7 +316,7 @@ Audio Source 是 device Capability，speech recognition 是 Backend Runtime 使�
 | 上下文提示 | request `context_refs` / `source_hint` |
 | Session tabs、顺序、active view、pane 尺寸 | 每个 Workbench Client 的 client-local workspace snapshot |
 | 系统通知 | best-effort side effect |
-| 局部转写 | speech session 内存；定期 checkpoint 到 Draft |
+| 局部转写 | 当前客户端 Platform Plugin 内存；稳定 SpeechEvent 通过 TipTap transaction 写入 Draft |
 
 HTTP snapshot、Tauri query result 和 WebSocket invalidation 都是上述事实的投影或提示，不是
 额外事实源。终态提交、取消等 application operation 必须幂等；CAS 冲突必须保留可见错误，

--- a/docs/BROWSER_LOCAL_ASR_AND_PLATFORM_PLUGINS_RESEARCH.md
+++ b/docs/BROWSER_LOCAL_ASR_AND_PLATFORM_PLUGINS_RESEARCH.md
@@ -1,0 +1,235 @@
+# 浏览器本地 ASR 与平台插件边界调研
+
+> 状态：方向校准研究，不是已完成实现  
+> 日期：2026-09-01  
+> 外部基线：sherpa-onnx `v1.13.7`（`917bed95c8e5c7c18aa4d69fea42e9ef8ef0a60e`）  
+> 仓库基线：`4ea6fbd` 与其后的未提交 Web Speech 实验  
+> 证据标记：**官方事实**来自 sherpa-onnx 官方仓库/文档或 Web Platform 官方文档；**仓库事实**来自当前 RambleDesk；**架构推论**是据此为 RambleDesk 作出的设计判断。
+
+## 1. 结论
+
+**浏览器端 ASR 应改为浏览器本地 sherpa-onnx WebAssembly，不应把 WAV 上传给 Desktop Web Access 后端识别。** Desktop、Browser、Mobile 各自在本机完成录音、重采样、VAD、ASR 和模型管理；Ramble 核心只接收统一的转录事件并把稳定文本写入唯一的 TipTap `document_json`。截图同理：由当前平台取得图像，核心只接收待持久化的附件候选。
+
+这个判断不是因为 WebAssembly “理论上可行”，而是因为 sherpa-onnx 已提供以下官方实现面：
+
+- **官方事实：** WebAssembly 导出同时覆盖 streaming ASR、non-streaming ASR 和 VAD；官方 JS wrapper 已有 online/offline recognizer 与 VAD 调用接口。[WASM 总览](https://k2-fsa.github.io/sherpa/onnx/wasm/index.html)、[当前共享导出列表](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/wasm-common.cmake)、[ASR wrapper](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/asr/sherpa-onnx-asr.js)、[VAD wrapper](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/vad/sherpa-onnx-vad.js)
+- **官方事实：** 当前仓库已有“麦克风 → Web Worker → VAD → non-streaming ASR”的 Web 示例。模型字节被写入 Emscripten 文件系统，推理在 Worker 中运行，并把分段与文本发回 UI。[Worker 管理代码](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/flutter-examples/vad-non-streaming-asr-from-microphone/lib/worker_web.dart)、[Worker 实现](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/flutter-examples/vad-non-streaming-asr-from-microphone/web/vad-asr-worker.js)
+- **官方事实：** Android 有 JNI/本地库构建路径，iOS 有 Swift/XCFramework 分发路径；没有技术理由让手机绕回 Desktop Runtime。[Android](https://k2-fsa.github.io/sherpa/onnx/android/index.html)、[Android 构建](https://k2-fsa.github.io/sherpa/onnx/android/build-sherpa-onnx.html)、[iOS Swift](https://k2-fsa.github.io/sherpa/onnx/ios/build-sherpa-onnx-swift.html)、[Swift Package](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/Package.swift)
+- **架构推论：** 浏览器上传 WAV 的路线把设备能力错误地穿过 Application Transport，并让浏览器依赖 Desktop 进程的模型、并发槽和生命周期。它既违反“音频仅在当前设备处理”的产品承诺，也阻断未来独立 Web/Mobile Client。
+
+因此建议停止继续产品化未提交的 Web Speech 上传协议，保留 `4ea6fbd` 中“采集与识别分离”的内部模块化成果，但把它收进 Desktop Speech Plugin，而不是把 Desktop Speech Engine 提升成所有客户端共享的后端能力。
+
+## 2. sherpa-onnx WebAssembly 的实际能力
+
+### 2.1 构建与运行形态
+
+**官方事实：** 官方仓库目前同时保留了三类 Web 构建入口：
+
+1. `build-wasm-simd-asr.sh` + `wasm/asr`：面向 ASR 的旧式构建，可把模型预加载进 Emscripten `.data`。
+2. `build-wasm-simd-vad-asr.sh` + `wasm/vad-asr`：VAD 与 offline ASR 的旧式组合构建。
+3. `build-wasm-simd-web.sh` + `wasm/web`：当前模块化 Web 构建，生成 `SherpaOnnx` factory，统一导出 streaming ASR、offline ASR、VAD 等能力，模型不必编进 `.data`。[当前 Web 构建脚本](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/build-wasm-simd-web.sh)、[Web CMake 入口](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/web/CMakeLists.txt)、[Flutter Web 产物组装](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/build-flutter-web-wasm.sh)
+
+**架构推论：** RambleDesk 应采用第 3 条作为维护基线，固定 sherpa-onnx tag、Emscripten 版本、构建参数和产物 SHA。旧式 `.data` demo 适合验证，不适合把大模型与应用版本强绑定。
+
+### 2.2 JS/WASM 调用接口
+
+**官方事实：** online recognizer 的标准生命周期是：创建 recognizer/stream，向 stream 调用 `acceptWaveform(sampleRate, Float32Array)`，在 `isReady` 时 `decode`，读取 `getResult`，在 endpoint 后 `reset`，结束时 `inputFinished` 并释放资源。offline recognizer 则在送入完整语音段后 `decode` 并读取结果。输入是 `[-1, 1]` 的单声道 `Float32Array`，并显式传入 sample rate。[ASR wrapper](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/asr/sherpa-onnx-asr.js)
+
+**官方事实：** VAD wrapper 支持 Silero VAD 与 TEN VAD 配置，并提供 `acceptWaveform`、`detected`、`front`、`pop`、`flush`、`reset` 等操作，可把连续 PCM 切成有界语音段再送 offline recognizer。[VAD wrapper](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/vad/sherpa-onnx-vad.js)
+
+**官方事实：** 官方资产说明明确展示了 streaming Zipformer transducer、streaming Paraformer，以及“Silero VAD + 任一支持的 non-streaming model”的组合方式。[Streaming ASR 资产说明](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/asr/assets/README.md)、[VAD + offline ASR 资产说明](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/vad-asr/assets/README.md)
+
+**官方事实：** 当前 Flutter Web Worker 示例的配置分支还覆盖 Zipformer CTC、SenseVoice、Whisper、NeMo Parakeet TDT、Moonshine、Qwen3 ASR、FunASR Nano 与 FireRed ASR CTC。这里能证明 wrapper/config 路径存在，不能证明每个模型都适合 RambleDesk 的目标浏览器与内存预算。[官方 Web Worker 配置](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/flutter-examples/vad-non-streaming-asr-from-microphone/lib/worker_web.dart)
+
+### 2.3 Worker 与 AudioWorklet
+
+**官方事实：** sherpa-onnx 当前完整示例把 VAD/ASR 放在专用 Web Worker 中，而不是 UI 主线程。旧 `wasm/asr/app-asr.js` 仍是示例级代码，使用已废弃的 `ScriptProcessorNode`；Web 平台建议把实时音频处理迁到 AudioWorklet，AudioWorklet 的处理逻辑运行在独立音频渲染线程。[官方 Worker 示例](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/flutter-examples/vad-non-streaming-asr-from-microphone/web/vad-asr-worker.js)、[MDN AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)、[MDN ScriptProcessorNode](https://developer.mozilla.org/en-US/docs/Web/API/ScriptProcessorNode)
+
+**架构推论：** Browser Speech Plugin 应使用两级执行面：
+
+- AudioWorklet 只做有界、实时安全的采集、单声道下混与 PCM 传递；不得在音频线程运行 ONNX。
+- 专用 Web Worker 拥有 sherpa WASM、模型文件、VAD/recognizer 与识别状态；通过带背压的有界消息协议接收 PCM，并只向 UI 发标准化 SpeechEvent。
+
+官方 Flutter 示例动态 `eval` JS 源码并创建 Blob URL。RambleDesk 不应照搬这一装载细节：应把 glue、wrapper 与 Worker 作为同源静态资源发布，以维持严格 CSP。可复用的是 Worker 内推理、模型写入 Emscripten FS 和消息生命周期。
+
+### 2.4 SIMD、线程与 COOP/COEP
+
+**官方事实：** 当前 Web 构建明确使用 ONNX Runtime 的 wasm-simd 静态库；`wasm-common.cmake` 设置 `INITIAL_MEMORY=512MB`、`ALLOW_MEMORY_GROWTH=1`，但官方构建脚本和 CMake flags 没有 `-pthread`/`-sUSE_PTHREADS`/shared-memory 开关。更直接地，sherpa-onnx C API 对 WASM 明确把大于 1 的 `num_threads` 强制降为 1；官方 Web Worker 代码也把 recognizer `numThreads` 固定为 `1`。[ORT SIMD 依赖](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/cmake/onnxruntime-wasm-simd.cmake)、[WASM flags](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/wasm-common.cmake)、[C API WASM 单线程限制](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/sherpa-onnx/c-api/c-api.cc#L62-L75)、[Worker 配置](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/flutter-examples/vad-non-streaming-asr-from-microphone/lib/worker_web.dart)
+
+**结论：当前上游单线程 SIMD 路径不要求 COOP/COEP。** SIMD 与 Wasm threads 是两件事。若未来 RambleDesk 自行打开 Wasm threads/shared memory，WebAssembly threads 会依赖共享内存，而 `SharedArrayBuffer` 的可靠使用要求 cross-origin isolation；届时需要至少配置 COOP `same-origin` 与 COEP `require-corp` 或 `credentialless`，并以 `crossOriginIsolated` 做运行时门禁。[MDN WebAssembly threads](https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format#webassembly_threads)、[MDN COOP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy)、[MDN crossOriginIsolated](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/crossOriginIsolated)、[MDN Wasm SIMD `v128`](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Value_types/v128)
+
+**架构推论：** 第一版不要为了“可能更快”提前开启线程和 COOP/COEP。先按官方单线程 SIMD 基线完成真实设备测量；只有测量证明单线程不达标、并验证所有同源/跨源资源可满足 COEP 后，再另立性能 ADR。
+
+## 3. 浏览器采集、重采样与权限
+
+**官方事实：** `getUserMedia()` 只在 secure context 可用，需要用户授权，而且用户忽略权限提示时 Promise 可能一直不 settle。[MDN getUserMedia](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia)
+
+**官方事实：** Secure Contexts 规范把 loopback 地址视作 potentially trustworthy，因此当前 `http://127.0.0.1` Web Access 可以在符合规范的现代浏览器中申请麦克风；一旦开放普通 LAN 地址，必须使用 HTTPS，不能把 loopback 例外外推到局域网。[W3C Secure Contexts](https://www.w3.org/TR/secure-contexts/)、[MDN Secure Contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Secure_Contexts)
+
+**官方事实：** `AudioContext.sampleRate` 表示该 context 全部节点使用的实际采样率；构造时请求指定采样率并不等于设备一定按 16 kHz 工作，不支持的值还可能失败。[MDN AudioContext constructor](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext)、[MDN sampleRate](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/sampleRate)
+
+**架构推论：** Browser Speech Plugin 必须读取实际 sample rate，稳定地下混为单声道，再用保持跨块状态的流式 resampler 转为模型要求的 16 kHz；不能假定 `new AudioContext({ sampleRate: 16000 })` 已解决重采样。采集协议还要有明确的队列上限、drop 计数、停止时尾帧 flush 和设备中断状态。
+
+权限拒绝、长期未响应、设备拔出、页面刷新、后台节流都应成为 typed state。浏览器本地 ASR 不应在失败时静默回退为上传服务器；产品降级应是明确提示“此浏览器/设备暂不可用”，并保留文字编辑。
+
+## 4. 模型资产、体积与浏览器缓存
+
+### 4.1 已知体积
+
+**官方事实：** sherpa-onnx 旧版 WASM 构建文档中的一个 streaming Zipformer 示例，产物约为 199 MB `.data` 加约 10 MB `.wasm`；这是一个具体示例，不是所有模型的固定体积。[官方构建文档](https://k2-fsa.github.io/sherpa/onnx/wasm/build.html)
+
+**仓库事实：** RambleDesk 当前 manifest 的落盘文件合计为：
+
+| 模型 | 当前文件体积 | 浏览器首批判断 |
+| --- | ---: | --- |
+| X-ASR streaming | 169,347,218 bytes；下载包 133,895,136 bytes | 首选 feasibility candidate，但须验证这个具体模型与当前 WASM build |
+| SenseVoice | 239,549,735 bytes | 可作为 VAD + offline 后续候选，首装和内存成本较高 |
+| FunASR Nano | 1,009,605,061 bytes | 不应成为浏览器默认；先排除首批 |
+
+这些数字只描述模型文件，不包含约 512 MB 的初始 Wasm memory 设置、WASM/glue、JS/ArrayBuffer 与 Emscripten FS 装载时可能出现的临时副本。**不能用模型文件大小推导峰值内存。**
+
+**官方事实：** sherpa-onnx 没有发布可直接套用到 RambleDesk 目标浏览器/设备的首载时间、峰值内存、实时率或长会话延迟 SLA。官方 demo 和构建成功只能证明运行路径存在，不能替代 RambleDesk 的浏览器 benchmark。
+
+**架构推论：** 浏览器 Phase 0 先验证 X-ASR streaming，从“持续 partial + endpoint 后 stable”的 Ramble 体验入手。它是候选，不是已确认兼容：官方 wrapper 支持 online transducer，但当前资料没有直接证明 RambleDesk 这份 2026 X-ASR manifest 已在目标浏览器矩阵中跑通。SenseVoice/VAD 可进入第二阶段；约 1 GB 的 FunASR Nano 不进入浏览器默认路径。
+
+### 4.2 分发与缓存
+
+**官方事实：** 当前官方 Worker 示例把模型作为应用 assets 读成字节，通过消息交给 Worker，再写入 Emscripten MEMFS；它没有提供 RambleDesk 所需的跨版本模型安装、校验或持久缓存管理。[Worker 管理代码](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/flutter-examples/vad-non-streaming-asr-from-microphone/lib/worker_web.dart)、[Worker 文件装载](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/flutter-examples/vad-non-streaming-asr-from-microphone/web/vad-asr-worker.js)
+
+**官方事实：** Cache API 可以持久保存 Request/Response 对，但生命周期与配额受浏览器管理，应用需要自己做版本和清理；OPFS 是 origin-private 的本地文件存储，也受配额和站点数据清理影响。应用可用 `navigator.storage.estimate()` 评估配额，并请求 persistent storage，但不能把它视为永不驱逐的保证。[MDN Cache](https://developer.mozilla.org/en-US/docs/Web/API/Cache)、[MDN OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)、[MDN storage quotas](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria)
+
+**架构推论：** Browser Speech Plugin 内部应有版本化 Model Store：
+
+- key 至少包含 `model_id + model_version + file_sha256`；manifest 记录每个文件的 URL、byte size、SHA-256、license、notice 和 browser eligibility；
+- 下载前估算空间，下载后逐文件验 size/hash，全部成功才原子地标为 installed；支持取消、损坏恢复、显式删除与旧版本 GC；
+- Cache API 与 OPFS 二选一应由 feasibility spike 以装载成本和浏览器兼容性决定；不管采用哪个，当前 sherpa runtime 仍需要把模型暴露给 Emscripten FS；
+- “离线可用”只能在一次完整、校验通过的安装和离线重启测试之后展示。
+
+### 4.3 CSP 与静态资源
+
+**仓库事实：** `crates/rambledesk-local-server/src/web_access_server.rs` 当前 CSP 只有 `default-src 'self'` 等规则，没有允许 WebAssembly 编译的 `script-src 'wasm-unsafe-eval'`；静态文件服务也需要为 `.wasm` 返回正确的 `application/wasm` MIME。
+
+**官方事实：** CSP 的 `script-src`/`default-src` 会控制 WebAssembly compilation；`'wasm-unsafe-eval'` 可以只放开 Wasm compilation，而不等同于放开一般 JS `eval()`。[MDN CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy)
+
+**架构推论：** Web pilot 应加入最窄的 `script-src 'self' 'wasm-unsafe-eval'`，Worker 使用同源静态 URL，并明确 `worker-src 'self'`。不要为复制官方示例的动态源码装载而加入 `'unsafe-eval'` 或宽泛 Blob script。COOP/COEP 仍只在未来启用 Wasm threads 时加入。
+
+## 5. 许可证与模型分发
+
+**官方事实：** sherpa-onnx 框架代码是 Apache-2.0。[LICENSE](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/LICENSE)
+
+**官方事实：** 这不自动覆盖模型。官方预训练模型说明会单独指出模型包中的 LICENSE；例如 SenseVoice 页面要求查看解压目录的模型许可证，FunASR Nano 也有独立的模型导出与来源说明。[SenseVoice 模型](https://k2-fsa.github.io/sherpa/onnx/sense-voice/pretrained.html)、[FunASR Nano](https://k2-fsa.github.io/sherpa/onnx/funasr-nano/export.html)
+
+**仓库事实：** 当前 RambleDesk manifest 已把 SenseVoice 标为 `FunASR Model Open Source License Agreement 1.1`，FunASR Nano 标为 `FunASR Model License`；X-ASR manifest 目前没有独立 `license` 字段。
+
+**架构推论：** 将模型下载到用户浏览器仍是模型分发。上线前必须逐模型确认官方发布包中的许可证、notice、再分发权限与展示义务；不能以 sherpa-onnx 的 Apache-2.0 代替模型许可证。X-ASR 缺失的 manifest license 是 browser pilot 之前的阻断项。
+
+## 6. Ramble 的平台插件设计
+
+### 6.1 核心原则
+
+这里引入待写入 `docs/TERMINOLOGY.md` 的新术语 **Platform Plugin（平台插件）**：一个在单一客户端平台内实现设备能力、权限、资源与生命周期的深模块。它不是 Host Adapter，也不经 Application Transport 代理设备操作。
+
+Ramble 核心收敛为 TipTap 编辑流程：
+
+- canonical 真源始终是版本化 TipTap `document_json`；Markdown 只是导出、提交与历史投影；
+- 核心拥有 SpeechEvent 到 TipTap transaction 的映射、stable segment identity、pending/cleaned 标记、autosave/CAS、附件 node 插入和撤销；
+- 核心不拥有麦克风/屏幕权限、PCM/WAV、重采样、VAD、模型文件、WASM/原生线程、浏览器缓存或系统截图 overlay；
+- Application Transport 只传输 Feedback Draft/附件等业务事实，不传输实时音频、识别 session 或平台权限。
+
+### 6.2 两条独立 Interface
+
+不要做一个包含所有设备功能的浅 `PlatformPlugin` 大接口。建立一个很薄的 capability registry，下面挂两条独立深 Interface：
+
+```text
+TipTap Ramble Core
+  ├─ SpeechRecognitionPlugin.start(options, emit) -> SpeechSession
+  │    SpeechSession.stop()   # flush 尾帧并产生最终 stable event
+  │    SpeechSession.cancel() # 释放平台资源，不提交残余文本
+  │
+  └─ CapturePlugin.capture(request) -> AttachmentCandidate | Cancelled
+```
+
+`SpeechRecognitionPlugin` 的 Interface 只暴露平台无关的 availability/model status、start/stop/cancel 与标准化事件：`started`、`level`、可选 `partial`、`stable(segment_id, text)`、`warning`、`stopped`、`error`。权限、模型安装、采集、重采样、VAD、backpressure、recognizer 和线程/Worker 全部隐藏在 Implementation 内。平台之间共享的是事件语义与合同测试，不要求相同的 partial 节奏、引擎进程或模型。
+
+`CapturePlugin` 只返回待由 Draft 存储验证和持久化的 `AttachmentCandidate`（bytes/Blob、MIME、dimensions、source metadata）。它不直接编辑 TipTap，也不写最终附件路径。
+
+### 6.3 平台映射
+
+| 平台 | SpeechRecognitionPlugin Implementation | CapturePlugin Implementation |
+| --- | --- | --- |
+| Desktop | `cpal`/系统音频 + Rust sherpa-onnx + native worker/thread；模型在 Desktop 本地资料库 | OS 截图、全局快捷键、overlay、文件选择 |
+| Browser | `getUserMedia` + AudioWorklet + 流式 resampler + dedicated Worker + sherpa-onnx WASM + origin model cache | `getDisplayMedia`、文件选择、粘贴/拖入；遵守用户手势与浏览器权限 |
+| Android | `AudioRecord` + sherpa-onnx JNI/Kotlin；模型在 app sandbox | 系统 picker/camera/media projection，按 Android 权限模型 |
+| iOS | `AVAudioEngine` + sherpa-onnx Swift/XCFramework；模型在 app sandbox | Photos/camera/share sheet 等 iOS 能力 |
+
+**官方事实：** 浏览器 `getDisplayMedia()` 需要 secure context 和 transient user activation，每次都必须让用户选择/授权，权限不能持久化。[MDN getDisplayMedia](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia)
+
+**架构推论：** Browser Capture Plugin 不能承诺 Desktop 的全局快捷键或无提示 overlay 语义。平台可以拥有不同的 acquisition UX，但交给 TipTap 核心的附件候选合同一致。
+
+## 7. 对 `4ea6fbd` 与未提交实验的处置
+
+### 7.1 保留 `4ea6fbd` 的部分
+
+`4ea6fbd` 将 native audio capture 与 recognizer 分离，这个方向应保留：
+
+- `PcmAudioChunk` 的单声道 Float32、显式 sample rate 与有界时长合同；
+- `SpeechEngineConfig`、`SpeechEngineSession`、`SpeechEngineHandle.try_push` 的 session/lifecycle 与有界队列/backpressure；
+- recognizer 内部统一重采样到模型采样率；
+- native source 与 engine composition，以及相应资源释放和背压测试。
+
+但这些应成为 **Desktop Speech Plugin 的 Implementation 细节**。需要撤回“Speech Engine 是 Backend Runtime 共享能力”“Browser Audio Source 把 Blob 上传给它”的文档含义。Desktop 内部的 `Audio Source`/`Speech Engine` seam 可以存在，不应成为跨客户端网络 seam。
+
+### 7.2 撤销未提交 Web Speech 上传实验
+
+根据本次检查，以下整条路线应撤销，而不是继续修补：
+
+- Web Access `/api/speech/recognition-sessions` 的 POST/PUT WAV/WebSocket/finish/cancel 协议；
+- Web 端 `HttpSpeechRecognitionSession` 和 canonical WAV 编码/上传；
+- server 端 recognition coordinator、session 状态机、上传上限与协议错误映射；
+- Desktop `DesktopWebSpeechBackend` 与 uploaded WAV parser；
+- 让 Desktop 麦克风和 Browser 上传识别共用一个 `SpeechRuntimeGate` 的跨平台并发槽；
+- 仅为这些 speech routes 增加的 router/auth/capability 字段与协议测试。
+
+若 Desktop 本机仍需要“同一时间一个识别 session”的 gate，可以在 Desktop Speech Plugin 内保留或重写；它不能限制另一个设备上浏览器自己的本地识别。现有协议测试只有在改写为平台无关 SpeechEvent/TipTap 插入合同测试后才值得保留。
+
+### 7.3 后续文档零残留
+
+实施前至少需要用新 ADR 同步修订：
+
+- `docs/TERMINOLOGY.md` 中 Audio Source、Speech Engine、Native/Browser Capability 的定义；
+- `docs/ARCHITECTURE.md` 中 browser Blob/chunk 送后端识别的描述；
+- `docs/adr/005-shared-workbench-transport-capabilities.md` 第 5 节的 server-side recognition 路线。
+
+目标不是把旧段落补一句例外，而是消除“设备能力经 Application Transport 代理”和“浏览器复用 Desktop Speech Engine”的残留。`Adapter` 继续专指 Host Adapter；新概念使用 Platform Plugin，避免术语碰撞。
+
+## 8. 建议落地顺序与验收门
+
+### Phase 0：浏览器 feasibility spike
+
+只做 X-ASR streaming 单模型闭环：同源静态 WASM/Worker、AudioWorklet、实际采样率读取、流式重采样、Worker 内 recognizer、最小 Model Store、SpeechEvent → 当前 TipTap Editor。它不新增后端 speech route。
+
+必须在承诺兼容前记录真实目标设备，而不是只跑单元测试：
+
+- 浏览器矩阵：RambleDesk 实际支持的 Chrome/Edge/Firefox/Safari 版本与机器架构；
+- cold install bytes/time、warm start time、WASM 初始化、模型 hash 验证、离线重启；
+- 峰值内存、稳定内存、30/60 分钟长会话、页面 reload 后资源释放；
+- real-time factor、partial/stable p50/p95 latency、丢帧数、队列峰值；
+- 权限拒绝/不响应、设备拔出、tab background、AudioContext suspend/resume、模型损坏、quota/eviction；
+- CSP、`.wasm` MIME、SIMD feature failure 与无服务端上传的网络检查。
+
+### Phase 1：合同固化
+
+以同一组 black-box contract tests 验证 Desktop/Browser Speech Plugin：start/stop/cancel 幂等、每个 stable segment 只插入一次、错误不破坏 Draft、停止会 flush、取消会释放设备、识别事件不携带 PCM/WAV。TipTap transaction 和 CAS 冲突处理留在 Ramble 核心测试。
+
+### Phase 2：offline 模型与 Mobile
+
+在体积/性能门通过后再加入 Browser VAD + SenseVoice offline；Android/iOS 分别以官方 native binding 实现同一 SpeechRecognitionPlugin Interface。不要把 WASM 当作所有平台的统一运行时，统一点应是 Interface 与 TipTap 事务语义。
+
+## 9. 决策摘要
+
+1. 接受“ASR 在输入发生的设备本地执行”为产品与架构原则。
+2. Browser 采用 sherpa-onnx single-thread SIMD WebAssembly，AudioWorklet 采集，专用 Worker 推理；当前不要求 COOP/COEP。
+3. 停止 Web Access WAV 上传/后端识别实验；Web Access 不新增实时音频协议。
+4. 保留 `4ea6fbd` 的采集/recognizer 分离、PCM、重采样和背压设计，但收进 Desktop Speech Plugin。
+5. Ramble 核心只拥有 TipTap Draft、SpeechEvent 插入和附件持久化；语音与截图是独立 Platform Plugin。
+6. 浏览器模型必须版本化缓存、逐文件校验并单独审计模型许可证；X-ASR 是首个待验证候选，不是未经测量的兼容承诺。

--- a/docs/BROWSER_LOCAL_ASR_AND_PLATFORM_PLUGINS_RESEARCH.md
+++ b/docs/BROWSER_LOCAL_ASR_AND_PLATFORM_PLUGINS_RESEARCH.md
@@ -119,9 +119,9 @@
 
 **官方事实：** 这不自动覆盖模型。官方预训练模型说明会单独指出模型包中的 LICENSE；例如 SenseVoice 页面要求查看解压目录的模型许可证，FunASR Nano 也有独立的模型导出与来源说明。[SenseVoice 模型](https://k2-fsa.github.io/sherpa/onnx/sense-voice/pretrained.html)、[FunASR Nano](https://k2-fsa.github.io/sherpa/onnx/funasr-nano/export.html)
 
-**仓库事实：** 当前 RambleDesk manifest 已把 SenseVoice 标为 `FunASR Model Open Source License Agreement 1.1`，FunASR Nano 标为 `FunASR Model License`；X-ASR manifest 目前没有独立 `license` 字段。
+**仓库事实：** 当前 RambleDesk manifest 已把 SenseVoice 标为 `FunASR Model Open Source License Agreement 1.1`，FunASR Nano 标为 `FunASR Model License`，并把 X-ASR 标为 `Apache-2.0`。这些字段是当前产品 manifest 的声明，不代替对上游模型包内 LICENSE/NOTICE 与再分发条件的独立核验。
 
-**架构推论：** 将模型下载到用户浏览器仍是模型分发。上线前必须逐模型确认官方发布包中的许可证、notice、再分发权限与展示义务；不能以 sherpa-onnx 的 Apache-2.0 代替模型许可证。X-ASR 缺失的 manifest license 是 browser pilot 之前的阻断项。
+**架构推论：** 将模型下载到用户浏览器仍是模型分发。上线前必须逐模型确认官方发布包中的许可证、notice、再分发权限与展示义务；不能只因为 sherpa-onnx 框架采用 Apache-2.0，就推断任一模型也采用相同许可。X-ASR 的 manifest 声明仍需由模型包证据验证，验证结果是 browser pilot 产品化之前的门禁。
 
 ## 6. Ramble 的平台插件设计
 

--- a/docs/BROWSER_LOCAL_ASR_AND_PLATFORM_PLUGINS_RESEARCH.md
+++ b/docs/BROWSER_LOCAL_ASR_AND_PLATFORM_PLUGINS_RESEARCH.md
@@ -1,6 +1,6 @@
 # 浏览器本地 ASR 与平台插件边界调研
 
-> 状态：方向校准研究，不是已完成实现  
+> 状态：方向校准研究 + WEB9 实施记录
 > 日期：2026-09-01  
 > 外部基线：sherpa-onnx `v1.13.7`（`917bed95c8e5c7c18aa4d69fea42e9ef8ef0a60e`）  
 > 仓库基线：`4ea6fbd` 与其后的未提交 Web Speech 实验  
@@ -30,6 +30,10 @@
 3. `build-wasm-simd-web.sh` + `wasm/web`：当前模块化 Web 构建，生成 `SherpaOnnx` factory，统一导出 streaming ASR、offline ASR、VAD 等能力，模型不必编进 `.data`。[当前 Web 构建脚本](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/build-wasm-simd-web.sh)、[Web CMake 入口](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/wasm/web/CMakeLists.txt)、[Flutter Web 产物组装](https://github.com/k2-fsa/sherpa-onnx/blob/v1.13.7/build-flutter-web-wasm.sh)
 
 **架构推论：** RambleDesk 应采用第 3 条作为维护基线，固定 sherpa-onnx tag、Emscripten 版本、构建参数和产物 SHA。旧式 `.data` demo 适合验证，不适合把大模型与应用版本强绑定。
+
+**WEB9 交付证据：** 官方 [`sherpa_onnx_web` 1.13.7 package](https://pub.dev/packages/sherpa_onnx_web/versions/1.13.7) 提供可与模型分离的 generic Web runtime。RambleDesk 的 prepare 脚本固定下载 [`sherpa_onnx_web-1.13.7.tar.gz`](https://pub.dev/api/archives/sherpa_onnx_web-1.13.7.tar.gz)（archive SHA-256 `b3b5d54df39e720b626439a8f14ea08ea1bdb5513f64dff2a5c5bb251e6093b7`），并逐项校验 ASR wrapper、modular glue 和 14,869,666-byte Wasm 后写入 gitignored `public/browser-speech/runtime/`。应用仓库只提交 prepare 脚本、Worker 与 AudioWorklet 源码；build/dev 从官方 archive 可复现准备 runtime。浏览器首个模型改为 [pkufool/zipformer-small-streaming](https://www.modelscope.cn/models/pkufool/zipformer-small-streaming) 的 32-chunk int8 CTC 文件与 tokens，共 29,258,848 bytes，由用户显式安装到版本化 Cache Storage。
+
+这条路径与官方 release 中旧的 `sherpa-onnx-wasm-simd-v1.13.7-zh-en-asr-zipformer` 预编译 demo bundle 不同：后者把 `sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20` 模型预载入约 199 MB `.data`，不是 WEB9 的交付资产。RambleDesk 不提交或下载该旧 bundle。
 
 ### 2.2 JS/WASM 调用接口
 
@@ -82,7 +86,8 @@
 
 | 模型 | 当前文件体积 | 浏览器首批判断 |
 | --- | ---: | --- |
-| X-ASR streaming | 169,347,218 bytes；下载包 133,895,136 bytes | 首选 feasibility candidate，但须验证这个具体模型与当前 WASM build |
+| X-ASR streaming | 169,347,218 bytes；下载包 133,895,136 bytes | 在内置浏览器中完成文件与 runtime 校验，但 generic Wasm runtime 创建 recognizer 时抛出原生异常；不作为 browser pilot |
+| Zipformer Small streaming CTC | 29,258,848 bytes | WEB9 browser pilot；已完成真实下载、逐文件 hash、断点恢复和 recognizer 创建 |
 | SenseVoice | 239,549,735 bytes | 可作为 VAD + offline 后续候选，首装和内存成本较高 |
 | FunASR Nano | 1,009,605,061 bytes | 不应成为浏览器默认；先排除首批 |
 
@@ -90,7 +95,7 @@
 
 **官方事实：** sherpa-onnx 没有发布可直接套用到 RambleDesk 目标浏览器/设备的首载时间、峰值内存、实时率或长会话延迟 SLA。官方 demo 和构建成功只能证明运行路径存在，不能替代 RambleDesk 的浏览器 benchmark。
 
-**架构推论：** 浏览器 Phase 0 先验证 X-ASR streaming，从“持续 partial + endpoint 后 stable”的 Ramble 体验入手。它是候选，不是已确认兼容：官方 wrapper 支持 online transducer，但当前资料没有直接证明 RambleDesk 这份 2026 X-ASR manifest 已在目标浏览器矩阵中跑通。SenseVoice/VAD 可进入第二阶段；约 1 GB 的 FunASR Nano 不进入浏览器默认路径。
+**WEB9 实测决策：** X-ASR 仍适合作为 Desktop 原生 streaming 模型，但其 169 MB 文件在当前 generic Wasm runtime 中没有通过 recognizer 创建门禁。Browser pilot 改用 29 MB Zipformer Small streaming CTC：在 Codex 内置 Chromium 中已完成冷下载、SHA-256 校验、失败后断点恢复、Wasm/runtime 校验和 recognizer 创建；麦克风许可提示没有在该自动化浏览器中被响应，因而真实 PCM 输入与出字仍保留为 Chrome/Safari 人工验收项。SenseVoice/VAD 可进入第二阶段；约 1 GB 的 FunASR Nano 不进入浏览器默认路径。
 
 ### 4.2 分发与缓存
 
@@ -119,9 +124,9 @@
 
 **官方事实：** 这不自动覆盖模型。官方预训练模型说明会单独指出模型包中的 LICENSE；例如 SenseVoice 页面要求查看解压目录的模型许可证，FunASR Nano 也有独立的模型导出与来源说明。[SenseVoice 模型](https://k2-fsa.github.io/sherpa/onnx/sense-voice/pretrained.html)、[FunASR Nano](https://k2-fsa.github.io/sherpa/onnx/funasr-nano/export.html)
 
-**仓库事实：** 当前 RambleDesk manifest 已把 SenseVoice 标为 `FunASR Model Open Source License Agreement 1.1`，FunASR Nano 标为 `FunASR Model License`，并把 X-ASR 标为 `Apache-2.0`。这些字段是当前产品 manifest 的声明，不代替对上游模型包内 LICENSE/NOTICE 与再分发条件的独立核验。
+**仓库事实：** 当前 Desktop manifest 已把 SenseVoice 标为 `FunASR Model Open Source License Agreement 1.1`，FunASR Nano 标为 `FunASR Model License`，并把 X-ASR 标为 `Apache-2.0`。Browser pilot 的 ModelScope 仓库元数据声明 Apache-2.0；这些字段不代替对上游模型包内 LICENSE/NOTICE 与再分发条件的独立核验。
 
-**架构推论：** 将模型下载到用户浏览器仍是模型分发。上线前必须逐模型确认官方发布包中的许可证、notice、再分发权限与展示义务；不能只因为 sherpa-onnx 框架采用 Apache-2.0，就推断任一模型也采用相同许可。X-ASR 的 manifest 声明仍需由模型包证据验证，验证结果是 browser pilot 产品化之前的门禁。
+**架构推论：** 将模型下载到用户浏览器仍是模型分发。上线前必须逐模型确认官方发布包中的许可证、notice、再分发权限与展示义务；不能只因为 sherpa-onnx 框架采用 Apache-2.0，就推断任一模型也采用相同许可。模型仓库元数据仍需由包内证据复核，验证结果是 browser pilot 产品化之前的门禁。
 
 ## 6. Ramble 的平台插件设计
 
@@ -206,7 +211,7 @@ TipTap Ramble Core
 
 ### Phase 0：浏览器 feasibility spike
 
-只做 X-ASR streaming 单模型闭环：同源静态 WASM/Worker、AudioWorklet、实际采样率读取、流式重采样、Worker 内 recognizer、最小 Model Store、SpeechEvent → 当前 TipTap Editor。它不新增后端 speech route。
+只做 Zipformer Small streaming CTC 单模型闭环：同源静态 WASM/Worker、AudioWorklet、实际采样率读取、流式重采样、Worker 内 recognizer、最小 Model Store、SpeechEvent → 当前 TipTap Editor。它不新增后端 speech route。
 
 必须在承诺兼容前记录真实目标设备，而不是只跑单元测试：
 
@@ -232,4 +237,4 @@ TipTap Ramble Core
 3. 停止 Web Access WAV 上传/后端识别实验；Web Access 不新增实时音频协议。
 4. 保留 `4ea6fbd` 的采集/recognizer 分离、PCM、重采样和背压设计，但收进 Desktop Speech Plugin。
 5. Ramble 核心只拥有 TipTap Draft、SpeechEvent 插入和附件持久化；语音与截图是独立 Platform Plugin。
-6. 浏览器模型必须版本化缓存、逐文件校验并单独审计模型许可证；X-ASR 是首个待验证候选，不是未经测量的兼容承诺。
+6. 浏览器模型必须版本化缓存、逐文件校验并单独审计模型许可证；Zipformer Small CTC 是 browser pilot，兼容范围仍以真实浏览器矩阵验收为准。

--- a/docs/CODEG_WEB_SERVICE_RESEARCH.md
+++ b/docs/CODEG_WEB_SERVICE_RESEARCH.md
@@ -215,8 +215,8 @@ Codeg 主业务实时通道是 WebSocket。SSE 只用于代理 `officecli watch`
 | 系统全局快捷键 | Tauri global shortcut | 不支持 | `SystemGlobalShortcut` capability |
 | 原生截图/区域 overlay | Desktop host 原生能力 | 不等价；首版粘贴/上传 | `ImageAttachment` |
 | 主动屏幕分享 | 可保留现有原生实现 | `getDisplayMedia()`，捕获浏览器所在设备 | `ImageAttachment` 或后续 screen-share session |
-| 麦克风录音 | 当前 Tauri/Rust 音频采集 | `getUserMedia` + `MediaRecorder`，采集浏览器所在设备 | `AudioBlob/UploadedAudio` |
-| ASR | 后端 speech service | 上传/流式发送给同一后端 speech service | `Transcript` 与统一错误状态 |
+| 麦克风录音 | 当前 Tauri/Rust 音频采集 | `getUserMedia` + AudioWorklet，采集浏览器所在设备 | 当前客户端的 Speech Recognition Plugin |
+| ASR | Rust sherpa-onnx，在 Desktop 本地运行 | sherpa-onnx WebAssembly，在 dedicated Worker 本地运行 | `SpeechEvent` 与统一错误状态 |
 | 本地文件 | 可传 native path | 必须先上传 bytes/blob | `Attachment` |
 
 ### 5.1 快捷键
@@ -245,23 +245,20 @@ Tauri 的 OS 全局快捷键属于 Desktop plugin 与权限能力。[Tauri Globa
 RambleDesk 更合理的拆法是：
 
 ```text
-AudioCapture（客户端能力）
-  ├─ Tauri：现有 native capture
-  └─ Web：getUserMedia + MediaRecorder
+Speech Recognition Plugin（客户端平台能力）
+  ├─ Desktop：native capture + Rust sherpa-onnx
+  └─ Web：getUserMedia + AudioWorklet + Worker + sherpa-onnx WASM
                  │
                  ▼
-       AudioBlob / UploadedAudio
+       SpeechEvent + timing/error
                  │
                  ▼
-SpeechRecognizerSession（共享后端服务）
-                 │
-                 ▼
-       Transcript + timing/error
+           TipTap Ramble Core
 ```
 
-浏览器麦克风访问要求安全上下文和用户授权；`localhost` 可作为安全上下文，但局域网裸 HTTP 通常不行。浏览器还可能产生不同容器/codec，应通过 `MediaRecorder.isTypeSupported()` 协商，不能假设统一 WAV。[MDN `getUserMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia)、[MDN `MediaRecorder`](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder)、[MDN `dataavailable`](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/dataavailable_event)
+浏览器麦克风访问要求安全上下文和用户授权；loopback 可作为可信上下文，但局域网裸 HTTP 通常不行。Browser Speech Recognition Plugin 应读取实际采样率、用 AudioWorklet 取得 PCM，并在 dedicated Worker 中完成本地重采样、VAD 与 sherpa-onnx WASM 推理。[MDN `getUserMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia)、[MDN AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)
 
-所以“让手机通过 LAN 地址访问并录音”会把 HTTPS/pairing 从部署优化提升为功能前提。Web 第一版若没有可信 HTTPS，可以只承诺 loopback 录音，或先交付文字、图片与音频文件上传，把浏览器实时录音/流式 ASR 拆为后续 PR。
+所以“让手机通过 LAN 地址访问并录音”会把 HTTPS/pairing 从部署优化提升为功能前提。Web 第一版先验证 loopback Browser 本地 ASR；LAN 与 Mobile Client 分别在拥有可信 HTTPS 和本地插件实现后开放，不以服务端音频上传作为 fallback。
 
 ## 6. 建议的 RambleDesk 目标边界
 
@@ -283,12 +280,12 @@ SpeechRecognizerSession（共享后端服务）
                            │
                   rambledesk-storage / SQLite
 
-LocalCapability（由客户端持有）
-  ├─ ShortcutAdapter
-  ├─ CaptureAdapter
-  ├─ AudioCaptureAdapter
-  ├─ AttachmentIngressAdapter
-  └─ WindowIntegrationAdapter
+Platform Capability / Plugin（由客户端持有）
+  ├─ Shortcut Capability
+  ├─ Capture Plugin
+  ├─ Speech Recognition Plugin
+  ├─ Attachment Ingress Capability
+  └─ Window Integration Capability
 ```
 
 这保持 [ARCHITECTURE.md](ARCHITECTURE.md) 的原则：`rambledesk-core` 不持有 HTTP/Tauri，Desktop 继续作为 composition root；新增 Web router 只是 application contract 的第二个 transport adapter。
@@ -348,7 +345,7 @@ interface WorkbenchClient {
 
 1. **定义 Workbench DTO、错误与 BackendTransport 合同。** 为现有 Tauri commands 建立类型化 client，不改变行为。
 2. **收口 UI 中的 Tauri 直接依赖。** 请求、草稿、附件、设置通过 TauriWorkbenchTransport；保留少量 composition root。
-3. **建立 LocalCapability Adapters。** 快捷键、截图、录音、文件与窗口能力从业务组件移出，并加入 capability matrix。
+3. **建立 Platform Capability / Plugin Implementation。** 快捷键、截图、录音、文件与窗口能力从业务 Module 移出，并加入 capability matrix。
 4. **让共享 UI 可在普通浏览器构建。** 不要求此时拥有完整后端；保证 SSR/static build 不直接访问 Tauri globals。
 5. **静态构建与 Desktop bundle 合并。** 同一前端产物供 WebView 与后续 Web server 使用。
 
@@ -363,7 +360,7 @@ interface WorkbenchClient {
 3. **WebTransport 与浏览器登录。** Bearer HTTP；WS 使用 subprotocol token 或换成登录后短期 HttpOnly session，必须有明确威胁模型。
 4. **轻量跨客户端同步。** WS invalidation + reconnect refetch；沿用 draft revision/CAS，不先做 replay ring buffer。
 5. **浏览器附件入口。** 图片粘贴、拖放、文件上传；服务端统一生成 attachment metadata。
-6. **浏览器音频采集与 ASR。** 只有 HTTPS/secure-context 决策明确后再做；先 Blob upload，确有实时性需求再做 chunk streaming。
+6. **浏览器本地音频采集与 ASR。** 先在 loopback secure context 中验证 AudioWorklet、Worker、sherpa-onnx WASM 与模型缓存；不新增音频上传或服务端识别协议。
 7. **LAN opt-in 与配对体验。** 明确监听范围、地址/二维码、失败诊断、HTTPS/tunnel 指引，再承诺跨设备访问。
 
 ## 8. 第一阶段不应直接照搬 Codeg 的复杂度
@@ -389,7 +386,7 @@ interface WorkbenchClient {
 - HTTP API 是 command parity 还是业务资源/用例 allowlist；本报告建议“allowlist”。
 - WS 第一版传 delta 还是 invalidation；本报告建议“invalidation + revision”。
 - 浏览器凭证是长期 bearer token 还是短期 session；需单独安全 ADR。若先用 token，至少与 MCP token 分离。
-- Web ASR 是完整文件上传还是实时 chunk；本报告建议“先上传，后流式”。
+- Web ASR 在浏览器本地使用 streaming 还是 VAD + offline；先以 X-ASR streaming 做 feasibility gate，再按真实设备结果决定后续模型。
 - 静态前端是否保持单一构建产物；本报告建议“是”，避免 Desktop/Web 页面分叉。
 
 ## 10. 一手资料索引
@@ -408,4 +405,4 @@ interface WorkbenchClient {
 - [Tauri Global Shortcut plugin](https://v2.tauri.app/plugin/global-shortcut/)
 - [MDN `MediaDevices.getDisplayMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia)
 - [MDN `MediaDevices.getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia)
-- [MDN `MediaRecorder`](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder)
+- [MDN AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)

--- a/docs/CODEG_WEB_SERVICE_RESEARCH.md
+++ b/docs/CODEG_WEB_SERVICE_RESEARCH.md
@@ -386,7 +386,7 @@ interface WorkbenchClient {
 - HTTP API 是 command parity 还是业务资源/用例 allowlist；本报告建议“allowlist”。
 - WS 第一版传 delta 还是 invalidation；本报告建议“invalidation + revision”。
 - 浏览器凭证是长期 bearer token 还是短期 session；需单独安全 ADR。若先用 token，至少与 MCP token 分离。
-- Web ASR 在浏览器本地使用 streaming 还是 VAD + offline；先以 X-ASR streaming 做 feasibility gate，再按真实设备结果决定后续模型。
+- Web ASR 在浏览器本地使用 streaming 还是 VAD + offline；WEB9 先以 Zipformer Small streaming CTC 做 pilot，再按真实设备结果决定后续模型。
 - 静态前端是否保持单一构建产物；本报告建议“是”，避免 Desktop/Web 页面分叉。
 
 ## 10. 一手资料索引

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -39,7 +39,7 @@ MVP 不做：
 | 宿主会话 | 宿主中的原对话、任务或运行上下文；同一会话可产生多次请求。 |
 | 适配器 | 宿主接入 RambleDesk 的完整流程。 |
 | 工作台 | 人类处理反馈请求的桌面 UI。 |
-| Ramble | 工作台中的自由反馈采集模式，包含语音、文字和截图。 |
+| Ramble | 以 TipTap Feedback Draft 为核心的自由反馈编辑流程；语音、截图和粘贴是可选的平台输入能力。 |
 | Action Group | 反馈草稿中用 Blockquote 表达的 `@Action` 归属。 |
 | Tidy | 当前 Editor 中手动触发的 ASR 段落整理；使用自己独立的模型配置，不是 Cooking。 |
 | Cooking | 提交前可选的大模型编辑步骤；把 Uncooked Feedback 整理为 Cooked Feedback，同时保留原稿。 |

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -1,6 +1,6 @@
 # RambleDesk 术语表
 
-> 状态：v4 当前基线。
+> 状态：v5 当前基线。
 > 目标：固定产品语言、协议字段和 package 边界。代码、文档、UI 文案、测试命名若与本文冲突，以本文为准。
 
 本文是 RambleDesk 的唯一术语源。其他文档只引用本文，不重新定义产品对象。
@@ -17,12 +17,13 @@
 8. MCP 是通用 MCP 适配器的一种 transport，不是全局基础设施。
 9. 提交后的 continuation 不是适配器。适配器可以选择“不需要 continuation”“手动 continuation”或“原生 continuation”。
 10. RambleDesk 不要求源码 checkout 路径。路径最多是适配器提供的可选 context hint。
+11. 语音识别与屏幕采集发生在输入所在的客户端设备；Platform Plugin 只把结构化转录事件或附件候选交给 TipTap Ramble Core，不通过 Application Transport 代理设备能力。
 
 ## 核心闭环
 
 1. 宿主中的智能体通过适配器创建反馈请求。
 2. RambleDesk 持久化请求，并在工作台展示。
-3. 人类在工作台中检查上下文、截图、录音、书写反馈，然后提交或取消。
+3. 人类在工作台的 TipTap Feedback Draft 中检查上下文和书写反馈；当前平台的语音、截图等 Platform Plugin 可以向同一文档提供结构化输入。
 4. RambleDesk 发布不可变反馈包。
 5. 适配器或 continuation 让原宿主读取反馈包并继续。
 
@@ -44,15 +45,19 @@
 | Desktop Shell（桌面壳层） | Tauri 进程、窗口、托盘、更新器、原生权限和 desktop composition root。 | 组装 Desktop Client、Backend Runtime 与本地能力；不拥有 UI 业务事实。 |
 | Native Capability（原生能力） | 由 Desktop Shell 提供的 OS / device Implementation，例如全局快捷键、系统截图、原生录音、托盘、更新器和原生对话框。 | 独立于 Application Transport；可访问的设备和权限范围不能被 Web Client 假定。 |
 | Browser Capability（浏览器能力） | 由浏览器 API 提供的 device-scoped Implementation，例如受权限和用户手势约束的媒体、剪贴板、文件选择、下载和通知。 | 独立于 Application Transport；受 secure context、浏览器、权限与当前设备限制，不等价于 Native Capability，也不代表服务器文件系统。 |
-| Audio Source（音频源） | 由 Native Capability 或 Browser Capability 提供的音频输入 Interface/Implementation；可以是本机流，也可以是浏览器上传的 Blob 或有界分段。 | 只负责采集、编码与传输，不执行语音识别，不拥有 Feedback Draft。 |
-| Speech Engine（语音识别引擎） | Backend Runtime 使用的识别能力，消费 Audio Source 输入并产生统一 SpeechEvent。 | 与设备采集分离；Desktop 与 Web 不得各自形成不同的识别语义。 |
+| Platform Plugin（平台插件） | 在一个 Workbench Client 平台内组合设备 Capability、权限、资源和生命周期的深 Module。 | 不是 Host Adapter，也不表示可动态安装的第三方扩展；不经 Application Transport 代理设备操作，不拥有 Feedback Draft。 |
+| Speech Recognition Plugin（语音识别插件） | 在当前客户端设备内组合 Audio Source、重采样、VAD、Speech Engine 与模型管理，并产生统一 SpeechEvent 的 Platform Plugin。 | 原始音频、识别 session 和模型不进入 Application Transport；平台共享事件语义，不共享同一个引擎进程。 |
+| Capture Plugin（采集插件） | 在当前客户端设备上取得截图、相机、粘贴或文件输入，并返回 Attachment Candidate 的 Platform Plugin。 | 不直接编辑 TipTap，不写最终附件路径；平台可以有不同 acquisition UX。 |
+| Attachment Candidate（附件候选） | Platform Plugin 交给共享 Draft 流程验证和持久化的客户端本地 bytes/Blob、MIME 与来源 metadata。 | 不是已持久化附件，也不是服务器路径；只有 application mutation 成功后才能成为 Feedback Draft 附件引用。 |
+| Audio Source（音频源） | Speech Recognition Plugin 内负责取得有明确 sample rate 的本地单声道 PCM 的 Interface/Implementation。 | 不执行语音识别、不传输到 Backend Runtime、不拥有 Feedback Draft。 |
+| Speech Engine（语音识别引擎） | Speech Recognition Plugin 内消费本地 PCM 并产生 SpeechEvent 的识别 Implementation。 | Desktop、Browser 与 Mobile 各自在本设备运行；统一点是事件合同，不是进程、模型或 transport。 |
 | 反馈请求 | 由适配器创建、由人类处理的持久单位，用 `request_id` 标识。 | RambleDesk 的核心输入事实。 |
 | 反馈包 | 请求进入终态后发布的不可变证据，包含 manifest、markdown、附件路径和 hash。 | RambleDesk 的核心输出事实；宿主继续前必须读取。 |
 | 适配器 | 面向一类宿主的完整接入流程：创建请求、读取反馈、处理 continuation。 | 可以由多个 package 或 transport 组成。 |
 | continuation | 请求进入终态后，让原宿主继续的行为。 | 只处理终态之后；不创建请求，不发布反馈包。 |
 | 宿主会话 | 宿主中的原对话、任务或运行上下文。 | 同一宿主会话可以发起多次反馈请求；不是源码 checkout。 |
 | context hint | 适配器可选提供的展示/定位信息，例如标题、路径、URL、文件引用。 | 不参与认证，不是必需身份字段，不保证可恢复。 |
-| Ramble | 工作台内的自由反馈采集模式，尤其是语音、文字、截图驱动的反馈。 | 属于人类工作流，不属于适配器协议。 |
+| Ramble | 以 TipTap Feedback Draft 为中心的自由反馈编辑流程；文字是基础输入，语音、截图等 Platform Plugin 可向同一文档贡献结构化内容。 | 不等同于录音 session，不拥有平台设备能力，也不属于适配器协议。 |
 | Uncooked Feedback | 人类通过 Ramble、文字、截图形成的原始反馈正文；允许保留口语、重复和自我修正。 | 是人类原始证据，Cooking 不得覆盖；提交后保存为反馈包中的 `uncooked.md`。 |
 | Feedback Draft | 当前未提交请求的可编辑正文。canonical 真源是版本化 TipTap `document_json`，`body_markdown` 是同一份文档的派生投影。 | 不得把 Markdown 当作第二真源独立维护。 |
 | Action Group | 用标准 Blockquote 表达的 `@Action` 归属容器。 | 同一 Action 再次打开时创建新容器，不与旧区间合并。 |
@@ -164,6 +169,7 @@ Pi 原生适配器不需要提交后的 continuation，因为 Pi 已经在工具
 | Web Client / HTTP + WebSocket Application Transport Implementation / Web Access | `apps/desktop` 中的共享 Svelte UI、browser composition/auth gate/HTTP Transport，以及 `crates/rambledesk-local-server` 中的独立 Web Access server Module。 | 复用同一 Backend Runtime 与安全 policy/primitives，并与 Local Integration Server 分离 listener、credential、auth domain、生命周期和 route set。 |
 | Native Capability Implementation | `apps/desktop` 及 desktop-only crates。 | 与 Application Transport 分离并通过 capability manifest 暴露可用性。 |
 | Browser Capability Implementation | `apps/desktop` 当前使用浏览器 file picker 与 download，原生截图、原生录音、窗口和系统路径操作明确不可用。 | 后续媒体/剪贴板能力只承诺浏览器实际允许的范围，不模拟原生或服务器文件系统语义。 |
+| Platform Plugin Implementation | `apps/desktop` 的 capability registry、Desktop Tauri Implementation 与 Browser Implementation；`rambledesk-speech` 是 Desktop Speech Recognition Plugin 的内部实现。 | 每个平台本地处理设备输入；只向共享 TipTap Ramble Core 输出 SpeechEvent 或 Attachment Candidate。 |
 
 | Package / 区域 | 职责 | 不应包含 |
 | --- | --- | --- |
@@ -226,6 +232,7 @@ UI 文案允许：
 - “手动继续”
 - “桌面客户端”与“Web 客户端”
 - “Web 访问”
+- “平台插件”
 
 UI 文案避免：
 
@@ -235,12 +242,15 @@ UI 文案避免：
 - 用 “Adapter / 适配器”指代 Application Transport 或 Native / Browser Capability；它们分别称为 Interface 与 Implementation。
 - 把 Backend Runtime 称为“Web Server”，或用“关闭 Web”暗示停止 Backend Runtime / Local Integration Server。
 - 把 Browser Capability 描述成 Native Capability 的等价实现，或把浏览器文件选择描述成服务器工作目录选择。
+- 把 Platform Plugin 描述成 Host Adapter，或把第一方、静态装配的 Platform Plugin 暗示为任意第三方动态插件。
+- 把 Ramble 描述成录音 session，或把 Speech Engine 描述成 Backend Runtime 的跨客户端共享服务。
 
 代码与架构文档命名：
 
 - `Adapter / 适配器` 只用于完整 host-facing 集成，例如 Generic MCP Adapter 与 Pi Native Adapter。
 - Workbench Client 的应用访问 seam 称为 `Application Transport Interface`；Tauri IPC、HTTP + WebSocket 称为其 `Implementation`。
 - OS / device seam 称为 `Native Capability` 或 `Browser Capability`；具体实现称为 `Capability Implementation`，不称为 Adapter。
+- 组合语音、截图等单一平台设备流程的深 Module 称为 `Platform Plugin`；首期是第一方 typed composition，不承诺动态插件系统。
 - `Web Access` 只表示可独立启停的浏览器访问 feature，不表示 Backend Runtime。
 
 ## 合并标准
@@ -249,6 +259,8 @@ UI 文案避免：
 - `core` 不包含 JSON、HTTP、MCP、Pi、Local Integration Server、Web Access 或 desktop command 逻辑。
 - Backend Runtime 是唯一业务事实来源；Workbench Client 只保存 client-local workspace snapshot，不缓存 canonical Feedback Draft。
 - Application Transport 与 Native / Browser Capability 保持独立，Transport Implementation 不执行设备能力。
+- Speech Recognition Plugin 与 Capture Plugin 在当前客户端设备运行；Application Transport 不传输实时音频、识别 session 或设备权限。
+- Ramble Core 的 canonical 输入面是 TipTap Feedback Draft；Platform Plugin 只能通过 SpeechEvent 或 Attachment Candidate 贡献内容。
 - Local Integration Server 与 Web Access 必须复用同一安全 policy/primitives，同时分离 listener、credential、auth domain、启停生命周期和 route set。
 - 本地 JSON API 位于 `rambledesk-local-server`。
 - MCP 是薄适配层，不持有 listener、token path 或 JSON API。

--- a/docs/UI_WEB_REFACTOR_EVALUATION.md
+++ b/docs/UI_WEB_REFACTOR_EVALUATION.md
@@ -147,7 +147,7 @@ Web Access 与 Local Integration Server 可以复用同一个 server crate 和 r
 
 - JSON HTTP：命令、查询、附件上传下载、设置；
 - WebSocket：请求状态、Draft revision、Session 状态等轻量 invalidate / delta；
-- 浏览器录音首期通过 HTTP 上传分段或完成后的 Blob；只有实时 partial transcript 成为明确需求时，才增加独立 binary WebSocket。
+- 实时音频与 recognition session 不进入 Application Transport；浏览器录音和 ASR 由浏览器本地 Platform Plugin 完成，只把稳定的 TipTap Draft mutation 经现有 HTTP contract 持久化。
 
 事件流从一开始必须定义 snapshot / reconnect，而不是假定广播永不丢失：
 
@@ -180,23 +180,23 @@ Desktop 与 Browser 同时打开后，Server 事实与 Client 工作区状态必
 | 剪贴板 | 可做系统级集成 | 受 secure context、权限和用户手势限制 | `ClipboardCapability` |
 | 文件选择 | 原生文件/目录对话框 | 浏览器选择的是 Client 文件 | `FileCapability` |
 | Server 工作目录 | 本机可用原生对话框 | 必须使用 Server-side folder browser / path picker | Server Interface |
-| 录音 | Tauri / native microphone source | `getUserMedia` + MediaRecorder | `AudioCapture` Adapter |
-| ASR | 本地 microphone + server-side engine | 音频上传到同一 engine | `SpeechEngine` Module |
+| 录音 | Tauri / native microphone source | `getUserMedia` + AudioWorklet | 当前客户端的 `SpeechRecognitionPlugin` |
+| ASR | Rust sherpa-onnx，在 Desktop 本地运行 | sherpa-onnx WebAssembly，在 dedicated Worker 本地运行 | 统一 `SpeechEvent`，不统一引擎进程 |
 | 系统通知 | 原生通知 | Web Notification，best effort | `NotificationCapability` |
 | 更新器、Tray、窗口、系统权限 | 完整 | 不提供 | Desktop-only Capability |
 
 浏览器截图和录音不能伪装成 Desktop 的等价实现：`getDisplayMedia()` 每次都需要用户选择共享源和瞬时用户操作；`getUserMedia()`、Clipboard 等能力依赖 secure context 与权限。远程浏览器捕获的是浏览器所在设备，而不是运行 RambleDesk Server 的设备。
 
-### 5.1 录音与 ASR 的拆分
+### 5.1 TipTap Ramble Core 与平台语音插件
 
-现有 `rambledesk-speech` 已有事件、重采样、VAD 和识别引擎资产，但 native microphone acquisition 与 recognizer 生命周期仍耦合。建议拆成：
+现有 `rambledesk-speech` 已有事件、重采样、VAD 和识别引擎资产。录音与识别继续在输入所在设备本地完成，并通过 Platform Plugin 隐藏平台差异：
 
-- `AudioCapture` Interface：产出有格式说明的 audio chunk / blob；
-- `NativeAudioCapture`：使用当前 cpal 采集，并可继续给本地 engine 提供 PCM；
-- `BrowserAudioCapture`：使用 `getUserMedia` 与 `MediaRecorder`，按浏览器实际支持格式上传；
-- `SpeechEngine`：在后端统一解码、resample、VAD / ASR，并发出统一 SpeechEvent。
+- `SpeechRecognitionPlugin`：对共享 Workbench 只暴露 availability/model status、start/stop/cancel 和统一 SpeechEvent；
+- Desktop Implementation：使用当前 cpal 与 Rust sherpa-onnx，在 Desktop 本地组合 Audio Source 与 Speech Engine；
+- Browser Implementation：使用 `getUserMedia`、AudioWorklet、流式重采样、dedicated Worker 与 sherpa-onnx WASM；
+- TipTap Ramble Core：把 stable SpeechEvent 映射成唯一 Feedback Draft 的 transaction；不拥有 PCM、模型或设备权限。
 
-不建议把 Web Speech API 作为主路径，因为浏览器实现、网络依赖、隐私和转写一致性都难以成为稳定产品合同。
+不建议把 Web Speech API 作为主路径，因为浏览器实现、网络依赖、隐私和转写一致性都难以成为稳定产品合同；也不以音频上传服务端作为 silent fallback。
 
 ## 六、安全模型
 
@@ -325,13 +325,14 @@ Desktop 与 Browser 同时打开后，Server 事实与 Client 工作区状态必
 
 验收：浏览器粘贴或上传的截图可进入现有编辑器与附件管线；远程 Client 文件与 Server path 不混淆。主动屏幕共享作为后续 `BrowserCaptureCapability`：只能通过用户手势调用 `getDisplayMedia()`，不宣称等价于 Desktop 全局区域截图。
 
-#### WEB-9：Web 录音与 ASR（3 commits）
+#### WEB-9：边缘媒体插件与 Browser 本地 ASR（4 commits）
 
 1. `Separate AudioSource from SpeechEngine`
-2. `Add browser audio upload and server-side recognition sessions`
-3. `Add BrowserAudioSource and preserve desktop speech behavior`
+2. `Define edge media plugins and the TipTap Ramble core`
+3. `Route platform input through editor contribution contracts`
+4. `Add browser-local sherpa WASM speech recognition`
 
-验收：Desktop 与 Web 产生相同 SpeechEvent 合同；浏览器通过 `getUserMedia` 采集并协商浏览器支持的格式；断线、停止、权限拒绝、设备丢失不会留下幽灵 recording session。首期可先做分段/结束后上传；只有实时 partial transcript 成为明确验收项时才增加 PCM streaming binary channel。
+验收：Desktop 与 Web 产生相同 SpeechEvent 合同，但各自在输入设备本地识别；浏览器使用 AudioWorklet、流式重采样与 dedicated Worker 运行 sherpa-onnx WASM；权限拒绝、设备丢失、页面隐藏、停止和模型损坏不会破坏 TipTap Draft 或留下幽灵 recording session；网络检查证明没有音频上传或服务端 speech route。
 
 #### WEB-10：Web Access 产品化与清理（3 commits）
 
@@ -339,7 +340,7 @@ Desktop 与 Browser 同时打开后，Server 事实与 Client 工作区状态必
 2. `Add loopback security limits diagnostics and acceptance tests`
 3. `Remove direct UI transport calls and run residual architecture scans`
 
-验收：用户能启动/停止 Web Access、复制 Token、打开本机地址并看到明确状态；Backend Runtime 与 Local Integration Server 不被误关；普通 UI 不再直接调用 invoke，所有调用都经 ApplicationTransport 或明确列出的 native Capability Adapter。
+验收：用户能启动/停止 Web Access、复制 Token、打开本机地址并看到明确状态；Backend Runtime 与 Local Integration Server 不被误关；普通 UI 不再直接调用 invoke，所有调用都经 ApplicationTransport 或明确列出的 Native Capability / Platform Plugin Implementation。
 
 ## 八、每一阶段的质量闸门
 
@@ -362,7 +363,7 @@ Desktop 与 Browser 同时打开后，Server 事实与 Client 工作区状态必
 ### Web 闸门
 
 - 本机文字反馈闭环先于截图和语音；
-- Chrome / Safari 至少覆盖登录、Draft、附件、提交、刷新恢复；
+- Chrome / Safari 至少覆盖登录、Draft、附件、提交、刷新恢复；Browser ASR 的生产兼容矩阵必须由另行记录的真实设备结果支持；
 - insecure context 下明确禁用麦克风、截图或剪贴板能力；
 - 第一版不把 listener 暴露到局域网；
 - Token 不进入 URL、日志、反馈包和浏览器持久明文存储。
@@ -376,7 +377,7 @@ Desktop 与 Browser 同时打开后，Server 事实与 Client 工作区状态必
 | 断线漏掉 Request 状态事件 | 高 | snapshot + invalidate + reconnect refetch + ready gate；高频 Timeline 后续再加 scoped replay |
 | Browser 与 Server 文件系统语义混淆 | 高 | client upload 与 server workspace picker 分开建模 |
 | LAN token 被明文截获 | 高 | 首版 loopback；LAN 必须 HTTPS / WSS 或可信代理 |
-| Web ASR 延迟和断线状态复杂 | 高 | 首期 Blob/分段上传、明确 recognition session、最后实施；实时流按需增加 |
+| Browser ASR 首载、内存和长会话延迟 | 高 | 固定 sherpa-onnx 与模型版本，先做真实设备 feasibility gate；AudioWorklet 采集、Worker 推理、版本化模型缓存 |
 | 前端框架重构吞噬产品开发 | 中 | 保留 Svelte / Vite；只引入两个深 Interface |
 | 设置页“停止 Web”误杀 Desktop 后端 | 中 | Backend Runtime 与 Web Access 两个术语、两个生命周期 |
 

--- a/docs/adr/003-unified-ramble-state.md
+++ b/docs/adr/003-unified-ramble-state.md
@@ -1,7 +1,11 @@
-# ADR 003：Ramble 是统一的采集状态
+# ADR 003：Ramble 是统一的采集状态（历史决策）
 
-- 状态：Accepted
+- 状态：Superseded by [ADR 006](./006-edge-media-plugins-and-tiptap-ramble-core.md)
 - 日期：2026-07-31
+
+> 本文保留 0.3.x 阶段的历史设计背景，不再定义当前 Ramble 合同。现行决策以
+> `docs/TERMINOLOGY.md` 和 ADR 006 为准：Ramble 以 TipTap Feedback Draft 为核心，
+> 语音、截图与剪贴板是可选的平台输入能力，不构成必须同时启停的统一采集状态机。
 
 ## 背景
 

--- a/docs/adr/005-shared-workbench-transport-capabilities.md
+++ b/docs/adr/005-shared-workbench-transport-capabilities.md
@@ -89,14 +89,16 @@ Session Runtime。终态与 runtime lifecycle 只能由可审计的显式 applic
 Client 应持续 autosave；关闭 workspace view 继续使用 save gate，但不得依赖不可靠的 browser
 `unload` 完成唯一一次保存或终态 mutation。重连/重开后从 Backend Runtime refetch 事实。
 
-### 5. Audio Source 与 Speech Engine 分离
+### 5. Platform Plugin 在输入设备本地处理媒体
 
-Audio Source 是 Native / Browser Capability，Speech Engine 是 Backend Runtime 使用的识别能力。
-Desktop Native Audio Source 可以直接把本机音频流交给既有 Speech Engine；Browser Audio Source
-通过浏览器权限和用户手势取得媒体，首期使用 authenticated HTTP 上传 MediaRecorder Blob 或
-有界分段到 server-side recognition session。两端投影同一 SpeechEvent contract；断线、停止、
-权限拒绝与设备丢失必须显式终结 recognition session。只有实时 partial transcript 成为明确需求
-时才新增独立 binary WebSocket，不复用 invalidation WebSocket 传输 PCM。
+本节由 [ADR 006](006-edge-media-plugins-and-tiptap-ramble-core.md) 修订。Audio Source 与 Speech
+Engine 可以在单个平台插件内部保持分离，但它们不构成跨客户端网络 seam。Desktop、Browser 与
+未来 Mobile Client 各自在输入所在设备完成采集、重采样、VAD、识别和模型管理；Application
+Transport 不传输实时音频、recognition session 或设备权限。
+
+Speech Recognition Plugin 只向共享 TipTap Ramble Core 投影统一 SpeechEvent；Capture Plugin
+只返回 Attachment Candidate。平台共享事件和候选合同，不共享同一个引擎进程、模型或 acquisition
+UX。
 
 ### 6. Local Integration Server 与 Web Access 独立
 
@@ -171,7 +173,7 @@ Web routes 分别设置 body、upload、rate 与 concurrent-connection 上限。
 ### Target
 
 - LAN/TLS Web Access 与更完整的 credential 管理 UI。
-- Browser Audio Source、浏览器截图/剪贴板与更完整的 capability manifest。
+- Browser Speech Recognition Plugin、Capture Plugin 与更完整的 capability manifest。
 - Native/Browser Capability 继续位于 Application Transport 外，通过 manifest 呈现差异。
 
 ## Rejected
@@ -195,7 +197,7 @@ Web routes 分别设置 body、upload、rate 与 concurrent-connection 上限。
 - headless 或独立 Web deployment packaging；
 - 完整 credential rotation/revocation 管理 UI；
 - sequence replay、ring buffer、multiplex protocol；
-- 实时二进制音频 WebSocket；
+- 浏览器本地 sherpa-onnx WASM 的生产模型矩阵与性能优化；
 - ACP、Router 或全局 client state framework。
 
 ## Consequences
@@ -220,9 +222,9 @@ Web routes 分别设置 body、upload、rate 与 concurrent-connection 上限。
   角色，不创建隐含新 crate，也不把领域规则或 transport credential 放入 core。两个 listener
   必须复用同一套 security policy/primitives，延续“本地安全策略只有一处实现”，但分离 credential、
   auth domain 与 lifecycle。
-- **ADR 002：** 保留 `cpal` / speech crate 的 Native Capability 实现；未来浏览器音频只能通过
-  Browser Capability 接入，不改写现有 speech/application contract。
-- **ADR 003：** Ramble 仍是统一采集状态，但 Web Client 必须按 capability manifest 显示缺失或
+- **ADR 002：** 保留 `cpal` / speech crate 作为 Desktop Speech Recognition Plugin 的内部实现；
+  Browser 通过自己的本地 Plugin 接入，不改写现有 SpeechEvent / Draft contract。
+- **ADR 003：** Ramble 仍是统一 TipTap 编辑流程，但 Web Client 必须按 capability manifest 显示缺失或
   降级的全局快捷键、系统截图和剪贴板能力。
 - **ADR 004：** 本 ADR 修订其“整个应用最多一个 Editor”的所有权作用域为“每个 Workbench Client
   instance 最多一个 Editor”。canonical Draft 仍在 Backend Runtime/SQLite；跨客户端并发只由

--- a/docs/adr/006-edge-media-plugins-and-tiptap-ramble-core.md
+++ b/docs/adr/006-edge-media-plugins-and-tiptap-ramble-core.md
@@ -1,0 +1,35 @@
+# ADR 006：边缘媒体插件与 TipTap Ramble Core
+
+- 状态：Accepted
+- 日期：2026-09-01
+- 术语源：[TERMINOLOGY.md](../TERMINOLOGY.md)
+- 调研：[BROWSER_LOCAL_ASR_AND_PLATFORM_PLUGINS_RESEARCH.md](../BROWSER_LOCAL_ASR_AND_PLATFORM_PLUGINS_RESEARCH.md)
+
+## Decision
+
+Ramble 是以 TipTap Feedback Draft 为中心的编辑流程，不是录音 session。语音识别、截图和未来相机
+输入由当前 Workbench Client 设备上的第一方 Platform Plugin 完成；Application Transport 不代理
+设备权限，也不传输实时音频或 recognition session。
+
+Speech Recognition Plugin 在每个平台本地组合采集、重采样、VAD、Speech Engine 与模型管理，只向
+TipTap Ramble Core 输出统一 SpeechEvent。Capture Plugin 只返回 Attachment Candidate，由共享 Draft
+流程验证和持久化后插入 TipTap。平台共享合同与黑盒测试，不共享同一个引擎进程、模型、权限或
+acquisition UX。
+
+Desktop 保留 `rambledesk-speech` 内部的 Audio Source / Speech Engine seam；Browser 使用
+`getUserMedia`、AudioWorklet、dedicated Worker 与 sherpa-onnx WebAssembly；Mobile 未来使用各自
+原生音频 API 与 sherpa-onnx binding。Platform Plugin 首期表示静态装配的 typed 深 Module，不承诺
+任意第三方动态插件系统。
+
+## Rejected
+
+- Browser 把 MediaRecorder Blob、WAV 或 PCM 上传给 Desktop / Backend Runtime 识别；这会把设备能力
+  穿过 Application Transport，使 Web Client 依赖另一设备的模型、并发槽和生命周期。
+- 把 Ramble 定义为必须启动语音的独立采集状态机；文字和 TipTap 编辑才是基础流程，语音只是可选输入。
+- 让 Speech / Capture Plugin 直接编辑 TipTap 或写最终附件路径；这会让平台实现拥有 Draft 语义。
+
+## Consequences
+
+Browser 必须承担 WASM 与模型的版本、下载、校验、缓存、许可证、内存和真实设备性能验收。作为回报，
+原始音频留在输入设备，Desktop / Browser / Mobile 可以独立运行，Web Access 不增加 speech route 或
+音频流协议，Ramble 的唯一持久输入面仍是版本化 TipTap `document_json`。

--- a/scripts/prepare-sherpa-web.mjs
+++ b/scripts/prepare-sherpa-web.mjs
@@ -1,0 +1,104 @@
+import { createHash } from 'node:crypto'
+import { gunzipSync } from 'node:zlib'
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import process from 'node:process'
+
+const VERSION = '1.13.7'
+const ARCHIVE_URL = `https://pub.dev/api/archives/sherpa_onnx_web-${VERSION}.tar.gz`
+const ARCHIVE_SHA256 = 'b3b5d54df39e720b626439a8f14ea08ea1bdb5513f64dff2a5c5bb251e6093b7'
+const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const OUTPUT = path.join(REPOSITORY_ROOT, 'apps/desktop/public/browser-speech/runtime')
+const FILES = Object.freeze({
+  'sherpa-onnx-asr.js': Object.freeze({
+    bytes: 53_867,
+    sha256: 'd51ae8e8b756ee5e53423ffada0c9702973f154f561aca7984fe0b12f4060178',
+  }),
+  'sherpa-onnx-wasm-web.js': Object.freeze({
+    bytes: 93_039,
+    sha256: '872cced0954291abe919cc75f3a454f2673ef215bdd0496788daa5fac8a3ba47',
+  }),
+  'sherpa-onnx-wasm-web.wasm': Object.freeze({
+    bytes: 14_869_666,
+    sha256: 'f0bd7239906d96a5aff87b523879b898c0522d58c2c7ac2f8795b74186dc9c99',
+  }),
+})
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+async function installedRuntimeIsValid() {
+  try {
+    const provenance = JSON.parse(await readFile(path.join(OUTPUT, 'provenance.json'), 'utf8'))
+    if (provenance.version !== VERSION || provenance.archiveSha256 !== ARCHIVE_SHA256) return false
+    for (const [name, expected] of Object.entries(FILES)) {
+      const bytes = await readFile(path.join(OUTPUT, name))
+      if (bytes.byteLength !== expected.bytes || sha256(bytes) !== expected.sha256) return false
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+function extractTarEntry(tar, wantedName) {
+  for (let offset = 0; offset + 512 <= tar.byteLength;) {
+    const header = tar.subarray(offset, offset + 512)
+    if (header.every((byte) => byte === 0)) break
+    const rawName = Buffer.from(header.subarray(0, 100)).toString('utf8').replace(/\0.*$/u, '')
+    const rawPrefix = Buffer.from(header.subarray(345, 500)).toString('utf8').replace(/\0.*$/u, '')
+    const name = rawPrefix ? `${rawPrefix}/${rawName}` : rawName
+    const rawSize = Buffer.from(header.subarray(124, 136)).toString('ascii').replace(/\0.*$/u, '').trim()
+    const size = Number.parseInt(rawSize || '0', 8)
+    if (!Number.isSafeInteger(size) || size < 0) throw new Error(`Invalid tar size for ${name}`)
+    const start = offset + 512
+    if (name === `assets/${wantedName}` || name.endsWith(`/assets/${wantedName}`)) {
+      return Buffer.from(tar.subarray(start, start + size))
+    }
+    offset = start + Math.ceil(size / 512) * 512
+  }
+  throw new Error(`The official package does not contain assets/${wantedName}`)
+}
+
+async function main() {
+  if (await installedRuntimeIsValid()) return
+  const response = await fetch(ARCHIVE_URL, { redirect: 'follow' })
+  if (!response.ok) throw new Error(`Could not download sherpa_onnx_web ${VERSION}: HTTP ${response.status}`)
+  const archive = Buffer.from(await response.arrayBuffer())
+  const archiveDigest = sha256(archive)
+  if (archiveDigest !== ARCHIVE_SHA256) {
+    throw new Error(`sherpa_onnx_web archive SHA-256 mismatch: ${archiveDigest}`)
+  }
+  const tar = gunzipSync(archive)
+  const staging = `${OUTPUT}.part-${process.pid}`
+  await rm(staging, { recursive: true, force: true })
+  await mkdir(staging, { recursive: true })
+  try {
+    for (const [name, expected] of Object.entries(FILES)) {
+      const bytes = extractTarEntry(tar, name)
+      const digest = sha256(bytes)
+      if (bytes.byteLength !== expected.bytes || digest !== expected.sha256) {
+        throw new Error(`${name} integrity mismatch: ${bytes.byteLength} bytes, SHA-256 ${digest}`)
+      }
+      await writeFile(path.join(staging, name), bytes)
+    }
+    await writeFile(path.join(staging, 'provenance.json'), `${JSON.stringify({
+      schemaVersion: 1,
+      package: 'sherpa_onnx_web',
+      version: VERSION,
+      archiveUrl: ARCHIVE_URL,
+      archiveSha256: ARCHIVE_SHA256,
+      files: FILES,
+    }, null, 2)}\n`)
+    await rm(OUTPUT, { recursive: true, force: true })
+    await mkdir(path.dirname(OUTPUT), { recursive: true })
+    await rename(staging, OUTPUT)
+  } catch (cause) {
+    await rm(staging, { recursive: true, force: true })
+    throw cause
+  }
+}
+
+await main()


### PR DESCRIPTION
## Summary
- split native audio capture from speech inference behind session-scoped platform plugin contracts
- implement browser-local sherpa-onnx WebAssembly recognition with AudioWorklet capture, Dedicated Worker inference, streaming resampling, bounded backpressure, and terminal cleanup
- add a pinned, hash-verified browser model store and reproducible sherpa runtime preparation
- serve worker/Wasm assets with exact inventory, MIME, and CSP rules
- keep TipTap as the canonical Ramble editing core and document the edge-media architecture and licensing gates

## Validation
- `pnpm check`
- `pnpm test` (81 files, 429 tests)
- `pnpm build:web`
- `pnpm format:check`
- `pnpm check:terminology`
- `pnpm contracts:check`
- `pnpm check:rust-size`
- `pnpm test:pi`
- `pnpm test:dsh`
- `pnpm test:rust`
- `pnpm clippy`

## Browser acceptance
- verified cold model download, pinned byte counts and SHA-256, retry from verified partial cache, sherpa Wasm/runtime identity, and recognizer creation in the in-app Chromium browser
- the automated browser did not expose an actionable microphone permission prompt, so real PCM transcription remains an explicit manual Chrome/Safari acceptance item
- the previous 169 MB X-ASR candidate failed recognizer creation in the generic Wasm runtime; the browser pilot therefore uses the verified 29 MB Zipformer Small streaming CTC model