### PR TITLE
UI: make Session tabs own the full workspace

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,7 @@
     "@tiptap/starter-kit": "^3.29.2",
     "ai": "^7.0.48",
     "paneforge": "1.0.2",
+    "svelte-dnd-action": "0.9.79",
     "svelte-sonner": "^1.1.1"
   },
   "devDependencies": {

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1827,7 +1827,7 @@
     onNotifications={() => void openSettings('notifications')}
     onWindowError={(message) => (pageError = tr('Window action failed: {error}', { error: message }))}
   >
-    {#snippet workspaceTabs(onStartDragging: ((event: PointerEvent) => void) | null)}
+    {#snippet workspaceTabs()}
       <WorkspaceTabStrip
         views={workspaceShellState.views}
         activeViewKey={workspaceShellState.activeViewKey}
@@ -1837,7 +1837,6 @@
         onActivate={(viewKey) => void activateWorkspaceTab(viewKey)}
         onClose={closeWorkspaceTab}
         onReorder={reorderWorkspaceTabs}
-        {onStartDragging}
       />
     {/snippet}
   </AppTitlebar>

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte'
-  import { Pane, PaneGroup, PaneResizer } from 'paneforge'
 
   import rambelleArchived from './assets/rambelle-states/archived.webp'
   import rambelleIdle from './assets/rambelle-states/idle.webp'
@@ -155,9 +154,7 @@
   import {
     initialHostRailCollapsed,
     saveHostRailCollapsed,
-    savePaneLayout,
     saveWorkspaceSnapshot,
-    savedPaneLayout,
     savedWorkspaceSnapshot,
   } from './lib/uiPreferences'
   import {
@@ -182,10 +179,6 @@
     tidyReasoningEffort,
     tidySystemPrompt,
   } from './lib/preferences'
-
-  type PaneGroupHandle = {
-    setLayout: (layout: number[]) => void
-  }
 
   const RESUME_PROMPT_STREAM = defineApplicationStream<ResumePrompt>('rambledesk://resume-prompt')
   const OPEN_ADAPTERS_STREAM = defineApplicationStream<void>('rambledesk://open-adapters')
@@ -270,24 +263,9 @@
       loadingWorkspace = true
     }
   }
-  const REQUEST_LIST_DEFAULT_WIDTH = 296
-  const REQUEST_LIST_MIN_WIDTH = 240
-  const WIDE_WORKSPACE_MIN_WIDTH = 648
-  const NARROW_WORKSPACE_MIN_WIDTH = 360
-  const PANE_RESIZER_SIZE = 11
-  const REQUEST_WORKSPACE_LAYOUT_KEY = 'request-workspace-layout'
-  let latestRequestWorkspaceLayout = savedPaneLayout(REQUEST_WORKSPACE_LAYOUT_KEY)
-
   let taskBriefOpen = true
   let todayOnly = false
   let hostSessionRailCollapsed = initialHostRailCollapsed()
-  let workbenchLayout: HTMLDivElement
-  let requestWorkspaceGroup: HTMLDivElement | null = null
-  let requestWorkspacePaneGroup: PaneGroupHandle | undefined
-  let requestWorkspaceLayoutReady = false
-  let requestWorkspaceLayoutInitializing = false
-  let workbenchLayoutWidth = 0
-  let requestWorkspaceWidth = 0
   let genericMcpConfiguration = ''
   let voicePhase: VoicePhase = 'idle'
   let voiceDevice = ''
@@ -650,71 +628,10 @@
     approving ||
     currentRequestCooking ||
     workspace?.request.status === 'in_progress'
-  $: workspaceMinimumWidth =
-    workbenchLayoutWidth > 1180 ? WIDE_WORKSPACE_MIN_WIDTH : NARROW_WORKSPACE_MIN_WIDTH
-  $: requestWorkspacePaneWidth = Math.max(0, requestWorkspaceWidth - PANE_RESIZER_SIZE)
-  $: requestListMinimumSize = requestWorkspacePaneWidth
-    ? Math.min(100, (REQUEST_LIST_MIN_WIDTH / requestWorkspacePaneWidth) * 100)
-    : 0
-  $: desiredWorkspaceMinimumSize = requestWorkspacePaneWidth
-    ? Math.min(100, (workspaceMinimumWidth / requestWorkspacePaneWidth) * 100)
-    : 0
-  $: workspaceMinimumSize = Math.min(
-    desiredWorkspaceMinimumSize,
-    Math.max(0, 100 - requestListMinimumSize),
-  )
-  $: requestListMaximumSize = Math.max(requestListMinimumSize, 100 - workspaceMinimumSize)
   $: saveHostRailCollapsed(hostSessionRailCollapsed)
-
-  function saveRequestWorkspaceLayout(layout: number[]) {
-    if (!requestWorkspaceLayoutReady) return
-    latestRequestWorkspaceLayout = layout
-    savePaneLayout(REQUEST_WORKSPACE_LAYOUT_KEY, layout)
-  }
-
-  async function initializeRequestWorkspaceLayout() {
-    if (requestWorkspaceLayoutReady || requestWorkspaceLayoutInitializing) return
-    requestWorkspaceLayoutInitializing = true
-    try {
-      await tick()
-      if (
-        renderedWorkspaceSurface === 'standalone' ||
-        !requestWorkspacePaneGroup ||
-        requestWorkspacePaneWidth <= 0
-      ) return
-      const defaultRequestListSize = Math.min(
-        requestListMaximumSize,
-        Math.max(
-          requestListMinimumSize,
-          (REQUEST_LIST_DEFAULT_WIDTH / requestWorkspacePaneWidth) * 100,
-        ),
-      )
-      requestWorkspacePaneGroup.setLayout(
-        latestRequestWorkspaceLayout ?? [defaultRequestListSize, 100 - defaultRequestListSize],
-      )
-      requestWorkspaceLayoutReady = true
-    } finally {
-      requestWorkspaceLayoutInitializing = false
-    }
-  }
-
-  $: if (renderedWorkspaceSurface !== 'standalone') {
-    void initializeRequestWorkspaceLayout()
-  } else {
-    requestWorkspaceLayoutReady = false
-  }
 
   onMount(() => {
     const cleanupAttachments = attachmentController.mount()
-    const syncLayoutDimensions = () => {
-      workbenchLayoutWidth = workbenchLayout?.clientWidth ?? 0
-      requestWorkspaceWidth = requestWorkspaceGroup?.clientWidth ?? 0
-    }
-    const layoutObserver = new ResizeObserver(syncLayoutDimensions)
-    if (workbenchLayout) layoutObserver.observe(workbenchLayout)
-    if (requestWorkspaceGroup) layoutObserver.observe(requestWorkspaceGroup)
-    syncLayoutDimensions()
-    const cleanupLayoutObserver = () => layoutObserver.disconnect()
     const unsubscribeApplicationEvents = !desktopShellAvailable && !previewMode
       ? applicationTransport.subscribe(
           APPLICATION_EVENTS_STREAM,
@@ -752,7 +669,6 @@
       return () => {
         unsubscribeApplicationEvents()
         applicationSnapshotRefetch.dispose()
-        cleanupLayoutObserver()
         cleanupAttachments()
       }
     }
@@ -812,7 +728,6 @@
       resumePromptUnlisten()
       openAdaptersUnlisten()
       if (updateCheckTimer !== undefined) clearTimeout(updateCheckTimer)
-      cleanupLayoutObserver()
       cleanupAttachments()
     }
   })
@@ -1908,7 +1823,7 @@
     {/snippet}
   </AppTitlebar>
 
-  <div bind:this={workbenchLayout} class="flex h-[calc(100%-40px)] min-h-0 min-w-0">
+  <div class="flex h-[calc(100%-40px)] min-h-0 min-w-0">
     <HostSessionRail
       bind:collapsed={hostSessionRailCollapsed}
       sessions={$navigation.hostSessions}
@@ -1928,21 +1843,9 @@
       onSettings={() => void openSettings('general')}
     />
 
-    <PaneGroup
-      bind:this={requestWorkspacePaneGroup}
-      bind:ref={requestWorkspaceGroup}
-      direction="horizontal"
-      class="min-h-0 min-w-0 flex-1"
-      id="request-workspace-split"
-      onLayoutChange={saveRequestWorkspaceLayout}
-    >
+    <div class="flex min-h-0 min-w-0 flex-1" id="request-workspace-layout">
       {#if renderedWorkspaceSurface !== 'standalone'}
-        <Pane
-          id="request-list-pane"
-          defaultSize={28}
-          minSize={requestListMinimumSize}
-          maxSize={requestListMaximumSize}
-        >
+        <div class="w-[296px] shrink-0 border-r" id="request-list-pane">
           <RequestListPane
             requests={visibleRequests}
             activeRequestId={workspace?.request.request_id ?? null}
@@ -1961,18 +1864,10 @@
             onOpenRequest={(requestId) => void openRequest(requestId)}
             onToggleToday={() => (todayOnly = !todayOnly)}
           />
-        </Pane>
-
-        <PaneResizer
-          class="workbench-pane-resizer workbench-pane-resizer--vertical"
-          aria-label={tr('Resize request list')}
-        />
+        </div>
       {/if}
 
-      <Pane
-        id="workspace-pane"
-        minSize={renderedWorkspaceSurface !== 'standalone' ? workspaceMinimumSize : 0}
-      >
+      <div class="min-h-0 min-w-0 flex-1" id="workspace-pane">
         <div class="flex h-full min-h-0 min-w-0 flex-col">
           <div
             class="min-h-0 flex-1"
@@ -2123,8 +2018,8 @@
             {/if}
           </div>
         </div>
-      </Pane>
-    </PaneGroup>
+      </div>
+    </div>
 
     {#if resumePrompt}
       <ResumePromptDialog

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -910,6 +910,16 @@
     persistCurrentWorkspaceSnapshot()
   }
 
+  function reorderWorkspaceTabs(viewKeys: readonly string[]) {
+    const nextState = workspaceShellReducer(workspaceShellState, {
+      type: 'reorder',
+      viewKeys,
+    })
+    if (nextState === workspaceShellState) return
+    workspaceShellState = nextState
+    persistCurrentWorkspaceSnapshot()
+  }
+
   function openLoadedWorkspaceView(next: FeedbackWorkspaceView) {
     openSessionView(
       sessionViewDescriptor(next.request.host_id, next.request.host_session_id),
@@ -1892,12 +1902,13 @@
         labelForView={workspaceTabLabel}
         onActivate={(viewKey) => void activateWorkspaceTab(viewKey)}
         onClose={closeWorkspaceTab}
+        onReorder={reorderWorkspaceTabs}
         {onStartDragging}
       />
     {/snippet}
   </AppTitlebar>
 
-  <div bind:this={workbenchLayout} class="flex h-[calc(100%-46px)] min-h-0 min-w-0">
+  <div bind:this={workbenchLayout} class="flex h-[calc(100%-40px)] min-h-0 min-w-0">
     <HostSessionRail
       bind:collapsed={hostSessionRailCollapsed}
       sessions={$navigation.hostSessions}

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -8,7 +8,6 @@
   import AppTitlebar from './lib/AppTitlebar.svelte'
   import OnboardingWizard from './lib/OnboardingWizard.svelte'
   import UpdateAvailableDialog from './lib/UpdateAvailableDialog.svelte'
-  import ArchivedSessionsDialog from './lib/components/navigation/ArchivedSessionsDialog.svelte'
   import HostSessionRail from './lib/components/navigation/HostSessionRail.svelte'
   import RequestListPane from './lib/components/navigation/RequestListPane.svelte'
   import { Sonner, toast } from './lib/components/ui/sonner'
@@ -19,6 +18,7 @@
   import RambelleProfileWorkspaceView from './lib/workspace/RambelleProfileWorkspaceView.svelte'
   import SettingsWorkspaceView from './lib/workspace/SettingsWorkspaceView.svelte'
   import TaskWorkspaceView from './lib/workspace/TaskWorkspaceView.svelte'
+  import ArchivedSessionsWorkspaceView from './lib/workspace/ArchivedSessionsWorkspaceView.svelte'
   import type { JSONContent } from '@tiptap/core'
   import {
     defineApplicationStream,
@@ -70,6 +70,7 @@
   } from './lib/notifications'
   import { isWithinLast24Hours } from './lib/requestRecency'
   import {
+    archiveViewDescriptor,
     inboxViewDescriptor,
     rambelleProfileViewDescriptor,
     requestTaskViewDescriptor,
@@ -227,8 +228,8 @@
   let resumePrompt: ResumePrompt | null = null
   let resumeCopyState: 'idle' | 'copied' | 'failed' = 'idle'
   let notificationState: NotificationState = 'checking'
-  let archivedSessionsOpen = false
   let archivedInitialSession: SessionViewDescriptor | null = null
+  let archivedSelectionEpoch = 0
   let lastSessionRecoveryFingerprint = ''
   let activeRecoveryTransition: object | null = null
   let settingsSection: SettingsSection = 'general'
@@ -521,6 +522,8 @@
     switch (view.kind) {
       case 'inbox':
         return tr('All requests')
+      case 'archive':
+        return tr('Archived sessions')
       case 'settings':
         return tr('Settings')
       case 'request-task': {
@@ -973,7 +976,12 @@
       loadingWorkspace = false
       return
     }
-    if (view.kind === 'inbox' || view.kind === 'settings' || view.kind === 'rambelle-profile') {
+    if (
+      view.kind === 'inbox' ||
+      view.kind === 'archive' ||
+      view.kind === 'settings' ||
+      view.kind === 'rambelle-profile'
+    ) {
       clearWorkspace()
       workbenchMounted = true
       loadingWorkspace = false
@@ -1555,9 +1563,20 @@
     })
   }
 
-  function openArchivedSessions(initialSession: SessionViewDescriptor | null = null) {
+  async function openArchivedSessions(initialSession: SessionViewDescriptor | null = null) {
+    if (workspaceTransitionLocked || pendingWorkspaceViewKey) return
     archivedInitialSession = initialSession
-    archivedSessionsOpen = true
+    archivedSelectionEpoch += 1
+    const view = archiveViewDescriptor()
+    const viewKey = workspaceViewKey(view)
+    if (workspaceShellState.activeViewKey === viewKey) return
+    workspaceTransition.invalidate()
+    await workspaceTransition.activate({
+      view,
+      requestId: null,
+      shellAction: { type: 'open' },
+      pendingViewKey: viewKey,
+    })
   }
 
   function applyWorkspaceMutation(next: FeedbackWorkspaceView) {
@@ -1881,6 +1900,18 @@
           >
             {#if renderedWorkspaceView?.kind === 'inbox'}
               <InboxWorkspaceView />
+            {:else if renderedWorkspaceView?.kind === 'archive'}
+              <ArchivedSessionsWorkspaceView
+                transport={applicationTransport}
+                {previewMode}
+                {resolveHostProfile}
+                formatTime={formatTimeLocal}
+                {messageFrom}
+                initialSession={archivedInitialSession}
+                selectionEpoch={archivedSelectionEpoch}
+                onError={(message) => (pageError = message)}
+                onChanged={retrySessionViewRecovery}
+              />
             {:else if renderedWorkspaceView?.kind === 'settings'}
               <SettingsWorkspaceView
                 {capabilities}
@@ -1889,7 +1920,7 @@
                 sectionSelectionEpoch={settingsSectionSelectionEpoch}
                 {updateInstallBlocked}
                 onRestartOnboarding={restartOnboarding}
-                onOpenArchived={openArchivedSessions}
+                onOpenArchived={() => void openArchivedSessions()}
                 onOpenRambelleProfile={() => void openRambelleProfile()}
               />
             {:else if renderedWorkspaceView?.kind === 'request-task'}
@@ -1916,7 +1947,7 @@
                 busy={renderedSessionResolution.reason === 'unresolved' || pendingWorkspaceViewKey !== null}
                 onRetry={retrySessionViewRecovery}
                 onClose={() => closeWorkspaceTab(workspaceViewKey(renderedSessionResolution!.session))}
-                onOpenArchive={() => openArchivedSessions(renderedSessionResolution!.session)}
+                onOpenArchive={() => void openArchivedSessions(renderedSessionResolution!.session)}
               />
             {:else if workbenchMounted}
               {#key renderedSessionView ? workspaceViewKey(renderedSessionView) : 'workspace:empty'}
@@ -2035,18 +2066,6 @@
 {#if onboardingAvailable}
   <OnboardingWizard {capabilities} bind:openWizard={onboardingOpen} onClose={closeOnboarding} />
 {/if}
-
-<ArchivedSessionsDialog
-  bind:open={archivedSessionsOpen}
-  transport={applicationTransport}
-  {previewMode}
-  {resolveHostProfile}
-  formatTime={formatTimeLocal}
-  {messageFrom}
-  initialSession={archivedInitialSession}
-  onError={(message) => (pageError = message)}
-  onChanged={retrySessionViewRecovery}
-/>
 
 {#if softwareUpdatesAvailable}
   <UpdateAvailableDialog

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -15,6 +15,7 @@
   import { Sonner, toast } from './lib/components/ui/sonner'
   import ResumePromptDialog from './lib/workbench/ResumePromptDialog.svelte'
   import SessionWorkbench from './lib/workbench/SessionWorkbench.svelte'
+  import InboxWorkspaceView from './lib/workspace/InboxWorkspaceView.svelte'
   import MissingSessionView from './lib/workspace/MissingSessionView.svelte'
   import RambelleProfileWorkspaceView from './lib/workspace/RambelleProfileWorkspaceView.svelte'
   import SettingsWorkspaceView from './lib/workspace/SettingsWorkspaceView.svelte'
@@ -70,6 +71,7 @@
   } from './lib/notifications'
   import { isWithinLast24Hours } from './lib/requestRecency'
   import {
+    inboxViewDescriptor,
     rambelleProfileViewDescriptor,
     requestTaskViewDescriptor,
     sessionViewDescriptor,
@@ -99,11 +101,12 @@
     type SessionViewCatalog,
     type SessionViewResolution,
   } from './lib/workspace/sessionViewRecovery'
-  import WorkspaceTabStrip from './lib/workspace/WorkspaceTabStrip.svelte'
   import {
     workspaceTabId,
     workspaceTabPanelId,
   } from './lib/workspace/workspaceTabNavigation'
+  import WorkspaceTabStrip from './lib/workspace/WorkspaceTabStrip.svelte'
+  import { workspaceSurface } from './lib/workspace/workspaceSurface'
   import {
     createWorkspaceTransition,
     type WorkspaceTransitionOutcome,
@@ -273,7 +276,7 @@
   const NARROW_WORKSPACE_MIN_WIDTH = 360
   const PANE_RESIZER_SIZE = 11
   const REQUEST_WORKSPACE_LAYOUT_KEY = 'request-workspace-layout'
-  const savedRequestWorkspaceLayout = savedPaneLayout(REQUEST_WORKSPACE_LAYOUT_KEY)
+  let latestRequestWorkspaceLayout = savedPaneLayout(REQUEST_WORKSPACE_LAYOUT_KEY)
 
   let taskBriefOpen = true
   let todayOnly = false
@@ -282,6 +285,7 @@
   let requestWorkspaceGroup: HTMLDivElement | null = null
   let requestWorkspacePaneGroup: PaneGroupHandle | undefined
   let requestWorkspaceLayoutReady = false
+  let requestWorkspaceLayoutInitializing = false
   let workbenchLayoutWidth = 0
   let requestWorkspaceWidth = 0
   let genericMcpConfiguration = ''
@@ -518,6 +522,7 @@
       )
     : undefined
   $: renderedWorkspaceView = activeWorkspaceView(workspaceShellState)
+  $: renderedWorkspaceSurface = workspaceSurface(renderedWorkspaceView)
   $: renderedSessionView = renderedWorkspaceView?.kind === 'session'
     ? renderedWorkspaceView
     : null
@@ -536,6 +541,8 @@
   }
   const workspaceTabLabel = (view: WorkspaceViewDescriptor) => {
     switch (view.kind) {
+      case 'inbox':
+        return tr('All requests')
       case 'settings':
         return tr('Settings')
       case 'request-task': {
@@ -660,7 +667,41 @@
   $: saveHostRailCollapsed(hostSessionRailCollapsed)
 
   function saveRequestWorkspaceLayout(layout: number[]) {
-    if (requestWorkspaceLayoutReady) savePaneLayout(REQUEST_WORKSPACE_LAYOUT_KEY, layout)
+    if (!requestWorkspaceLayoutReady) return
+    latestRequestWorkspaceLayout = layout
+    savePaneLayout(REQUEST_WORKSPACE_LAYOUT_KEY, layout)
+  }
+
+  async function initializeRequestWorkspaceLayout() {
+    if (requestWorkspaceLayoutReady || requestWorkspaceLayoutInitializing) return
+    requestWorkspaceLayoutInitializing = true
+    try {
+      await tick()
+      if (
+        renderedWorkspaceSurface === 'standalone' ||
+        !requestWorkspacePaneGroup ||
+        requestWorkspacePaneWidth <= 0
+      ) return
+      const defaultRequestListSize = Math.min(
+        requestListMaximumSize,
+        Math.max(
+          requestListMinimumSize,
+          (REQUEST_LIST_DEFAULT_WIDTH / requestWorkspacePaneWidth) * 100,
+        ),
+      )
+      requestWorkspacePaneGroup.setLayout(
+        latestRequestWorkspaceLayout ?? [defaultRequestListSize, 100 - defaultRequestListSize],
+      )
+      requestWorkspaceLayoutReady = true
+    } finally {
+      requestWorkspaceLayoutInitializing = false
+    }
+  }
+
+  $: if (renderedWorkspaceSurface !== 'standalone') {
+    void initializeRequestWorkspaceLayout()
+  } else {
+    requestWorkspaceLayoutReady = false
   }
 
   onMount(() => {
@@ -673,20 +714,6 @@
     if (workbenchLayout) layoutObserver.observe(workbenchLayout)
     if (requestWorkspaceGroup) layoutObserver.observe(requestWorkspaceGroup)
     syncLayoutDimensions()
-    void tick().then(() => {
-      if (!requestWorkspacePaneGroup || requestWorkspacePaneWidth <= 0) return
-      const defaultRequestListSize = Math.min(
-        requestListMaximumSize,
-        Math.max(
-          requestListMinimumSize,
-          (REQUEST_LIST_DEFAULT_WIDTH / requestWorkspacePaneWidth) * 100,
-        ),
-      )
-      requestWorkspaceLayoutReady = true
-      requestWorkspacePaneGroup.setLayout(
-        savedRequestWorkspaceLayout ?? [defaultRequestListSize, 100 - defaultRequestListSize],
-      )
-    })
     const cleanupLayoutObserver = () => layoutObserver.disconnect()
     const unsubscribeApplicationEvents = !desktopShellAvailable && !previewMode
       ? applicationTransport.subscribe(
@@ -804,6 +831,9 @@
       if (!initialized) return
       await refreshSessionViewRecovery()
       if (initialWorkspaceSnapshot) await restoreInitialWorkspaceSnapshot()
+      else if (previewMode && workspace) {
+        await navigation.selectScope(workspace.request.host_id, workspace.request.host_session_id)
+      }
     })()
   }
 
@@ -1018,11 +1048,12 @@
       loadingWorkspace = false
       return
     }
-    if (view.kind === 'settings' || view.kind === 'rambelle-profile') {
+    if (view.kind === 'inbox' || view.kind === 'settings' || view.kind === 'rambelle-profile') {
       clearWorkspace()
       workbenchMounted = true
       loadingWorkspace = false
-      if (view.kind === 'settings') void refreshGenericMcpConfiguration()
+      if (view.kind === 'inbox') await navigation.selectScope(null, null)
+      else if (view.kind === 'settings') void refreshGenericMcpConfiguration()
       return
     }
     if (view.kind === 'request-task') {
@@ -1086,7 +1117,17 @@
     const priorScope = currentNavigationScope()
     workspaceTransition.invalidate()
     const selection = await navigation.selectScope(hostId, hostSessionId)
-    if (!selection.selected || !hostId || !hostSessionId) return
+    if (!selection.selected) return
+    if (!hostId || !hostSessionId) {
+      const outcome = await workspaceTransition.activate({
+        view: inboxViewDescriptor(),
+        requestId: null,
+        shellAction: { type: 'open' },
+        pendingViewKey: workspaceViewKey(inboxViewDescriptor()),
+      })
+      await restoreNavigationScope(priorScope, outcome)
+      return
+    }
     if (workspaceTransitionLocked) {
       await navigation.selectScope(priorScope.hostId, priorScope.hostSessionId)
       return
@@ -1121,6 +1162,10 @@
     )
     if (!view) return
     if (view.kind !== 'session') {
+      if (view.kind === 'inbox') {
+        const selection = await navigation.selectScope(null, null)
+        if (!selection.selected) return
+      }
       const outcome = await workspaceTransition.activate({
         view,
         requestId: view.kind === 'request-task' ? view.requestId : null,
@@ -1130,6 +1175,7 @@
       if (outcome === 'activated' && view.kind === 'settings') {
         void refreshGenericMcpConfiguration()
       }
+      if (view.kind === 'inbox') await restoreNavigationScope(priorScope, outcome)
       return
     }
     const resolution = sessionViewResolution(sessionViewResolutions, viewKey)
@@ -1210,6 +1256,9 @@
           ?.request_id ??
         selection.requests[0]?.request_id ??
         null
+    } else if (fallbackView?.kind === 'inbox') {
+      const selection = await navigation.selectScope(null, null)
+      if (!selection.selected) return
     } else if (fallbackView?.kind === 'request-task') {
       fallbackRequestId = fallbackView.requestId
     }
@@ -1373,6 +1422,7 @@
     requestId: string,
   ): Promise<WorkspaceTransitionOutcome> {
     if (workspaceTransitionLocked) return 'blocked'
+    const priorScope = currentNavigationScope()
     workspaceTransition.invalidate()
     if (
       workspace?.request.request_id === requestId &&
@@ -1383,12 +1433,18 @@
     }
     pageError = ''
     const view = viewForRequest(requestId)
-    return workspaceTransition.activate({
+    if (view) {
+      const selection = await navigation.selectScope(view.hostId, view.hostSessionId)
+      if (!selection.selected) return 'failed'
+    }
+    const outcome = await workspaceTransition.activate({
       view,
       requestId,
       shellAction: { type: 'open' },
       pendingViewKey: view ? workspaceViewKey(view) : `request:${JSON.stringify(requestId)}`,
     })
+    await restoreNavigationScope(priorScope, outcome)
+    return outcome
   }
 
   async function openRequest(requestId: string, _saveCurrent = true): Promise<boolean> {
@@ -1814,7 +1870,7 @@
   <AppTitlebar
     windowControls={capabilities.windowControls}
     notifications={capabilities.notifications}
-    sourceLabel={workspace?.request.source_hint ?? workspace?.request.title ?? 'Workbench'}
+    sidebarCollapsed={hostSessionRailCollapsed}
     pendingCount={$navigation.pendingRequests.length}
     {rambleEngaged}
     {rambleActive}
@@ -1826,7 +1882,20 @@
     notificationDisabled={false}
     onNotifications={() => void openSettings('notifications')}
     onWindowError={(message) => (pageError = tr('Window action failed: {error}', { error: message }))}
-  />
+  >
+    {#snippet workspaceTabs(onStartDragging: ((event: PointerEvent) => void) | null)}
+      <WorkspaceTabStrip
+        views={workspaceShellState.views}
+        activeViewKey={workspaceShellState.activeViewKey}
+        pendingViewKey={pendingWorkspaceViewKey}
+        disabled={workspaceTransitionLocked}
+        labelForView={workspaceTabLabel}
+        onActivate={(viewKey) => void activateWorkspaceTab(viewKey)}
+        onClose={closeWorkspaceTab}
+        {onStartDragging}
+      />
+    {/snippet}
+  </AppTitlebar>
 
   <div bind:this={workbenchLayout} class="flex h-[calc(100%-46px)] min-h-0 min-w-0">
     <HostSessionRail
@@ -1856,48 +1925,44 @@
       id="request-workspace-split"
       onLayoutChange={saveRequestWorkspaceLayout}
     >
-      <Pane
-        id="request-list-pane"
-        defaultSize={28}
-        minSize={requestListMinimumSize}
-        maxSize={requestListMaximumSize}
-      >
-        <RequestListPane
-          requests={visibleRequests}
-          activeRequestId={workspace?.request.request_id ?? null}
-          cookingRequestIds={cookingRequestIds}
-          scopeLabel={requestScopeLabel}
-          searchQuery={$navigation.requestSearch}
-          loading={$navigation.loadingRequests}
-          refreshing={$navigation.refreshingPage}
-          loadingMore={$navigation.loadingMoreRequests}
-          hasMore={todayOnly ? false : $navigation.nextRequestCursor !== null}
-          {todayOnly}
-          {resolveHostProfile}
-          formatTime={formatTimeLocal}
-          onRefresh={() => void navigation.refreshPage()}
-          onLoadMore={() => void navigation.loadMoreRequests()}
-          onOpenRequest={(requestId) => void openRequest(requestId)}
-          onToggleToday={() => (todayOnly = !todayOnly)}
-        />
-      </Pane>
-
-      <PaneResizer
-        class="workbench-pane-resizer workbench-pane-resizer--vertical"
-        aria-label={tr('Resize request list')}
-      />
-
-      <Pane id="workspace-pane" minSize={workspaceMinimumSize}>
-        <div class="flex h-full min-h-0 min-w-0 flex-col">
-          <WorkspaceTabStrip
-            views={workspaceShellState.views}
-            activeViewKey={workspaceShellState.activeViewKey}
-            pendingViewKey={pendingWorkspaceViewKey}
-            disabled={workspaceTransitionLocked}
-            labelForView={workspaceTabLabel}
-            onActivate={(viewKey) => void activateWorkspaceTab(viewKey)}
-            onClose={closeWorkspaceTab}
+      {#if renderedWorkspaceSurface !== 'standalone'}
+        <Pane
+          id="request-list-pane"
+          defaultSize={28}
+          minSize={requestListMinimumSize}
+          maxSize={requestListMaximumSize}
+        >
+          <RequestListPane
+            requests={visibleRequests}
+            activeRequestId={workspace?.request.request_id ?? null}
+            cookingRequestIds={cookingRequestIds}
+            scopeLabel={requestScopeLabel}
+            searchQuery={$navigation.requestSearch}
+            loading={$navigation.loadingRequests}
+            refreshing={$navigation.refreshingPage}
+            loadingMore={$navigation.loadingMoreRequests}
+            hasMore={todayOnly ? false : $navigation.nextRequestCursor !== null}
+            {todayOnly}
+            {resolveHostProfile}
+            formatTime={formatTimeLocal}
+            onRefresh={() => void navigation.refreshPage()}
+            onLoadMore={() => void navigation.loadMoreRequests()}
+            onOpenRequest={(requestId) => void openRequest(requestId)}
+            onToggleToday={() => (todayOnly = !todayOnly)}
           />
+        </Pane>
+
+        <PaneResizer
+          class="workbench-pane-resizer workbench-pane-resizer--vertical"
+          aria-label={tr('Resize request list')}
+        />
+      {/if}
+
+      <Pane
+        id="workspace-pane"
+        minSize={renderedWorkspaceSurface !== 'standalone' ? workspaceMinimumSize : 0}
+      >
+        <div class="flex h-full min-h-0 min-w-0 flex-col">
           <div
             class="min-h-0 flex-1"
             role={renderedWorkspaceView ? 'tabpanel' : undefined}
@@ -1908,7 +1973,9 @@
               ? workspaceTabId(workspaceViewKey(renderedWorkspaceView))
               : undefined}
           >
-            {#if renderedWorkspaceView?.kind === 'settings'}
+            {#if renderedWorkspaceView?.kind === 'inbox'}
+              <InboxWorkspaceView />
+            {:else if renderedWorkspaceView?.kind === 'settings'}
               <SettingsWorkspaceView
                 {capabilities}
                 mcpConfiguration={genericMcpConfiguration}

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -83,6 +83,7 @@
   --sidebar-accent-foreground: #205b96;
   --sidebar-border: #c8d5e3;
   --sidebar-ring: var(--brand-ice);
+  --titlebar-background: #dfe7f0;
   --app-background: var(--brand-silver);
   --glass: rgb(247 249 252 / 92%);
   --shadow: 0 18px 50px rgb(42 70 101 / 10%);
@@ -123,6 +124,7 @@
   --sidebar-accent-foreground: #b7dbfa;
   --sidebar-border: #34465a;
   --sidebar-ring: #78b7f5;
+  --titlebar-background: #0d1722;
   --app-background: #101823;
   --glass: rgb(20 31 44 / 94%);
   --shadow: 0 20px 58px rgb(0 0 0 / 38%);

--- a/apps/desktop/src/lib/AppTitlebar.svelte
+++ b/apps/desktop/src/lib/AppTitlebar.svelte
@@ -13,13 +13,12 @@
   } from '$lib/capabilities/workbenchCapabilities'
   import { t } from '$lib/i18n'
   import { locale } from '$lib/preferences'
+  import { titlebarPointerIntent } from '$lib/titlebarInteractions'
 
   const unavailableCapabilities = createUnavailableWorkbenchCapabilities()
 
   export let sidebarCollapsed = false
-  export let workspaceTabs: Snippet<[
-    onStartDragging: ((event: PointerEvent) => void) | null,
-  ]>
+  export let workspaceTabs: Snippet
   export let pendingCount = 0
   export let rambleEngaged = false
   export let rambleActive = false
@@ -65,25 +64,41 @@
     }
   }
 
-  async function startDragging(event: PointerEvent) {
-    if (!windowControlsAvailable || event.button !== 0) return
-    const target = event.target
-    if (target instanceof Element) {
-      const button = target.closest('button')
-      if (button && !button.matches('.titlebar-brand, .titlebar-drag')) return
-    }
+  function isInteractiveTitlebarTarget(target: EventTarget | null) {
+    if (!(target instanceof Element)) return false
+    const button = target.closest('button')
+    if (button?.matches('.titlebar-brand')) return false
+    return Boolean(button || target.closest('[role="tab"], [data-workspace-tab-item]'))
+  }
+
+  async function handleTitlebarPointerDown(event: PointerEvent) {
+    if (!windowControlsAvailable) return
+    const intent = titlebarPointerIntent({
+      button: event.button,
+      clickCount: event.detail,
+      interactive: isInteractiveTitlebarTarget(event.target),
+    })
+    if (intent === 'ignore') return
     try {
-      await windowControls.implementation.startDragging()
+      if (intent === 'toggle-maximize') {
+        await windowControls.implementation.toggleMaximize()
+        if (!isMac) maximized = await windowControls.implementation.isMaximized()
+      } else {
+        await windowControls.implementation.startDragging()
+      }
     } catch (cause) {
       onWindowError(cause instanceof Error ? cause.message : String(cause))
     }
   }
 </script>
 
+<!-- svelte-ignore a11y_no_static_element_interactions (the handler delegates native titlebar dragging while preserving interactive descendants) -->
 <header
   class={[
     'app-titlebar relative z-30 flex h-10 select-none items-stretch overflow-hidden rounded-t-[15px] border-b',
   ]}
+  data-titlebar-event-boundary
+  onpointerdown={(event) => void handleTitlebarPointerDown(event)}
 >
   {#if windowControlsAvailable && isMac}
     <div class="absolute left-[15px] flex h-full items-center gap-2" aria-label={t($locale, 'Window controls')}>
@@ -115,7 +130,6 @@
         ]}
         aria-label={t($locale, 'Drag window')}
         title={t($locale, 'Drag window')}
-        onpointerdown={(event) => void startDragging(event)}
       >
         {#if !sidebarCollapsed || !isMac}
           <img class="size-7 shrink-0 rounded-md object-contain" src={appIcon} alt="" draggable="false" />
@@ -141,7 +155,7 @@
 
   <div class="flex min-w-0 flex-1 items-stretch">
     <div class="min-w-0 flex-1">
-      {@render workspaceTabs(windowControlsAvailable ? startDragging : null)}
+      {@render workspaceTabs()}
     </div>
 
     <div class="flex shrink-0 items-center gap-1.5 px-2">

--- a/apps/desktop/src/lib/AppTitlebar.svelte
+++ b/apps/desktop/src/lib/AppTitlebar.svelte
@@ -82,7 +82,7 @@
 
 <header
   class={[
-    'relative z-30 flex h-10 select-none items-stretch overflow-hidden rounded-t-[15px] border-b bg-background/95 backdrop-blur-md',
+    'app-titlebar relative z-30 flex h-10 select-none items-stretch overflow-hidden rounded-t-[15px] border-b',
   ]}
 >
   {#if windowControlsAvailable && isMac}
@@ -139,7 +139,7 @@
     {/if}
   </div>
 
-  <div class="flex min-w-0 flex-1 items-stretch bg-muted/25">
+  <div class="flex min-w-0 flex-1 items-stretch">
     <div class="min-w-0 flex-1">
       {@render workspaceTabs(windowControlsAvailable ? startDragging : null)}
     </div>
@@ -219,6 +219,10 @@
 </header>
 
 <style>
+  .app-titlebar {
+    background: var(--titlebar-background);
+  }
+
   .traffic.close {
     background: #ff5f57;
   }

--- a/apps/desktop/src/lib/AppTitlebar.svelte
+++ b/apps/desktop/src/lib/AppTitlebar.svelte
@@ -82,7 +82,7 @@
 
 <header
   class={[
-    'relative z-30 flex h-[46px] select-none items-stretch rounded-t-[15px] border-b bg-background/95 backdrop-blur-md',
+    'relative z-30 flex h-10 select-none items-stretch overflow-hidden rounded-t-[15px] border-b bg-background/95 backdrop-blur-md',
   ]}
 >
   {#if windowControlsAvailable && isMac}

--- a/apps/desktop/src/lib/AppTitlebar.svelte
+++ b/apps/desktop/src/lib/AppTitlebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Bell, BellOff, Copy, Minus, Square, X } from '@lucide/svelte'
-  import { onMount } from 'svelte'
+  import { onMount, type Snippet } from 'svelte'
 
   import appIcon from '../assets/rambledesk-app-icon.webp'
   import { Badge } from '$lib/components/ui/badge'
@@ -16,7 +16,10 @@
 
   const unavailableCapabilities = createUnavailableWorkbenchCapabilities()
 
-  export let sourceLabel = 'Workbench'
+  export let sidebarCollapsed = false
+  export let workspaceTabs: Snippet<[
+    onStartDragging: ((event: PointerEvent) => void) | null,
+  ]>
   export let pendingCount = 0
   export let rambleEngaged = false
   export let rambleActive = false
@@ -80,7 +83,6 @@
 <header
   class={[
     'relative z-30 flex h-[46px] select-none items-stretch rounded-t-[15px] border-b bg-background/95 backdrop-blur-md',
-    windowControlsAvailable && isMac ? 'pl-[58px]' : '',
   ]}
 >
   {#if windowControlsAvailable && isMac}
@@ -98,109 +100,122 @@
     </div>
   {/if}
 
-  {#if windowControlsAvailable}
-    <button
-      class="titlebar-brand flex min-w-0 cursor-grab items-center gap-2.5 border-0 bg-transparent px-3 text-left text-foreground active:cursor-grabbing focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-ring"
-      aria-label={t($locale, 'Drag window')}
-      title={t($locale, 'Drag window')}
-      onpointerdown={(event) => void startDragging(event)}
-    >
-      <img class="size-7 shrink-0 rounded-md object-contain" src={appIcon} alt="" draggable="false" />
-      <strong class="text-xs font-semibold">RambleDesk</strong>
-      <span class="h-4 w-px bg-border"></span>
-      <span class="max-w-56 truncate text-[10px] text-muted-foreground">{sourceLabel}</span>
-    </button>
-  {:else}
-    <div class="titlebar-brand flex min-w-0 items-center gap-2.5 px-3 text-foreground">
-      <img class="size-7 shrink-0 rounded-md object-contain" src={appIcon} alt="" draggable="false" />
-      <strong class="text-xs font-semibold">RambleDesk</strong>
-      <span class="h-4 w-px bg-border"></span>
-      <span class="max-w-56 truncate text-[10px] text-muted-foreground">{sourceLabel}</span>
-    </div>
-  {/if}
-
-  {#if windowControlsAvailable}
-    <button
-      class="titlebar-drag min-w-6 flex-1 cursor-grab border-0 bg-transparent active:cursor-grabbing focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-ring"
-      aria-label={t($locale, 'Drag window')}
-      title={t($locale, 'Drag window')}
-      onpointerdown={(event) => void startDragging(event)}
-    ></button>
-  {:else}
-    <div class="min-w-6 flex-1"></div>
-  {/if}
-
-  <div class="flex shrink-0 items-center gap-1.5 px-2">
-    {#if rambleEngaged}
-      <Badge
-        variant="secondary"
+  <div
+    class={[
+      'flex h-full shrink-0 items-stretch border-r border-sidebar-border bg-sidebar text-sidebar-foreground transition-[width] duration-200',
+      sidebarCollapsed ? 'w-14' : 'w-[224px]',
+    ]}
+  >
+    {#if windowControlsAvailable}
+      <button
         class={[
-          'h-6 max-w-64 gap-1.5 px-2 text-[9px] max-[1080px]:max-w-40',
-          rambleActive
-            ? 'bg-destructive/10 text-destructive'
-            : 'bg-warning/10 text-warning-foreground dark:text-warning',
+          'titlebar-brand flex h-full min-w-0 flex-1 cursor-grab items-center border-0 bg-transparent text-left active:cursor-grabbing focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-ring',
+          sidebarCollapsed ? 'justify-center px-2' : 'gap-2.5 px-3',
+          isMac && !sidebarCollapsed ? 'pl-[58px]' : '',
         ]}
-        title={rambleRequestTitle}
+        aria-label={t($locale, 'Drag window')}
+        title={t($locale, 'Drag window')}
+        onpointerdown={(event) => void startDragging(event)}
       >
-        <span
-          class={[
-            'size-1.5 shrink-0 rounded-full',
-            rambleActive ? 'animate-pulse bg-destructive' : 'bg-warning',
-          ]}
-        ></span>
-        <span class="truncate">
-          {rambleActive ? t($locale, 'Recording') : t($locale, 'Ramble paused')} · {rambleRequestTitle}
-        </span>
-      </Badge>
-    {/if}
-    {#if pendingCount > 0}
-      <Badge
-        variant="secondary"
-        class="h-6 bg-warning/10 px-2 text-[9px] text-warning-foreground max-[900px]:hidden dark:text-warning"
+        {#if !sidebarCollapsed || !isMac}
+          <img class="size-7 shrink-0 rounded-md object-contain" src={appIcon} alt="" draggable="false" />
+        {/if}
+        {#if !sidebarCollapsed}
+          <strong class="truncate text-xs font-semibold">RambleDesk</strong>
+        {/if}
+      </button>
+    {:else}
+      <div
+        class={[
+          'titlebar-brand flex h-full min-w-0 flex-1 items-center text-sidebar-foreground',
+          sidebarCollapsed ? 'justify-center px-2' : 'gap-2.5 px-3',
+        ]}
       >
-        {pendingCount} {t($locale, 'pending')}
-      </Badge>
-    {/if}
-    {#if notificationsAvailable}
-      <Button
-        variant="ghost"
-        size="icon"
-        class={notificationEnabled ? 'text-info' : ''}
-        disabled={notificationDisabled}
-        onclick={onNotifications}
-        title={notificationText || t($locale, 'Notifications')}
-        aria-label={notificationText || t($locale, 'Notifications')}
-      >
-        {#if notificationEnabled}<Bell />{:else}<BellOff />{/if}
-      </Button>
+        <img class="size-7 shrink-0 rounded-md object-contain" src={appIcon} alt="" draggable="false" />
+        {#if !sidebarCollapsed}
+          <strong class="truncate text-xs font-semibold">RambleDesk</strong>
+        {/if}
+      </div>
     {/if}
   </div>
 
-  {#if windowControlsAvailable && !isMac}
-    <div class="ml-1 flex items-stretch" aria-label={t($locale, 'Window controls')}>
-      <button
-        class="grid w-11 place-items-center text-muted-foreground hover:bg-muted hover:text-foreground"
-        aria-label={t($locale, 'Minimize window')}
-        onclick={() => runWindowAction('minimize')}
-      >
-        <Minus class="size-4" />
-      </button>
-      <button
-        class="grid w-11 place-items-center text-muted-foreground hover:bg-muted hover:text-foreground"
-        aria-label={t($locale, 'Maximize or restore window')}
-        onclick={() => runWindowAction('maximize')}
-      >
-        {#if maximized}<Copy class="size-3.5" />{:else}<Square class="size-3.5" />{/if}
-      </button>
-      <button
-        class="grid w-11 place-items-center text-muted-foreground hover:bg-destructive hover:text-white"
-        aria-label={t($locale, 'Close window')}
-        onclick={() => runWindowAction('close')}
-      >
-        <X class="size-4" />
-      </button>
+  <div class="flex min-w-0 flex-1 items-stretch bg-muted/25">
+    <div class="min-w-0 flex-1">
+      {@render workspaceTabs(windowControlsAvailable ? startDragging : null)}
     </div>
-  {/if}
+
+    <div class="flex shrink-0 items-center gap-1.5 px-2">
+      {#if rambleEngaged}
+        <Badge
+          variant="secondary"
+          class={[
+            'h-6 max-w-64 gap-1.5 px-2 text-[9px] max-[1080px]:max-w-40',
+            rambleActive
+              ? 'bg-destructive/10 text-destructive'
+              : 'bg-warning/10 text-warning-foreground dark:text-warning',
+          ]}
+          title={rambleRequestTitle}
+        >
+          <span
+            class={[
+              'size-1.5 shrink-0 rounded-full',
+              rambleActive ? 'animate-pulse bg-destructive' : 'bg-warning',
+            ]}
+          ></span>
+          <span class="truncate">
+            {rambleActive ? t($locale, 'Recording') : t($locale, 'Ramble paused')} · {rambleRequestTitle}
+          </span>
+        </Badge>
+      {/if}
+      {#if pendingCount > 0}
+        <Badge
+          variant="secondary"
+          class="h-6 bg-warning/10 px-2 text-[9px] text-warning-foreground max-[900px]:hidden dark:text-warning"
+        >
+          {pendingCount} {t($locale, 'pending')}
+        </Badge>
+      {/if}
+      {#if notificationsAvailable}
+        <Button
+          variant="ghost"
+          size="icon"
+          class={notificationEnabled ? 'text-info' : ''}
+          disabled={notificationDisabled}
+          onclick={onNotifications}
+          title={notificationText || t($locale, 'Notifications')}
+          aria-label={notificationText || t($locale, 'Notifications')}
+        >
+          {#if notificationEnabled}<Bell />{:else}<BellOff />{/if}
+        </Button>
+      {/if}
+    </div>
+
+    {#if windowControlsAvailable && !isMac}
+      <div class="ml-1 flex items-stretch" aria-label={t($locale, 'Window controls')}>
+        <button
+          class="grid w-11 place-items-center text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label={t($locale, 'Minimize window')}
+          onclick={() => runWindowAction('minimize')}
+        >
+          <Minus class="size-4" />
+        </button>
+        <button
+          class="grid w-11 place-items-center text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label={t($locale, 'Maximize or restore window')}
+          onclick={() => runWindowAction('maximize')}
+        >
+          {#if maximized}<Copy class="size-3.5" />{:else}<Square class="size-3.5" />{/if}
+        </button>
+        <button
+          class="grid w-11 place-items-center text-muted-foreground hover:bg-destructive hover:text-white"
+          aria-label={t($locale, 'Close window')}
+          onclick={() => runWindowAction('close')}
+        >
+          <X class="size-4" />
+        </button>
+      </div>
+    {/if}
+  </div>
 </header>
 
 <style>

--- a/apps/desktop/src/lib/capabilities/tauri/tauriCapabilities.test.ts
+++ b/apps/desktop/src/lib/capabilities/tauri/tauriCapabilities.test.ts
@@ -107,6 +107,10 @@ describe('Tauri Workbench capabilities', () => {
     const api = createFakeApi({ read_notification_sound: [1, 2, 255] })
     const capabilities = createTauriWorkbenchCapabilities(api)
 
+    await capabilities.windowControls.implementation.startDragging()
+    await capabilities.windowControls.implementation.toggleMaximize()
+    expect(api.window.startDragging).toHaveBeenCalledOnce()
+    expect(api.window.toggleMaximize).toHaveBeenCalledOnce()
     await capabilities.windowControls.implementation.leaveFullscreen()
     expect(api.window.isFullscreen).toHaveBeenCalledOnce()
     expect(api.window.setFullscreen).toHaveBeenCalledWith(false)

--- a/apps/desktop/src/lib/components/navigation/HostSessionRail.svelte
+++ b/apps/desktop/src/lib/components/navigation/HostSessionRail.svelte
@@ -208,7 +208,7 @@
                   class={[
                     'grid h-9 w-full place-items-center rounded-md text-muted-foreground transition-colors [&_svg]:size-5',
                     activeHostId === session.host_id &&
-                    (activeHostSessionId === null || activeHostSessionId === session.host_session_id)
+                    activeHostSessionId === session.host_session_id
                       ? 'bg-sidebar-accent text-sidebar-accent-foreground'
                       : 'hover:bg-sidebar-accent/65 hover:text-sidebar-foreground',
                   ]}
@@ -234,20 +234,6 @@
                 {@const profile = resolveHostProfile(session.host_id)}
                 {@const key = hostSessionKey(session)}
                 <div class="group/session flex min-h-9 items-center gap-1">
-                  <button
-                    type="button"
-                    class={[
-                      'grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-sidebar-accent/65 hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-ring/40 [&_svg]:size-5',
-                      activeHostId === session.host_id && activeHostSessionId === null
-                        ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                        : undefined,
-                    ]}
-                    aria-label={`${tr('Select host')}: ${profile.label}`}
-                    title={`${tr('Select host')}: ${profile.label}`}
-                    onclick={() => onSelect(session.host_id, null)}
-                  >
-                    <span aria-hidden="true">{@html profile.icon_svg}</span>
-                  </button>
                   {#if editingSessionKey === key}
                     <form
                       class="flex h-9 min-w-0 flex-1 items-center"
@@ -288,6 +274,9 @@
                         title={`${session.title} · ${profile.label}`}
                         onclick={() => onSelect(session.host_id, session.host_session_id)}
                       >
+                        <span class="grid size-5 shrink-0 place-items-center text-muted-foreground [&_svg]:size-4" aria-hidden="true">
+                          {@html profile.icon_svg}
+                        </span>
                         <span class="min-w-0 flex-1 truncate">{session.title}</span>
                         {#if session.pinned_at}
                           <Pin class="size-3 shrink-0 text-primary" aria-hidden="true" />

--- a/apps/desktop/src/lib/i18n.ts
+++ b/apps/desktop/src/lib/i18n.ts
@@ -633,6 +633,7 @@ const chinese: Record<string, string> = {
   'Actions to experience': '需要体验',
   'Select host': '选择宿主',
   'Select a request': '选择一个请求',
+  'Open a request from the Inbox to continue in its Session tab.': '从收件箱打开请求，在对应的 Session 标签页中继续。',
   'Published': '已发布',
   'Cancelled': '已取消',
   'Paused': '已暂停',

--- a/apps/desktop/src/lib/titlebarInteractions.test.ts
+++ b/apps/desktop/src/lib/titlebarInteractions.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { titlebarPointerIntent } from './titlebarInteractions'
+
+describe('titlebarPointerIntent', () => {
+  it('starts dragging from a primary-button press on a passive titlebar surface', () => {
+    expect(titlebarPointerIntent({ button: 0, clickCount: 1, interactive: false })).toBe('drag')
+  })
+
+  it('toggles maximization on the second primary-button press', () => {
+    expect(titlebarPointerIntent({ button: 0, clickCount: 2, interactive: false })).toBe(
+      'toggle-maximize',
+    )
+  })
+
+  it('leaves tabs, buttons, and non-primary presses alone', () => {
+    expect(titlebarPointerIntent({ button: 0, clickCount: 1, interactive: true })).toBe('ignore')
+    expect(titlebarPointerIntent({ button: 0, clickCount: 2, interactive: true })).toBe('ignore')
+    expect(titlebarPointerIntent({ button: 1, clickCount: 1, interactive: false })).toBe('ignore')
+  })
+})

--- a/apps/desktop/src/lib/titlebarInteractions.ts
+++ b/apps/desktop/src/lib/titlebarInteractions.ts
@@ -1,0 +1,10 @@
+export type TitlebarPointerIntent = 'ignore' | 'drag' | 'toggle-maximize'
+
+export function titlebarPointerIntent(input: Readonly<{
+  button: number
+  clickCount: number
+  interactive: boolean
+}>): TitlebarPointerIntent {
+  if (input.button !== 0 || input.interactive) return 'ignore'
+  return input.clickCount === 2 ? 'toggle-maximize' : 'drag'
+}

--- a/apps/desktop/src/lib/workbench/WorkspaceHeader.svelte
+++ b/apps/desktop/src/lib/workbench/WorkspaceHeader.svelte
@@ -34,9 +34,9 @@
   }
 </script>
 
-<header class="flex min-h-16 shrink-0 items-center gap-4 border-b px-5 py-3">
+<header class="flex h-12 shrink-0 items-center gap-4 overflow-hidden border-b px-4">
   <div class="min-w-0 flex-1">
-    <div class="flex min-w-0 flex-wrap items-center gap-2 text-[10px] text-muted-foreground">
+    <div class="flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-[10px] text-muted-foreground">
       <span class="flex min-w-0 items-center gap-1.5">
         <span class="grid size-4 shrink-0 place-items-center [&_svg]:size-3.5">
           {@html resolveHostProfile(workspace.request.host_id).icon_svg}

--- a/apps/desktop/src/lib/workspace/ArchivedSessionsWorkspaceView.svelte
+++ b/apps/desktop/src/lib/workspace/ArchivedSessionsWorkspaceView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import {
     ArchiveRestore,
     ChevronDown,
@@ -9,12 +10,10 @@
     RefreshCw,
     Search,
     Trash2,
-    X,
   } from '@lucide/svelte'
   import { Badge } from '$lib/components/ui/badge'
   import type { ApplicationTransport } from '$lib/application/applicationTransport'
   import { Button } from '$lib/components/ui/button'
-  import * as Dialog from '$lib/components/ui/dialog'
   import { ScrollArea } from '$lib/components/ui/scroll-area'
   import type { FeedbackRequestSummary, FeedbackWorkspaceView, HostSessionSummary } from '$lib/feedback'
   import { requestStatusLabel } from '$lib/feedback'
@@ -39,13 +38,13 @@
     publishedFeedback: PublishedFeedbackView | null
   }
 
-  export let open = false
   export let transport: ApplicationTransport
   export let previewMode = false
   export let resolveHostProfile: (hostId: string) => HostProfile
   export let formatTime: (value: string | null | undefined) => string
   export let messageFrom: (cause: unknown) => string
   export let initialSession: SessionViewDescriptor | null = null
+  export let selectionEpoch = 0
   export let onError: (message: string) => void = () => {}
   export let onChanged: () => Promise<void> | void = () => {}
 
@@ -58,7 +57,8 @@
   let expandedSessions = new Set<string>()
   let selected: SelectedArchivedItem | null = null
   let detailLoadingRequestId: string | null = null
-  let openedOnce = false
+  let mounted = false
+  let appliedSelectionEpoch = -1
   let applyInitialSession = false
   let searchTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -75,18 +75,21 @@
   $: activeUncookedMarkdown =
     activePublishedFeedback?.uncooked_markdown ?? activeRequestDetails?.workspace.draft.body_markdown ?? ''
 
-  $: if (open && !openedOnce) {
-    openedOnce = true
+  onMount(() => {
+    mounted = true
+    appliedSelectionEpoch = selectionEpoch
     applyInitialSession = true
     void loadArchive()
-  }
-  $: if (!open && openedOnce) {
-    openedOnce = false
-    sessions = []
-    requestsBySession = {}
-    requestDetailsById = {}
-    selected = null
-    detailLoadingRequestId = null
+    return () => {
+      mounted = false
+      if (searchTimer) clearTimeout(searchTimer)
+    }
+  })
+
+  $: if (mounted && selectionEpoch !== appliedSelectionEpoch) {
+    appliedSelectionEpoch = selectionEpoch
+    applyInitialSession = true
+    void loadArchive()
   }
 
   function tr(source: string, values: Record<string, string | number> = {}) {
@@ -378,15 +381,11 @@
   }
 </script>
 
-<Dialog.Root bind:open>
-  <Dialog.Content
-    showCloseButton={false}
-    class="grid h-[min(760px,calc(100vh-3rem))] w-[min(1060px,calc(100vw-2rem))] max-w-none grid-rows-[56px_minmax(0,1fr)] gap-0 overflow-hidden p-0 sm:max-w-none"
-  >
-    <div class="flex min-h-0 items-center gap-2 border-b px-4">
-      <Dialog.Title class="min-w-0 flex-1 text-sm font-semibold">
+<section class="grid h-full min-h-0 min-w-0 grid-rows-[48px_minmax(0,1fr)] overflow-hidden bg-background">
+    <header class="flex min-h-0 items-center gap-2 border-b px-4">
+      <h1 class="min-w-0 flex-1 text-sm font-semibold">
         {tr('Archived sessions')}
-      </Dialog.Title>
+      </h1>
       <Button
         variant="ghost"
         size="icon-sm"
@@ -397,13 +396,7 @@
       >
         <RefreshCw class={loading ? 'animate-spin' : ''} />
       </Button>
-      <Dialog.Close
-        class="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-        aria-label={tr('Close')}
-      >
-        <X class="size-4" />
-      </Dialog.Close>
-    </div>
+    </header>
 
     <div class="grid min-h-0 overflow-hidden grid-cols-[minmax(0,320px)_minmax(0,1fr)]">
       <aside class="grid min-h-0 min-w-0 overflow-hidden grid-rows-[56px_minmax(0,1fr)] border-r bg-muted/20">
@@ -524,7 +517,7 @@
 
       <section class="grid min-h-0 min-w-0 overflow-hidden grid-rows-[72px_minmax(0,1fr)]">
         {#if activeSession && activeRequest}
-          <div class="flex min-h-0 items-center gap-2 border-b px-5">
+          <div class="flex min-h-0 min-w-0 items-center gap-2 overflow-hidden border-b px-5">
             <div class="min-w-0 flex-1">
               <p class="m-0 text-[10px] font-medium uppercase text-muted-foreground">
                 {tr('Request details')}
@@ -626,7 +619,7 @@
             </div>
           </ScrollArea>
         {:else if activeSession}
-          <div class="flex min-h-0 items-center gap-2 border-b px-5">
+          <div class="flex min-h-0 min-w-0 items-center gap-2 overflow-hidden border-b px-5">
             <div class="min-w-0 flex-1">
               <p class="m-0 text-[10px] font-medium uppercase text-muted-foreground">
                 {tr('Session details')}
@@ -719,5 +712,4 @@
         {/if}
       </section>
     </div>
-  </Dialog.Content>
-</Dialog.Root>
+</section>

--- a/apps/desktop/src/lib/workspace/InboxWorkspaceView.svelte
+++ b/apps/desktop/src/lib/workspace/InboxWorkspaceView.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { Inbox } from '@lucide/svelte'
+
+  import { t } from '$lib/i18n'
+  import { locale } from '$lib/preferences'
+
+  function tr(source: string) {
+    return t($locale, source)
+  }
+</script>
+
+<section class="grid h-full min-h-0 place-items-center bg-background px-8 text-center">
+  <div class="max-w-sm">
+    <div class="mx-auto grid size-11 place-items-center rounded-lg bg-muted text-muted-foreground">
+      <Inbox class="size-5" aria-hidden="true" />
+    </div>
+    <h2 class="mb-0 mt-4 text-base font-semibold">{tr('Select a request')}</h2>
+    <p class="mb-0 mt-2 text-xs leading-5 text-muted-foreground">
+      {tr('Open a request from the Inbox to continue in its Session tab.')}
+    </p>
+  </div>
+</section>

--- a/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
+++ b/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
@@ -24,6 +24,7 @@
   export let labelForView: (view: WorkspaceViewDescriptor) => string
   export let onActivate: (viewKey: string) => void = () => {}
   export let onClose: (viewKey: string) => Promise<void> | void = () => {}
+  export let onStartDragging: ((event: PointerEvent) => void) | null = null
 
   let viewKeys: string[] = []
   let focusedViewKey: string | null = null
@@ -95,23 +96,23 @@
   }
 </script>
 
-{#if views.length > 0}
-  <div class="shrink-0 border-b bg-muted/25 px-2 pt-1.5">
+<div class="flex h-full min-w-0 items-end overflow-hidden px-2 pt-1.5">
+  {#if views.length > 0}
     <div
-      class="overflow-x-auto overscroll-x-contain [scrollbar-width:thin]"
+      class="h-full min-w-0 overflow-x-auto overscroll-x-contain [scrollbar-width:thin]"
       role="tablist"
       aria-label={tr('Workspace tabs')}
       aria-orientation="horizontal"
       aria-busy={pendingViewKey !== null}
     >
-      <div class="flex min-w-max items-end gap-1">
+      <div class="flex h-full w-max items-end gap-1">
         {#each views as view (workspaceViewKey(view))}
           {@const viewKey = workspaceViewKey(view)}
           {@const label = labelForView(view)}
           <div
             role="presentation"
             class={[
-              'flex max-w-56 shrink-0 items-center rounded-t-md border border-b-0 transition-colors',
+              'mb-[-1px] flex h-[35px] max-w-56 shrink-0 items-center rounded-t-md border border-b-0 transition-colors',
               activeViewKey === viewKey
                 ? 'bg-background text-foreground'
                 : 'border-transparent text-muted-foreground hover:bg-background/60 hover:text-foreground',
@@ -153,5 +154,16 @@
         {/each}
       </div>
     </div>
-  </div>
-{/if}
+  {/if}
+  {#if onStartDragging}
+    <button
+      type="button"
+      class="titlebar-drag h-full min-w-6 flex-1 cursor-grab border-0 bg-transparent active:cursor-grabbing focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-ring"
+      aria-label={tr('Drag window')}
+      title={tr('Drag window')}
+      onpointerdown={onStartDragging}
+    ></button>
+  {:else}
+    <div class="h-full min-w-6 flex-1"></div>
+  {/if}
+</div>

--- a/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
+++ b/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
@@ -35,7 +35,6 @@
   export let onActivate: (viewKey: string) => void = () => {}
   export let onClose: (viewKey: string) => Promise<void> | void = () => {}
   export let onReorder: (viewKeys: readonly string[]) => void = () => {}
-  export let onStartDragging: ((event: PointerEvent) => void) | null = null
 
   let dndItems: WorkspaceTabDndItem[] = []
   let dragging = false
@@ -221,16 +220,11 @@
     </div>
   {/if}
 
-  {#if onStartDragging}
-    <!-- svelte-ignore a11y_no_static_element_interactions (window dragging is a pointer-only titlebar surface) -->
-    <div
-      class="titlebar-drag h-full min-w-10 flex-1 cursor-grab active:cursor-grabbing"
-      title={tr('Drag window')}
-      onpointerdown={onStartDragging}
-    ></div>
-  {:else}
-    <div class="h-full min-w-10 flex-1"></div>
-  {/if}
+  <div
+    class="titlebar-drag h-full min-w-10 flex-1 cursor-grab active:cursor-grabbing"
+    data-titlebar-drag-surface
+    title={tr('Drag window')}
+  ></div>
 </div>
 
 <style>

--- a/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
+++ b/apps/desktop/src/lib/workspace/WorkspaceTabStrip.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { flip } from 'svelte/animate'
   import { tick } from 'svelte'
   import { X } from '@lucide/svelte'
+  import { dndzone, type DndEvent } from 'svelte-dnd-action'
 
   import { t } from '$lib/i18n'
   import { locale } from '$lib/preferences'
@@ -17,6 +19,14 @@
     type WorkspaceTabNavigationIntent,
   } from './workspaceTabNavigation'
 
+  type WorkspaceTabDndItem = {
+    id: string
+    view: WorkspaceViewDescriptor
+  }
+
+  const FLIP_DURATION_MS = 140
+  const WORKSPACE_TAB_DND_TYPE = 'rambledesk-workspace-tab'
+
   export let views: readonly WorkspaceViewDescriptor[] = []
   export let activeViewKey: string | null = null
   export let pendingViewKey: string | null = null
@@ -24,30 +34,31 @@
   export let labelForView: (view: WorkspaceViewDescriptor) => string
   export let onActivate: (viewKey: string) => void = () => {}
   export let onClose: (viewKey: string) => Promise<void> | void = () => {}
+  export let onReorder: (viewKeys: readonly string[]) => void = () => {}
   export let onStartDragging: ((event: PointerEvent) => void) | null = null
 
+  let dndItems: WorkspaceTabDndItem[] = []
+  let dragging = false
   let viewKeys: string[] = []
   let focusedViewKey: string | null = null
-  let tabButtons = new Map<string, HTMLButtonElement>()
-  let lastScrolledActiveViewKey: string | null = null
+  let tabButtons = new Map<string, HTMLElement>()
 
-  $: viewKeys = views.map(workspaceViewKey)
+  $: if (!dragging) {
+    dndItems = views.map((view) => ({ id: workspaceViewKey(view), view }))
+  }
+  $: viewKeys = dndItems.map((item) => item.id)
   $: if (!focusedViewKey || !viewKeys.includes(focusedViewKey)) {
     focusedViewKey = activeViewKey && viewKeys.includes(activeViewKey) ? activeViewKey : viewKeys[0] ?? null
   }
-  $: if (activeViewKey !== lastScrolledActiveViewKey) {
-    lastScrolledActiveViewKey = activeViewKey
-    if (activeViewKey) {
-      focusedViewKey = activeViewKey
-      void revealTab(activeViewKey, false)
-    }
+  $: if (activeViewKey && viewKeys.includes(activeViewKey)) {
+    focusedViewKey = activeViewKey
   }
 
   function tr(source: string) {
     return t($locale, source)
   }
 
-  function registerTab(node: HTMLButtonElement, viewKey: string) {
+  function registerTab(node: HTMLElement, viewKey: string) {
     tabButtons.set(viewKey, node)
     return {
       destroy() {
@@ -56,25 +67,37 @@
     }
   }
 
-  async function revealTab(viewKey: string, focus: boolean) {
+  function registerTabKeyboard(node: HTMLElement, initialViewKey: string) {
+    let viewKey = initialViewKey
+    const listener = (event: KeyboardEvent) => handleKeydown(event, viewKey)
+    node.addEventListener('keydown', listener)
+    return {
+      update(nextViewKey: string) {
+        viewKey = nextViewKey
+      },
+      destroy() {
+        node.removeEventListener('keydown', listener)
+      },
+    }
+  }
+
+  async function focusTab(viewKey: string) {
     await tick()
-    const tab = tabButtons.get(viewKey)
-    if (!tab) return
-    tab.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-    if (focus) tab.focus()
+    tabButtons.get(viewKey)?.focus()
   }
 
   function moveFocus(intent: WorkspaceTabNavigationIntent) {
     const nextViewKey = workspaceTabNavigationTarget(viewKeys, focusedViewKey, intent)
     if (!nextViewKey) return
     focusedViewKey = nextViewKey
-    void revealTab(nextViewKey, true)
+    void focusTab(nextViewKey)
   }
 
   function handleKeydown(event: KeyboardEvent, viewKey: string) {
     const action = workspaceTabKeyboardAction(event.key)
     if (!action) return
     event.preventDefault()
+    event.stopPropagation()
     if (action.type === 'move') moveFocus(action.intent)
     else if (action.type === 'activate') activateTab(viewKey)
     else void closeAndFocus(viewKey)
@@ -82,7 +105,12 @@
 
   function activateTab(viewKey: string) {
     focusedViewKey = viewKey
-    requestWorkspaceTabActivation(viewKey, disabled || pendingViewKey !== null, onActivate)
+    const requested = requestWorkspaceTabActivation(
+      viewKey,
+      disabled || pendingViewKey !== null,
+      onActivate,
+    )
+    if (requested) void focusTab(viewKey)
   }
 
   async function closeAndFocus(viewKey: string) {
@@ -92,78 +120,244 @@
       activeViewKey && viewKeys.includes(activeViewKey) ? activeViewKey : viewKeys[0] ?? null
     if (!nextViewKey) return
     focusedViewKey = nextViewKey
-    await revealTab(nextViewKey, true)
+    await focusTab(nextViewKey)
+  }
+
+  function handleMiddleClick(event: MouseEvent, viewKey: string) {
+    if (event.button !== 1) return
+    event.preventDefault()
+    void closeAndFocus(viewKey)
+  }
+
+  function handleDndConsider(event: CustomEvent<DndEvent<WorkspaceTabDndItem>>) {
+    dragging = true
+    dndItems = event.detail.items
+  }
+
+  function handleDndFinalize(event: CustomEvent<DndEvent<WorkspaceTabDndItem>>) {
+    dndItems = event.detail.items
+    onReorder(dndItems.map((item) => item.id))
+    dragging = false
   }
 </script>
 
-<div class="flex h-full min-w-0 items-end overflow-hidden px-2 pt-1.5">
-  {#if views.length > 0}
+<div class="flex h-full min-w-0 items-stretch overflow-hidden pl-2 pt-1.5">
+  {#if dndItems.length > 0}
     <div
-      class="h-full min-w-0 overflow-x-auto overscroll-x-contain [scrollbar-width:thin]"
+      use:dndzone={{
+        items: dndItems,
+        type: WORKSPACE_TAB_DND_TYPE,
+        flipDurationMs: FLIP_DURATION_MS,
+        dragDisabled: disabled || pendingViewKey !== null,
+        morphDisabled: true,
+        dropFromOthersDisabled: true,
+        zoneTabIndex: -1,
+        zoneItemTabIndex: -1,
+        dropTargetStyle: {},
+        autoAriaDisabled: true,
+        delayTouchStart: 500,
+      }}
+      class="workspace-tab-list flex h-full min-w-0 flex-[0_1_auto] items-stretch overflow-hidden"
       role="tablist"
       aria-label={tr('Workspace tabs')}
       aria-orientation="horizontal"
       aria-busy={pendingViewKey !== null}
+      data-workspace-tab-list
+      onconsider={handleDndConsider}
+      onfinalize={handleDndFinalize}
     >
-      <div class="flex h-full w-max items-end gap-1">
-        {#each views as view (workspaceViewKey(view))}
-          {@const viewKey = workspaceViewKey(view)}
-          {@const label = labelForView(view)}
+      {#each dndItems as item (item.id)}
+        {@const viewKey = item.id}
+        {@const label = labelForView(item.view)}
+        <div
+          animate:flip={{ duration: FLIP_DURATION_MS }}
+          class="workspace-tab-item relative min-w-0 grow-0 shrink basis-48 cursor-grab active:cursor-grabbing"
+          class:z-10={activeViewKey === viewKey}
+          data-workspace-tab-item
+          data-workspace-view-key={viewKey}
+          data-active={activeViewKey === viewKey ? 'true' : 'false'}
+        >
+          <span class="workspace-tab-seat" aria-hidden="true"></span>
+          <!-- svelte-ignore a11y_click_events_have_key_events (the native keyboard action above preserves Tab semantics before DnD sees the event) -->
           <div
-            role="presentation"
-            class={[
-              'mb-[-1px] flex h-[35px] max-w-56 shrink-0 items-center rounded-t-md border border-b-0 transition-colors',
-              activeViewKey === viewKey
-                ? 'bg-background text-foreground'
-                : 'border-transparent text-muted-foreground hover:bg-background/60 hover:text-foreground',
-            ]}
+            use:registerTab={viewKey}
+            use:registerTabKeyboard={viewKey}
+            role="tab"
+            id={workspaceTabId(viewKey)}
+            aria-controls={workspaceTabPanelId(viewKey)}
+            aria-selected={activeViewKey === viewKey}
+            aria-disabled={disabled || pendingViewKey !== null}
+            data-workspace-tab-trigger
+            data-workspace-view-key={viewKey}
+            tabindex={focusedViewKey === viewKey ? 0 : -1}
+            class="workspace-tab-content group/tab relative flex h-full w-full min-w-0 items-center overflow-hidden rounded-t-lg px-2 pb-1.5 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
+            class:workspace-tab-active={activeViewKey === viewKey}
+            class:workspace-tab-inactive={activeViewKey !== viewKey}
+            title={label}
+            onclick={() => activateTab(viewKey)}
+            onauxclick={(event) => handleMiddleClick(event, viewKey)}
           >
-            <button
-              use:registerTab={viewKey}
-              type="button"
-              role="tab"
-              id={workspaceTabId(viewKey)}
-              data-workspace-view-key={viewKey}
-              data-active={activeViewKey === viewKey ? 'true' : 'false'}
-              aria-controls={workspaceTabPanelId(viewKey)}
-              aria-selected={activeViewKey === viewKey}
-              tabindex={focusedViewKey === viewKey ? 0 : -1}
-              class={[
-                'min-w-0 flex-1 truncate rounded-tl-md px-3 py-1.5 text-left text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
-                activeViewKey === viewKey ? 'font-medium' : undefined,
-              ]}
-              title={label}
-              disabled={disabled || pendingViewKey !== null}
-              onclick={() => activateTab(viewKey)}
-              onkeydown={(event) => handleKeydown(event, viewKey)}
-            >
+            <span class="workspace-tab-label pointer-events-none min-w-0 flex-1 overflow-hidden whitespace-nowrap">
               {label}
-            </button>
-            <button
-              type="button"
-              class="mr-1 grid size-5 shrink-0 place-items-center rounded-sm text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-40"
-              aria-label={`${tr('Close workspace tab')}: ${label}`}
-              title={tr('Close workspace tab')}
-              tabindex={activeViewKey === viewKey ? 0 : -1}
-              disabled={disabled || pendingViewKey !== null}
-              onclick={() => void closeAndFocus(viewKey)}
-            >
-              <X class="size-3" aria-hidden="true" />
-            </button>
+            </span>
           </div>
-        {/each}
-      </div>
+          <button
+            type="button"
+            class="workspace-tab-close absolute bottom-1.5 right-2 top-0 my-auto grid size-4 place-items-center rounded-md text-muted-foreground outline-none transition-opacity hover:bg-foreground/10 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-40"
+            class:workspace-tab-close-active={activeViewKey === viewKey}
+            aria-label={`${tr('Close workspace tab')}: ${label}`}
+            title={tr('Close workspace tab')}
+            tabindex={activeViewKey === viewKey ? 0 : -1}
+            disabled={disabled || pendingViewKey !== null}
+            onclick={(event) => {
+              event.stopPropagation()
+              void closeAndFocus(viewKey)
+            }}
+          >
+            <X class="size-3" aria-hidden="true" />
+          </button>
+        </div>
+      {/each}
     </div>
   {/if}
+
   {#if onStartDragging}
-    <button
-      type="button"
-      class="titlebar-drag h-full min-w-6 flex-1 cursor-grab border-0 bg-transparent active:cursor-grabbing focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-ring"
-      aria-label={tr('Drag window')}
+    <!-- svelte-ignore a11y_no_static_element_interactions (window dragging is a pointer-only titlebar surface) -->
+    <div
+      class="titlebar-drag h-full min-w-10 flex-1 cursor-grab active:cursor-grabbing"
       title={tr('Drag window')}
       onpointerdown={onStartDragging}
-    ></button>
+    ></div>
   {:else}
-    <div class="h-full min-w-6 flex-1"></div>
+    <div class="h-full min-w-10 flex-1"></div>
   {/if}
 </div>
+
+<style>
+  .workspace-tab-item::before {
+    position: absolute;
+    top: calc(50% - 3px);
+    left: 0;
+    width: 1px;
+    height: 1rem;
+    content: '';
+    background: var(--border);
+    opacity: 1;
+    pointer-events: none;
+    transform: translateY(-50%);
+    transition: opacity 150ms ease;
+  }
+
+  .workspace-tab-item:first-child::before,
+  .workspace-tab-item[data-active='true']::before,
+  .workspace-tab-item:hover::before,
+  .workspace-tab-item[data-active='true'] + .workspace-tab-item::before,
+  .workspace-tab-item:hover + .workspace-tab-item::before {
+    opacity: 0;
+  }
+
+  .workspace-tab-content {
+    isolation: isolate;
+    cursor: inherit;
+    color: var(--muted-foreground);
+  }
+
+  .workspace-tab-active {
+    padding-right: 1.5rem;
+    color: var(--foreground);
+    background: var(--background);
+  }
+
+  .workspace-tab-inactive::before {
+    position: absolute;
+    inset: 0.125rem 0.125rem 0.5rem;
+    z-index: -1;
+    content: '';
+    background: color-mix(in oklab, var(--background) 60%, transparent);
+    border-radius: 0.5rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 150ms ease;
+  }
+
+  .workspace-tab-inactive:hover::before {
+    opacity: 1;
+  }
+
+  .workspace-tab-label {
+    padding-right: 0.75rem;
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 0.75rem), transparent);
+    mask-image: linear-gradient(to right, #000 calc(100% - 0.75rem), transparent);
+  }
+
+  .workspace-tab-item:not([data-active='true']):hover .workspace-tab-label {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      #000 calc(100% - 1.75rem),
+      transparent calc(100% - 1rem)
+    );
+    mask-image: linear-gradient(
+      to right,
+      #000 calc(100% - 1.75rem),
+      transparent calc(100% - 1rem)
+    );
+  }
+
+  .workspace-tab-close {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .workspace-tab-item:hover .workspace-tab-close,
+  .workspace-tab-close-active,
+  .workspace-tab-close:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .workspace-tab-seat {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 0.5rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 150ms ease;
+  }
+
+  .workspace-tab-item[data-active='true'] .workspace-tab-seat {
+    opacity: 1;
+  }
+
+  .workspace-tab-seat::before,
+  .workspace-tab-seat::after {
+    position: absolute;
+    bottom: 0;
+    width: 0.5rem;
+    height: 0.5rem;
+    content: '';
+    background: var(--background);
+  }
+
+  .workspace-tab-seat::before {
+    left: -0.5rem;
+    -webkit-mask-image: radial-gradient(circle at top left, transparent 0.4375rem, #000 0.5rem);
+    mask-image: radial-gradient(circle at top left, transparent 0.4375rem, #000 0.5rem);
+  }
+
+  .workspace-tab-seat::after {
+    right: -0.5rem;
+    -webkit-mask-image: radial-gradient(circle at top right, transparent 0.4375rem, #000 0.5rem);
+    mask-image: radial-gradient(circle at top right, transparent 0.4375rem, #000 0.5rem);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .workspace-tab-item::before,
+    .workspace-tab-inactive::before,
+    .workspace-tab-close,
+    .workspace-tab-seat {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/desktop/src/lib/workspace/previewWorkspaceSnapshot.test.ts
+++ b/apps/desktop/src/lib/workspace/previewWorkspaceSnapshot.test.ts
@@ -70,4 +70,28 @@ describe('preview workspace snapshot store', () => {
           : 'rambelle-profile:singleton',
     })
   })
+
+  it('seeds a dense mixed tab strip for browser interaction acceptance', () => {
+    expect(seedPreviewWorkspaceScenario('tabs')).toBe('tabs')
+
+    const restored = savedPreviewWorkspaceSnapshot()!
+    expect(restored.shellState.views).toHaveLength(12)
+    expect(restored.shellState.views.map((view) => view.kind)).toEqual([
+      'inbox',
+      'session',
+      'session',
+      'session',
+      'request-task',
+      'rambelle-profile',
+      'settings',
+      'session',
+      'session',
+      'session',
+      'session',
+      'session',
+    ])
+    expect(restored.shellState.activeViewKey).toBe(
+      workspaceViewKey(restored.shellState.views[1]),
+    )
+  })
 })

--- a/apps/desktop/src/lib/workspace/previewWorkspaceSnapshot.test.ts
+++ b/apps/desktop/src/lib/workspace/previewWorkspaceSnapshot.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { sessionViewDescriptor, workspaceViewKey } from './viewDescriptors'
+import { archiveViewDescriptor, sessionViewDescriptor, workspaceViewKey } from './viewDescriptors'
 import {
   resetPreviewWorkspaceSnapshot,
   savedPreviewWorkspaceSnapshot,
@@ -55,6 +55,14 @@ describe('preview workspace snapshot store', () => {
       activeViewKey: 'settings:singleton',
     })
     expect(savedPreviewWorkspaceSnapshot()?.requestIds.size).toBe(0)
+  })
+
+  it('seeds the archive workspace acceptance scenario', () => {
+    expect(seedPreviewWorkspaceScenario('archive')).toBe('archive')
+    expect(savedPreviewWorkspaceSnapshot()?.shellState).toEqual({
+      views: [archiveViewDescriptor()],
+      activeViewKey: 'archive:singleton',
+    })
   })
 
   it.each([

--- a/apps/desktop/src/lib/workspace/previewWorkspaceSnapshot.ts
+++ b/apps/desktop/src/lib/workspace/previewWorkspaceSnapshot.ts
@@ -4,6 +4,7 @@ import {
   type WorkspaceSnapshotV2,
 } from './workspaceSnapshot'
 import {
+  inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
   sessionViewDescriptor,
@@ -19,6 +20,7 @@ export type PreviewWorkspaceScenario =
   | 'settings'
   | 'task'
   | 'profile'
+  | 'tabs'
 
 let snapshot: WorkspaceSnapshotV2 | null = null
 
@@ -38,9 +40,33 @@ export function seedPreviewWorkspaceScenario(value: string | null): PreviewWorks
     value !== 'unknown' &&
     value !== 'settings' &&
     value !== 'task' &&
-    value !== 'profile'
+    value !== 'profile' &&
+    value !== 'tabs'
   ) {
     return null
+  }
+  if (value === 'tabs') {
+    const activeView = sessionViewDescriptor('codex', 'desktop-refactor-2026-08-02')
+    const views: WorkspaceSnapshotV2['views'] = [
+      inboxViewDescriptor(),
+      { ...activeView, lastRequestId: '019fc1d9-51e7-7eb2-b196-e9266947fc41' },
+      { ...sessionViewDescriptor('pi', 'pi-native-wait'), lastRequestId: null },
+      { ...sessionViewDescriptor('claude', 'terminology-audit'), lastRequestId: null },
+      requestTaskViewDescriptor('019fc1d9-51e7-7eb2-b196-e9266947fc41'),
+      rambelleProfileViewDescriptor(),
+      settingsViewDescriptor(),
+      { ...sessionViewDescriptor('codex', 'release-readiness'), lastRequestId: null },
+      { ...sessionViewDescriptor('pi', 'native-capture-review'), lastRequestId: null },
+      { ...sessionViewDescriptor('claude', 'adapter-contract-audit'), lastRequestId: null },
+      { ...sessionViewDescriptor('codex', 'web-service-follow-up'), lastRequestId: null },
+      { ...sessionViewDescriptor('pi', 'feedback-draft-polish'), lastRequestId: null },
+    ]
+    savePreviewWorkspaceSnapshot({
+      version: 2,
+      views,
+      activeViewKey: workspaceViewKey(activeView),
+    })
+    return value
   }
   if (value === 'settings') {
     const view = settingsViewDescriptor()

--- a/apps/desktop/src/lib/workspace/previewWorkspaceSnapshot.ts
+++ b/apps/desktop/src/lib/workspace/previewWorkspaceSnapshot.ts
@@ -4,6 +4,7 @@ import {
   type WorkspaceSnapshotV2,
 } from './workspaceSnapshot'
 import {
+  archiveViewDescriptor,
   inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
@@ -14,6 +15,7 @@ import {
 
 export type PreviewWorkspaceScenario =
   | 'restore'
+  | 'archive'
   | 'archived'
   | 'unavailable'
   | 'unknown'
@@ -35,6 +37,7 @@ export function savePreviewWorkspaceSnapshot(next: WorkspaceSnapshotV2) {
 export function seedPreviewWorkspaceScenario(value: string | null): PreviewWorkspaceScenario | null {
   if (
     value !== 'restore' &&
+    value !== 'archive' &&
     value !== 'archived' &&
     value !== 'unavailable' &&
     value !== 'unknown' &&
@@ -44,6 +47,15 @@ export function seedPreviewWorkspaceScenario(value: string | null): PreviewWorks
     value !== 'tabs'
   ) {
     return null
+  }
+  if (value === 'archive') {
+    const view = archiveViewDescriptor()
+    savePreviewWorkspaceSnapshot({
+      version: 2,
+      views: [view],
+      activeViewKey: workspaceViewKey(view),
+    })
+    return value
   }
   if (value === 'tabs') {
     const activeView = sessionViewDescriptor('codex', 'desktop-refactor-2026-08-02')

--- a/apps/desktop/src/lib/workspace/viewDescriptors.test.ts
+++ b/apps/desktop/src/lib/workspace/viewDescriptors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
   sessionViewDescriptor,
@@ -9,6 +10,10 @@ import {
 } from './viewDescriptors'
 
 describe('workspace view descriptors', () => {
+  it('uses one stable key for the aggregate Inbox view', () => {
+    expect(workspaceViewKey(inboxViewDescriptor())).toBe('inbox:singleton')
+  })
+
   it('creates a readonly session descriptor with a type-prefixed stable key', () => {
     const first = sessionViewDescriptor('codex', 'session-1')
     const second = sessionViewDescriptor('codex', 'session-1')

--- a/apps/desktop/src/lib/workspace/viewDescriptors.test.ts
+++ b/apps/desktop/src/lib/workspace/viewDescriptors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  archiveViewDescriptor,
   inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
@@ -48,6 +49,11 @@ describe('workspace view descriptors', () => {
     expect(first).toEqual({ kind: 'settings' })
     expect(workspaceViewKey(first)).toBe('settings:singleton')
     expect(workspaceViewKey(second)).toBe(workspaceViewKey(first))
+  })
+
+  it('gives the archive workspace one singleton key', () => {
+    expect(archiveViewDescriptor()).toEqual({ kind: 'archive' })
+    expect(workspaceViewKey(archiveViewDescriptor())).toBe('archive:singleton')
   })
 
   it('keys request tasks by request id and keeps profile singleton', () => {

--- a/apps/desktop/src/lib/workspace/viewDescriptors.ts
+++ b/apps/desktop/src/lib/workspace/viewDescriptors.ts
@@ -12,6 +12,10 @@ export type InboxViewDescriptor = Readonly<{
   kind: 'inbox'
 }>
 
+export type ArchiveViewDescriptor = Readonly<{
+  kind: 'archive'
+}>
+
 export type RequestTaskViewDescriptor = Readonly<{
   kind: 'request-task'
   requestId: string
@@ -24,6 +28,7 @@ export type RambelleProfileViewDescriptor = Readonly<{
 export type WorkspaceViewDescriptor =
   | SessionViewDescriptor
   | InboxViewDescriptor
+  | ArchiveViewDescriptor
   | SettingsViewDescriptor
   | RequestTaskViewDescriptor
   | RambelleProfileViewDescriptor
@@ -43,6 +48,10 @@ export function inboxViewDescriptor(): InboxViewDescriptor {
   return { kind: 'inbox' }
 }
 
+export function archiveViewDescriptor(): ArchiveViewDescriptor {
+  return { kind: 'archive' }
+}
+
 export function requestTaskViewDescriptor(requestId: string): RequestTaskViewDescriptor {
   return { kind: 'request-task', requestId }
 }
@@ -55,6 +64,8 @@ export function workspaceViewKey(view: WorkspaceViewDescriptor): string {
   switch (view.kind) {
     case 'inbox':
       return 'inbox:singleton'
+    case 'archive':
+      return 'archive:singleton'
     case 'settings':
       return 'settings:singleton'
     case 'request-task':

--- a/apps/desktop/src/lib/workspace/viewDescriptors.ts
+++ b/apps/desktop/src/lib/workspace/viewDescriptors.ts
@@ -8,6 +8,10 @@ export type SettingsViewDescriptor = Readonly<{
   kind: 'settings'
 }>
 
+export type InboxViewDescriptor = Readonly<{
+  kind: 'inbox'
+}>
+
 export type RequestTaskViewDescriptor = Readonly<{
   kind: 'request-task'
   requestId: string
@@ -19,6 +23,7 @@ export type RambelleProfileViewDescriptor = Readonly<{
 
 export type WorkspaceViewDescriptor =
   | SessionViewDescriptor
+  | InboxViewDescriptor
   | SettingsViewDescriptor
   | RequestTaskViewDescriptor
   | RambelleProfileViewDescriptor
@@ -34,6 +39,10 @@ export function settingsViewDescriptor(): SettingsViewDescriptor {
   return { kind: 'settings' }
 }
 
+export function inboxViewDescriptor(): InboxViewDescriptor {
+  return { kind: 'inbox' }
+}
+
 export function requestTaskViewDescriptor(requestId: string): RequestTaskViewDescriptor {
   return { kind: 'request-task', requestId }
 }
@@ -44,6 +53,8 @@ export function rambelleProfileViewDescriptor(): RambelleProfileViewDescriptor {
 
 export function workspaceViewKey(view: WorkspaceViewDescriptor): string {
   switch (view.kind) {
+    case 'inbox':
+      return 'inbox:singleton'
     case 'settings':
       return 'settings:singleton'
     case 'request-task':

--- a/apps/desktop/src/lib/workspace/workspaceShell.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceShell.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
   sessionViewDescriptor,
@@ -20,6 +21,7 @@ const alpha = sessionViewDescriptor('codex', 'alpha')
 const beta = sessionViewDescriptor('codex', 'beta')
 const gamma = sessionViewDescriptor('pi', 'gamma')
 const settings = settingsViewDescriptor()
+const inbox = inboxViewDescriptor()
 const task = requestTaskViewDescriptor('request-alpha')
 const profile = rambelleProfileViewDescriptor()
 
@@ -78,6 +80,15 @@ describe('workspaceShellReducer', () => {
 
     expect(reopened.views).toEqual([alpha, settings, beta])
     expect(activeWorkspaceView(reopened)).toBe(settings)
+    expectValidState(reopened)
+  })
+
+  it('opens the aggregate Inbox once and focuses the existing singleton', () => {
+    const initial = reduce(EMPTY_WORKSPACE_SHELL_STATE, open(inbox), open(alpha))
+    const reopened = workspaceShellReducer(initial, open(inboxViewDescriptor()))
+
+    expect(reopened.views).toEqual([inbox, alpha])
+    expect(activeWorkspaceView(reopened)).toBe(inbox)
     expectValidState(reopened)
   })
 

--- a/apps/desktop/src/lib/workspace/workspaceShell.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceShell.test.ts
@@ -136,6 +136,46 @@ describe('workspaceShellReducer', () => {
     expectValidState(focused)
   })
 
+  it('reorders the complete view set without changing the active view', () => {
+    const initial = reduce(
+      EMPTY_WORKSPACE_SHELL_STATE,
+      open(alpha),
+      open(settings),
+      open(beta),
+      { type: 'focus', viewKey: workspaceViewKey(settings) },
+    )
+    const result = workspaceShellReducer(initial, {
+      type: 'reorder',
+      viewKeys: [workspaceViewKey(beta), workspaceViewKey(alpha), workspaceViewKey(settings)],
+    })
+
+    expect(result.views).toEqual([beta, alpha, settings])
+    expect(result.activeViewKey).toBe(workspaceViewKey(settings))
+    expectValidState(result)
+  })
+
+  it('ignores incomplete, duplicate, unknown, and no-op reorder actions', () => {
+    const initial = reduce(EMPTY_WORKSPACE_SHELL_STATE, open(alpha), open(beta), open(gamma))
+
+    expect(workspaceShellReducer(initial, {
+      type: 'reorder',
+      viewKeys: [workspaceViewKey(alpha), workspaceViewKey(beta)],
+    })).toBe(initial)
+    expect(workspaceShellReducer(initial, {
+      type: 'reorder',
+      viewKeys: [workspaceViewKey(alpha), workspaceViewKey(alpha), workspaceViewKey(gamma)],
+    })).toBe(initial)
+    expect(workspaceShellReducer(initial, {
+      type: 'reorder',
+      viewKeys: [workspaceViewKey(alpha), workspaceViewKey(beta), 'session:missing'],
+    })).toBe(initial)
+    expect(workspaceShellReducer(initial, {
+      type: 'reorder',
+      viewKeys: initial.views.map(workspaceViewKey),
+    })).toBe(initial)
+    expectValidState(initial)
+  })
+
   it('closes an inactive view without changing the active view', () => {
     const initial = reduce(
       EMPTY_WORKSPACE_SHELL_STATE,

--- a/apps/desktop/src/lib/workspace/workspaceShell.ts
+++ b/apps/desktop/src/lib/workspace/workspaceShell.ts
@@ -12,6 +12,7 @@ export type WorkspaceShellAction =
   | Readonly<{ type: 'open'; view: WorkspaceViewDescriptor }>
   | Readonly<{ type: 'focus'; viewKey: string }>
   | Readonly<{ type: 'close'; viewKey: string }>
+  | Readonly<{ type: 'reorder'; viewKeys: readonly string[] }>
 
 const EMPTY_WORKSPACE_VIEWS: readonly WorkspaceViewDescriptor[] = Object.freeze([])
 
@@ -55,6 +56,26 @@ export function workspaceShellReducer(
         views,
         activeViewKey: fallback ? workspaceViewKey(fallback) : null,
       }
+    }
+    case 'reorder': {
+      if (action.viewKeys.length !== state.views.length) return state
+
+      const viewsByKey = new Map(
+        state.views.map((view) => [workspaceViewKey(view), view] as const),
+      )
+      if (viewsByKey.size !== state.views.length) return state
+
+      const reorderedViews: WorkspaceViewDescriptor[] = []
+      const seen = new Set<string>()
+      for (const viewKey of action.viewKeys) {
+        const view = viewsByKey.get(viewKey)
+        if (!view || seen.has(viewKey)) return state
+        seen.add(viewKey)
+        reorderedViews.push(view)
+      }
+
+      const unchanged = reorderedViews.every((view, index) => view === state.views[index])
+      return unchanged ? state : { ...state, views: reorderedViews }
     }
   }
 }

--- a/apps/desktop/src/lib/workspace/workspaceSnapshot.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSnapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
   sessionViewDescriptor,
@@ -142,6 +143,21 @@ describe('workspace snapshots', () => {
       views: [settingsViewDescriptor(), alpha],
       activeViewKey: workspaceViewKey(settingsViewDescriptor()),
     })
+  })
+
+  it('round-trips the aggregate Inbox as a singleton client view', () => {
+    const state = workspaceShellReducer(EMPTY_WORKSPACE_SHELL_STATE, {
+      type: 'open',
+      view: inboxViewDescriptor(),
+    })
+    const snapshot = createWorkspaceSnapshot(state, new Map())
+
+    expect(snapshot).toEqual({
+      version: 2,
+      views: [{ kind: 'inbox' }],
+      activeViewKey: 'inbox:singleton',
+    })
+    expect(restoreWorkspaceSnapshot(snapshot)?.shellState).toEqual(state)
   })
 
   it('round-trips request task and profile descriptors without editor state', () => {

--- a/apps/desktop/src/lib/workspace/workspaceSnapshot.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSnapshot.test.ts
@@ -45,6 +45,24 @@ describe('workspace snapshots', () => {
     expect([...restored!.requestIds]).toEqual([...requestIds])
   })
 
+  it('round-trips a reordered tab strip without changing its active identity', () => {
+    const opened = workspaceShellReducer(
+      workspaceShellReducer(EMPTY_WORKSPACE_SHELL_STATE, { type: 'open', view: alpha }),
+      { type: 'open', view: beta },
+    )
+    const reordered = workspaceShellReducer(opened, {
+      type: 'reorder',
+      viewKeys: [workspaceViewKey(beta), workspaceViewKey(alpha)],
+    })
+
+    const restored = restoreWorkspaceSnapshot(
+      createWorkspaceSnapshot(reordered, new Map()),
+    )
+
+    expect(restored?.shellState.views).toEqual([beta, alpha])
+    expect(restored?.shellState.activeViewKey).toBe(workspaceViewKey(beta))
+  })
+
   it('reads v1 snapshots while keeping cross-host sessions distinct and deduplicated', () => {
     const value = {
       version: 1,

--- a/apps/desktop/src/lib/workspace/workspaceSnapshot.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSnapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  archiveViewDescriptor,
   inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
@@ -174,6 +175,21 @@ describe('workspace snapshots', () => {
       version: 2,
       views: [{ kind: 'inbox' }],
       activeViewKey: 'inbox:singleton',
+    })
+    expect(restoreWorkspaceSnapshot(snapshot)?.shellState).toEqual(state)
+  })
+
+  it('round-trips the archive workspace as a singleton client view', () => {
+    const state = workspaceShellReducer(EMPTY_WORKSPACE_SHELL_STATE, {
+      type: 'open',
+      view: archiveViewDescriptor(),
+    })
+    const snapshot = createWorkspaceSnapshot(state, new Map())
+
+    expect(snapshot).toEqual({
+      version: 2,
+      views: [{ kind: 'archive' }],
+      activeViewKey: 'archive:singleton',
     })
     expect(restoreWorkspaceSnapshot(snapshot)?.shellState).toEqual(state)
   })

--- a/apps/desktop/src/lib/workspace/workspaceSnapshot.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSnapshot.ts
@@ -1,4 +1,5 @@
 import {
+  inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
   sessionViewDescriptor,
@@ -35,6 +36,10 @@ export type WorkspaceSnapshotSettingsViewV2 = Readonly<{
   kind: 'settings'
 }>
 
+export type WorkspaceSnapshotInboxViewV2 = Readonly<{
+  kind: 'inbox'
+}>
+
 export type WorkspaceSnapshotRequestTaskViewV2 = Readonly<{
   kind: 'request-task'
   requestId: string
@@ -46,6 +51,7 @@ export type WorkspaceSnapshotRambelleProfileViewV2 = Readonly<{
 
 export type WorkspaceSnapshotViewV2 =
   | WorkspaceSnapshotSessionViewV2
+  | WorkspaceSnapshotInboxViewV2
   | WorkspaceSnapshotSettingsViewV2
   | WorkspaceSnapshotRequestTaskViewV2
   | WorkspaceSnapshotRambelleProfileViewV2
@@ -98,6 +104,9 @@ function descriptorForSnapshotView(
   if (version === WORKSPACE_SNAPSHOT_VERSION && isRecord(value) && value.kind === 'settings') {
     return { view: settingsViewDescriptor(), lastRequestId: null }
   }
+  if (version === WORKSPACE_SNAPSHOT_VERSION && isRecord(value) && value.kind === 'inbox') {
+    return { view: inboxViewDescriptor(), lastRequestId: null }
+  }
   if (
     version === WORKSPACE_SNAPSHOT_VERSION &&
     isRecord(value) &&
@@ -120,6 +129,8 @@ function snapshotViewDescriptor(view: WorkspaceSnapshotViewV2): WorkspaceViewDes
   switch (view.kind) {
     case 'session':
       return sessionViewDescriptor(view.hostId, view.hostSessionId)
+    case 'inbox':
+      return inboxViewDescriptor()
     case 'settings':
       return settingsViewDescriptor()
     case 'request-task':
@@ -144,6 +155,8 @@ export function createWorkspaceSnapshot(
           }
         case 'settings':
           return { kind: 'settings' }
+        case 'inbox':
+          return { kind: 'inbox' }
         case 'request-task':
           return { kind: 'request-task', requestId: view.requestId }
         case 'rambelle-profile':

--- a/apps/desktop/src/lib/workspace/workspaceSnapshot.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSnapshot.ts
@@ -1,4 +1,5 @@
 import {
+  archiveViewDescriptor,
   inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
@@ -40,6 +41,10 @@ export type WorkspaceSnapshotInboxViewV2 = Readonly<{
   kind: 'inbox'
 }>
 
+export type WorkspaceSnapshotArchiveViewV2 = Readonly<{
+  kind: 'archive'
+}>
+
 export type WorkspaceSnapshotRequestTaskViewV2 = Readonly<{
   kind: 'request-task'
   requestId: string
@@ -52,6 +57,7 @@ export type WorkspaceSnapshotRambelleProfileViewV2 = Readonly<{
 export type WorkspaceSnapshotViewV2 =
   | WorkspaceSnapshotSessionViewV2
   | WorkspaceSnapshotInboxViewV2
+  | WorkspaceSnapshotArchiveViewV2
   | WorkspaceSnapshotSettingsViewV2
   | WorkspaceSnapshotRequestTaskViewV2
   | WorkspaceSnapshotRambelleProfileViewV2
@@ -107,6 +113,9 @@ function descriptorForSnapshotView(
   if (version === WORKSPACE_SNAPSHOT_VERSION && isRecord(value) && value.kind === 'inbox') {
     return { view: inboxViewDescriptor(), lastRequestId: null }
   }
+  if (version === WORKSPACE_SNAPSHOT_VERSION && isRecord(value) && value.kind === 'archive') {
+    return { view: archiveViewDescriptor(), lastRequestId: null }
+  }
   if (
     version === WORKSPACE_SNAPSHOT_VERSION &&
     isRecord(value) &&
@@ -131,6 +140,8 @@ function snapshotViewDescriptor(view: WorkspaceSnapshotViewV2): WorkspaceViewDes
       return sessionViewDescriptor(view.hostId, view.hostSessionId)
     case 'inbox':
       return inboxViewDescriptor()
+    case 'archive':
+      return archiveViewDescriptor()
     case 'settings':
       return settingsViewDescriptor()
     case 'request-task':
@@ -157,6 +168,8 @@ export function createWorkspaceSnapshot(
           return { kind: 'settings' }
         case 'inbox':
           return { kind: 'inbox' }
+        case 'archive':
+          return { kind: 'archive' }
         case 'request-task':
           return { kind: 'request-task', requestId: view.requestId }
         case 'rambelle-profile':

--- a/apps/desktop/src/lib/workspace/workspaceSurface.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSurface.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  archiveViewDescriptor,
   inboxViewDescriptor,
   rambelleProfileViewDescriptor,
   requestTaskViewDescriptor,
@@ -19,6 +20,7 @@ describe('workspaceSurface', () => {
   })
 
   it('lets non-Session tabs use the complete surface beside the Session rail', () => {
+    expect(workspaceSurface(archiveViewDescriptor())).toBe('standalone')
     expect(workspaceSurface(settingsViewDescriptor())).toBe('standalone')
     expect(workspaceSurface(requestTaskViewDescriptor('request-1'))).toBe('standalone')
     expect(workspaceSurface(rambelleProfileViewDescriptor())).toBe('standalone')

--- a/apps/desktop/src/lib/workspace/workspaceSurface.test.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSurface.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  inboxViewDescriptor,
+  rambelleProfileViewDescriptor,
+  requestTaskViewDescriptor,
+  sessionViewDescriptor,
+  settingsViewDescriptor,
+} from './viewDescriptors'
+import { workspaceSurface } from './workspaceSurface'
+
+describe('workspaceSurface', () => {
+  it('keeps the request list inside each Session tab surface', () => {
+    expect(workspaceSurface(sessionViewDescriptor('codex', 'session-1'))).toBe('session')
+  })
+
+  it('gives the singleton Inbox tab the aggregate request list surface', () => {
+    expect(workspaceSurface(inboxViewDescriptor())).toBe('inbox')
+  })
+
+  it('lets non-Session tabs use the complete surface beside the Session rail', () => {
+    expect(workspaceSurface(settingsViewDescriptor())).toBe('standalone')
+    expect(workspaceSurface(requestTaskViewDescriptor('request-1'))).toBe('standalone')
+    expect(workspaceSurface(rambelleProfileViewDescriptor())).toBe('standalone')
+    expect(workspaceSurface(null)).toBe('standalone')
+  })
+})

--- a/apps/desktop/src/lib/workspace/workspaceSurface.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSurface.ts
@@ -15,6 +15,7 @@ export function workspaceSurface(view: WorkspaceViewDescriptor | null): Workspac
     case 'session':
       return 'session'
     case 'settings':
+    case 'archive':
     case 'request-task':
     case 'rambelle-profile':
       return 'standalone'

--- a/apps/desktop/src/lib/workspace/workspaceSurface.ts
+++ b/apps/desktop/src/lib/workspace/workspaceSurface.ts
@@ -1,0 +1,22 @@
+import type { WorkspaceViewDescriptor } from './viewDescriptors'
+
+export type WorkspaceSurface = 'inbox' | 'session' | 'standalone'
+
+/**
+ * Decides which part of the right-hand workspace belongs to the active tab.
+ * Session tabs own the request list and workbench; singleton and task tabs own
+ * the complete surface to the right of the Session rail.
+ */
+export function workspaceSurface(view: WorkspaceViewDescriptor | null): WorkspaceSurface {
+  if (!view) return 'standalone'
+  switch (view.kind) {
+    case 'inbox':
+      return 'inbox'
+    case 'session':
+      return 'session'
+    case 'settings':
+    case 'request-task':
+    case 'rambelle-profile':
+      return 'standalone'
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       paneforge:
         specifier: 1.0.2
         version: 1.0.2(svelte@5.56.8)
+      svelte-dnd-action:
+        specifier: 0.9.79
+        version: 0.9.79(svelte@5.56.8)
       svelte-sonner:
         specifier: ^1.1.1
         version: 1.1.1(svelte@5.56.8)
@@ -4118,6 +4121,11 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: ^5.0.0 || ^6.0.0
+
+  svelte-dnd-action@0.9.79:
+    resolution: {integrity: sha512-zCKaG1Q9hVgfJFyZXhY+uIpo9+cjsG03CqwNz8yBlWCRBphC8U2zli9FzIcrL4rhXEs8yV+asS4rV0RHDuQqQQ==}
+    peerDependencies:
+      svelte: '>=3.23.0 || ^5.0.0-next.0'
 
   svelte-sonner@1.1.1:
     resolution: {integrity: sha512-5cd3p7wa4cq0NsqslMwdlPb7x1JglEZ/GKrLePWNr5bCxR1nagAVrY01FRFrXfUGs41miLt3C327+8XJo5BzZw==}
@@ -9143,6 +9151,10 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-dnd-action@0.9.79(svelte@5.56.8):
+    dependencies:
+      svelte: 5.56.8
 
   svelte-sonner@1.1.1(svelte@5.56.8):
     dependencies:


### PR DESCRIPTION
## Summary\n\n- align the app titlebar with the flat Session rail and move workspace tabs into the titlebar\n- make each Session tab own both its request list and workbench\n- add a singleton Inbox tab for the aggregate request list while standalone tabs use the complete right-hand surface\n- preserve tab snapshots, pane sizing, navigation rollback, keyboard navigation, and Session row actions\n\n## Validation\n\n- pnpm --filter rambledesk-desktop check\n- pnpm --filter rambledesk-desktop test (88 files, 461 tests)\n- pnpm build:web\n- pnpm check:terminology\n- pnpm contracts:check\n- pnpm format:check\n- pnpm check:rust-size\n- browser interaction pass for Session, Inbox, and Settings tab surfaces\n- independent diff review with no remaining blocking or high-risk findings